### PR TITLE
Run Summary in the UI

### DIFF
--- a/agentdbg/ui_static/app.js
+++ b/agentdbg/ui_static/app.js
@@ -3,10 +3,13 @@ const runListErrorEl = document.getElementById('run-list-error');
 const btnRefreshEl = document.getElementById('btn-refresh');
 const btnCopyLinkEl = document.getElementById('btn-copy-link');
 const btnCopyRunIdEl = document.getElementById('btn-copy-run-id');
-const runHeaderEl = document.getElementById('run-header');
+const runSummaryEl = document.getElementById('run-summary');
+const runSummaryStatusEl = document.getElementById('run-summary-status');
+const runSummaryKpisEl = document.getElementById('run-summary-kpis');
+const runSummaryCalloutsEl = document.getElementById('run-summary-callouts');
+const runSummaryFiltersEl = document.getElementById('run-summary-filters');
 const timelineToolbarEl = document.getElementById('timeline-toolbar');
 const eventCountEl = document.getElementById('event-count');
-const filterChipsEl = document.getElementById('filter-chips');
 const timelineEmptyEl = document.getElementById('timeline-empty');
 const timelineErrorEl = document.getElementById('timeline-error');
 const timelineEventsEl = document.getElementById('timeline-events');
@@ -15,12 +18,17 @@ let currentEvents = [];
 let currentFilter = 'all';
 let lastRuns = [];
 let currentRunId = null;
+let currentRunMeta = null;
 let fetchAbort = null;
 const escapeDiv = document.createElement('div');
 
+// Filter value in URL vs internal event_type. Default All; URL persists so refresh keeps it.
+const FILTER_URL_MAP = { all: 'all', llm: 'LLM_CALL', tools: 'TOOL_CALL', errors: 'ERROR', state: 'STATE_UPDATE', loops: 'LOOP_WARNING' };
+const FILTER_LABELS = { all: 'All', LLM_CALL: 'LLM', TOOL_CALL: 'Tools', ERROR: 'Errors', STATE_UPDATE: 'State', LOOP_WARNING: 'Loops' };
+
 function getRunIdFromUrl() {
   const url = new URL(window.location.href);
-  const q = url.searchParams.get('run_id');
+  const q = url.searchParams.get('run') || url.searchParams.get('run_id');
   if (q) return q;
   const parts = url.pathname.split('/').filter(Boolean);
   if (parts.length === 0) return null;
@@ -29,29 +37,53 @@ function getRunIdFromUrl() {
   return looksLikeId ? last : null;
 }
 
+function getFilterFromUrl() {
+  const url = new URL(window.location.href);
+  const q = url.searchParams.get('filter');
+  if (!q) return 'all';
+  const v = FILTER_URL_MAP[q.toLowerCase()];
+  return v != null ? v : 'all';
+}
+
 function getRunUrl(runId) {
   if (!runId) return '';
   const url = new URL(window.location.href);
   url.pathname = '/';
-  url.searchParams.set('run_id', runId);
+  url.searchParams.set('run', runId);
+  if (currentFilter !== 'all') url.searchParams.set('filter', getFilterUrlValue(currentFilter));
   return url.toString();
+}
+
+function getFilterUrlValue(filterValue) {
+  if (filterValue === 'all') return 'all';
+  const entry = Object.entries(FILTER_URL_MAP).find(([, v]) => v === filterValue);
+  return entry ? entry[0] : 'all';
 }
 
 function setUrlRunId(runId, { replace = false } = {}) {
   if (!runId) return;
   const url = new URL(window.location.href);
   url.pathname = '/';
-  url.searchParams.set('run_id', runId);
+  url.searchParams.set('run', runId);
+  url.searchParams.set('filter', getFilterUrlValue(currentFilter));
   const method = replace ? 'replaceState' : 'pushState';
-  window.history[method]({ run_id: runId }, '', url.toString());
+  window.history[method]({ run_id: runId, filter: currentFilter }, '', url.toString());
+}
+
+function setUrlFilter(filterValue) {
+  const url = new URL(window.location.href);
+  url.searchParams.set('filter', getFilterUrlValue(filterValue));
+  window.history.replaceState({ run_id: currentRunId, filter: filterValue }, '', url.toString());
 }
 
 (function canonicalizeOnBoot() {
   const url = new URL(window.location.href);
-  const hasQuery = url.searchParams.has('run_id');
+  const runIdFromQuery = url.searchParams.get('run') || url.searchParams.get('run_id');
   const runIdFromPath = getRunIdFromUrl();
-  if (!hasQuery && runIdFromPath) {
-    setUrlRunId(runIdFromPath, { replace: true });
+  const runId = runIdFromQuery || runIdFromPath;
+  if (runId) {
+    currentFilter = getFilterFromUrl();
+    setUrlRunId(runId, { replace: true });
   }
 })();
 
@@ -189,29 +221,179 @@ function selectRun(runId, options) {
   loadEvents(runId, signal);
 }
 
+// Run Summary panel: single compact overview above the timeline.
+// State flow: run.json (loadRunMeta) -> currentRunMeta; events (loadEvents) -> currentEvents.
+// We render status strip + KPI chips from run only; callouts (first error, loop warning, running)
+// and filter row use events when available. If events fail to load, summary still shows from run.json;
+// jump links are hidden when events is null.
+function renderRunSummary(run, events) {
+  if (!runSummaryEl || !run) {
+    if (runSummaryEl) runSummaryEl.style.display = 'none';
+    return;
+  }
+  const counts = run.counts || {};
+  const llm = counts.llm_calls != null ? counts.llm_calls : 0;
+  const tools = counts.tool_calls != null ? counts.tool_calls : 0;
+  const errors = counts.errors != null ? counts.errors : 0;
+  const loopWarnings = counts.loop_warnings != null ? counts.loop_warnings : 0;
+  const status = (run.status || '').toLowerCase();
+  const runName = run.run_name || (run.run_id || currentRunId || '').slice(0, 8);
+  const shortId = (run.run_id || currentRunId || '').slice(0, 8);
+
+  // Status strip: badge, run name, started_at, duration, short id + copy
+  runSummaryStatusEl.textContent = '';
+  const badge = document.createElement('span');
+  badge.className = 'status-badge ' + (status === 'ok' ? 'ok' : status === 'error' ? 'error' : 'running');
+  badge.textContent = status === 'ok' ? 'OK' : status === 'error' ? 'ERROR' : 'RUNNING';
+  runSummaryStatusEl.appendChild(badge);
+  const nameSpan = document.createElement('span');
+  nameSpan.className = 'run-name';
+  nameSpan.textContent = runName;
+  runSummaryStatusEl.appendChild(nameSpan);
+  const metaSpan = document.createElement('span');
+  metaSpan.className = 'run-meta';
+  metaSpan.textContent = [run.started_at || '—', run.duration_ms != null ? run.duration_ms + ' ms' : ''].filter(Boolean).join(' · ');
+  runSummaryStatusEl.appendChild(metaSpan);
+  const idWrap = document.createElement('span');
+  idWrap.className = 'run-id-wrap';
+  const idText = document.createElement('span');
+  idText.textContent = shortId;
+  idWrap.appendChild(idText);
+  const copyIdBtn = document.createElement('button');
+  copyIdBtn.type = 'button';
+  copyIdBtn.className = 'btn-copy-id';
+  copyIdBtn.textContent = 'Copy';
+  copyIdBtn.setAttribute('aria-label', 'Copy run ID');
+  copyIdBtn.addEventListener('click', () => copyRunId());
+  idWrap.appendChild(copyIdBtn);
+  runSummaryStatusEl.appendChild(idWrap);
+
+  // KPI chips
+  runSummaryKpisEl.textContent = '';
+  ['llm_calls', 'tool_calls', 'errors', 'loop_warnings'].forEach((key) => {
+    const label = key === 'llm_calls' ? 'LLM' : key === 'tool_calls' ? 'Tools' : key === 'errors' ? 'Errors' : 'Loop warnings';
+    const val = counts[key] != null ? counts[key] : 0;
+    const chip = document.createElement('span');
+    chip.className = 'kpi-chip';
+    const vSpan = document.createElement('span');
+    vSpan.className = 'kpi-value';
+    vSpan.textContent = String(val);
+    chip.appendChild(document.createTextNode(label + ': '));
+    chip.appendChild(vSpan);
+    runSummaryKpisEl.appendChild(chip);
+  });
+
+  // Callouts: only when relevant; jump links only when events available
+  runSummaryCalloutsEl.textContent = '';
+  if (errors > 0 && Array.isArray(events) && events.length > 0) {
+    const firstErrorIdx = events.findIndex((ev) => (ev.event_type || '') === 'ERROR');
+    if (firstErrorIdx !== -1) {
+      const eventNum = firstErrorIdx + 1;
+      const link = document.createElement('button');
+      link.type = 'button';
+      link.className = 'callout error';
+      link.textContent = 'First error at event #' + eventNum;
+      link.setAttribute('aria-label', 'Jump to first error, event ' + eventNum);
+      link.addEventListener('click', () => jumpToEvent(firstErrorIdx, 'ERROR'));
+      runSummaryCalloutsEl.appendChild(link);
+    }
+  }
+  if (loopWarnings > 0 && Array.isArray(events) && events.length > 0) {
+    const firstLoopIdx = events.findIndex((ev) => (ev.event_type || '') === 'LOOP_WARNING');
+    if (firstLoopIdx !== -1) {
+      const eventNum = firstLoopIdx + 1;
+      const link = document.createElement('button');
+      link.type = 'button';
+      link.className = 'callout';
+      link.textContent = 'Loop warning detected';
+      link.setAttribute('aria-label', 'Jump to first loop warning, event ' + eventNum);
+      link.addEventListener('click', () => jumpToEvent(firstLoopIdx, 'LOOP_WARNING'));
+      runSummaryCalloutsEl.appendChild(link);
+    }
+  }
+  if (status === 'running') {
+    const refreshBtn = document.createElement('button');
+    refreshBtn.type = 'button';
+    refreshBtn.className = 'callout callout-refresh';
+    refreshBtn.textContent = 'Run still in progress — Refresh';
+    refreshBtn.setAttribute('aria-label', 'Refresh run');
+    refreshBtn.addEventListener('click', () => {
+      if (currentRunId) {
+        const ac = new AbortController();
+        loadRunMeta(currentRunId, ac.signal);
+        loadEvents(currentRunId, ac.signal);
+      }
+    });
+    runSummaryCalloutsEl.appendChild(refreshBtn);
+  }
+
+  // Quick filters row: All, LLM, Tools, Errors, State, Loops; state in URL
+  runSummaryFiltersEl.textContent = '';
+  const filterValues = ['all', 'LLM_CALL', 'TOOL_CALL', 'ERROR', 'STATE_UPDATE', 'LOOP_WARNING'];
+  filterValues.forEach((fv) => {
+    const btn = document.createElement('button');
+    btn.type = 'button';
+    btn.className = 'filter-chip' + (currentFilter === fv ? ' active' : '');
+    btn.textContent = FILTER_LABELS[fv] || fv;
+    btn.addEventListener('click', () => {
+      currentFilter = fv;
+      setUrlFilter(fv);
+      setSummaryFilterActive();
+      renderEvents();
+    });
+    runSummaryFiltersEl.appendChild(btn);
+  });
+
+  runSummaryEl.style.display = 'block';
+}
+
+function setSummaryFilterActive() {
+  if (!runSummaryFiltersEl) return;
+  runSummaryFiltersEl.querySelectorAll('.filter-chip').forEach((el, i) => {
+    const fv = ['all', 'LLM_CALL', 'TOOL_CALL', 'ERROR', 'STATE_UPDATE', 'LOOP_WARNING'][i];
+    el.classList.toggle('active', currentFilter === fv);
+  });
+}
+
+// Scroll to event at index in currentEvents, expand it, highlight briefly. Filter is set to all so it's visible.
+function jumpToEvent(indexInCurrentEvents, eventType) {
+  currentFilter = 'all';
+  setUrlFilter('all');
+  setSummaryFilterActive();
+  renderEvents();
+  requestAnimationFrame(() => {
+    const el = timelineEventsEl.querySelector('[data-event-index="' + indexInCurrentEvents + '"]');
+    if (!el) return;
+    el.scrollIntoView({ behavior: 'smooth', block: 'nearest' });
+    const summary = el.querySelector('.event-summary');
+    const details = el.querySelector('.event-details');
+    const toggle = el.querySelector('.toggle');
+    if (details && details.style.display !== 'block') {
+      details.style.display = 'block';
+      if (toggle) toggle.textContent = '▼';
+    }
+    el.classList.add('highlight');
+    setTimeout(() => el.classList.remove('highlight'), 2000);
+  });
+}
+
 async function loadRunMeta(runId, signal) {
   try {
     const r = await fetch('/api/runs/' + encodeURIComponent(runId), { signal });
     if (r.status === 404) {
-      runHeaderEl.style.display = 'none';
+      runSummaryEl.style.display = 'none';
+      currentRunMeta = null;
       return;
     }
     if (!r.ok) throw new Error(r.statusText || 'Failed to load run');
     const run = await r.json();
     if (signal?.aborted) return;
-    const counts = run.counts || {};
-    const parts = [
-      run.run_name ? 'Run: ' + run.run_name : '',
-      'Status: ' + (run.status || '—'),
-      'Started: ' + (run.started_at || '—'),
-      run.duration_ms != null ? 'Duration: ' + run.duration_ms + ' ms' : '',
-      Object.keys(counts).length ? 'Counts: ' + JSON.stringify(counts) : ''
-    ].filter(Boolean);
-    runHeaderEl.innerHTML = '<h2>' + escapeHtml(run.run_name || runId.slice(0, 8)) + '</h2><div class="meta">' + escapeHtml(parts.join(' · ')) + '</div>';
-    runHeaderEl.style.display = 'block';
+    currentRunMeta = run;
+    renderRunSummary(run, currentEvents.length ? currentEvents : null);
   } catch (e) {
     if (e.name === 'AbortError') return;
-    runHeaderEl.style.display = 'none';
+    runSummaryEl.style.display = 'none';
+    currentRunMeta = null;
   }
 }
 
@@ -219,7 +401,8 @@ function durationLabel(ms) {
   return ms != null ? ms + ' ms' : '—';
 }
 
-function buildEventEl(ev) {
+// Build one timeline event element. indexInCurrentEvents is used for jump-to-event (data-event-index).
+function buildEventEl(ev, indexInCurrentEvents) {
   const isLoop = ev.event_type === 'LOOP_WARNING';
   const isError = ev.event_type === 'ERROR';
   let className = 'event';
@@ -228,6 +411,7 @@ function buildEventEl(ev) {
   const div = document.createElement('div');
   div.className = className;
   div.dataset.eventType = ev.event_type || '';
+  if (indexInCurrentEvents != null) div.dataset.eventIndex = String(indexInCurrentEvents);
   const summary = document.createElement('div');
   summary.className = 'event-summary';
   summary.innerHTML = '<span class="toggle">▶</span><span class="type">' + escapeHtml(ev.event_type || '') + '</span><span class="name">' + escapeHtml(ev.name || '') + '</span><span class="duration">' + escapeHtml(durationLabel(ev.duration_ms)) + '</span><span class="ts">' + escapeHtml(ev.ts || '') + '</span>';
@@ -256,42 +440,16 @@ function buildEventEl(ev) {
 function renderToolbar(events) {
   const n = events.length;
   eventCountEl.textContent = n + ' event' + (n === 1 ? '' : 's');
-  const types = [];
-  const seen = new Set();
-  events.forEach((ev) => {
-    const t = ev.event_type || '';
-    if (t && !seen.has(t)) { seen.add(t); types.push(t); }
-  });
-  types.sort();
-  filterChipsEl.innerHTML = '';
-  const allChip = document.createElement('button');
-  allChip.type = 'button';
-  allChip.className = 'filter-chip' + (currentFilter === 'all' ? ' active' : '');
-  allChip.textContent = 'All';
-  allChip.addEventListener('click', () => { currentFilter = 'all'; setFilterActive(); renderEvents(); });
-  filterChipsEl.appendChild(allChip);
-  types.forEach((t) => {
-    const btn = document.createElement('button');
-    btn.type = 'button';
-    btn.className = 'filter-chip' + (currentFilter === t ? ' active' : '');
-    btn.textContent = t;
-    btn.addEventListener('click', () => { currentFilter = t; setFilterActive(); renderEvents(); });
-    filterChipsEl.appendChild(btn);
-  });
   timelineToolbarEl.style.display = 'flex';
 }
 
-function setFilterActive() {
-  filterChipsEl.querySelectorAll('.filter-chip').forEach((el) => {
-    const isAll = el.textContent === 'All';
-    el.classList.toggle('active', isAll ? currentFilter === 'all' : el.textContent === currentFilter);
-  });
-}
-
 function renderEvents() {
-  const toShow = currentFilter === 'all' ? currentEvents : currentEvents.filter((ev) => (ev.event_type || '') === currentFilter);
   const frag = document.createDocumentFragment();
-  toShow.forEach((ev) => frag.appendChild(buildEventEl(ev)));
+  currentEvents.forEach((ev, i) => {
+    if (currentFilter === 'all' || (ev.event_type || '') === currentFilter) {
+      frag.appendChild(buildEventEl(ev, i));
+    }
+  });
   timelineEventsEl.innerHTML = '';
   timelineEventsEl.appendChild(frag);
 }
@@ -331,7 +489,8 @@ async function loadEvents(runId, signal) {
     if (signal?.aborted) return;
     const events = data.events || [];
     currentEvents = events;
-    currentFilter = 'all';
+    currentFilter = getFilterFromUrl();
+    if (currentRunMeta) renderRunSummary(currentRunMeta, currentEvents);
     timelineEventsEl.innerHTML = '';
     if (events.length === 0) {
       timelineEmptyEl.textContent = 'No events for this run.';
@@ -342,14 +501,21 @@ async function loadEvents(runId, signal) {
     renderEvents();
   } catch (e) {
     if (e.name === 'AbortError') return;
+    currentEvents = [];
+    if (currentRunMeta) renderRunSummary(currentRunMeta, null);
     showTimelineError(e.message || 'Failed to load events');
   }
 }
 
 window.addEventListener('popstate', () => {
+  currentFilter = getFilterFromUrl();
   const runId = getRunIdFromUrl();
   const inList = runId && Array.from(runListEl.querySelectorAll('.run-item')).some((el) => el.dataset.runId === runId);
   if (inList) selectRun(runId, { fromPopState: true });
+  else {
+    setSummaryFilterActive();
+    renderEvents();
+  }
 });
 
 if (btnRefreshEl) btnRefreshEl.addEventListener('click', () => loadRuns());

--- a/agentdbg/ui_static/index.html
+++ b/agentdbg/ui_static/index.html
@@ -11,8 +11,8 @@
   <header class="page-header">
     <h1>AgentDbg</h1>
     <div class="header-actions">
-      <button type="button" id="btn-copy-link" class="btn-header" title="Copy link to this run" disabled>Copy link</button>
-      <button type="button" id="btn-copy-run-id" class="btn-header" title="Copy run ID" disabled>Copy run ID</button>
+      <button type="button" id="btn-copy-link" class="btn-header" title="Copy link to this run" aria-label="Copy link to this run" disabled>Copy link</button>
+      <button type="button" id="btn-copy-run-id" class="btn-header" title="Copy run ID" aria-label="Copy run ID" disabled>Copy run ID</button>
     </div>
   </header>
   <div class="layout">
@@ -26,11 +26,16 @@
     </aside>
     <main class="main">
       <div id="run-not-found-banner" class="run-not-found-banner" style="display:none;">Run not found. Showing latest run.</div>
-      <div id="run-header" class="run-header" style="display:none;"></div>
+      <!-- Run Summary: status strip, KPI chips, callouts, quick filters. Rendered by app.js from run.json + events. -->
+      <div id="run-summary" class="run-summary" style="display:none;" role="region" aria-label="Run summary">
+        <div id="run-summary-status" class="summary-status-strip"></div>
+        <div id="run-summary-kpis" class="summary-kpis"></div>
+        <div id="run-summary-callouts" class="summary-callouts"></div>
+        <div id="run-summary-filters" class="summary-filters"></div>
+      </div>
       <div id="timeline" class="timeline">
         <div id="timeline-toolbar" class="timeline-toolbar" style="display:none;">
           <span id="event-count" class="event-count"></span>
-          <div id="filter-chips" class="filters"></div>
         </div>
         <div id="timeline-empty" class="empty">Select a run to view events.</div>
         <div id="timeline-error" class="error" style="display:none;"></div>

--- a/agentdbg/ui_static/styles.css
+++ b/agentdbg/ui_static/styles.css
@@ -71,14 +71,95 @@ h1 { font-size: 1.25rem; margin: 0 0 1rem 0; color: var(--accent); }
   gap: 1rem;
   min-width: 0;
 }
-.run-header {
+/* Run Summary panel: status strip, KPI chips, callouts, quick filters (above timeline). */
+.run-summary {
   background: var(--surface);
   border: 1px solid var(--border);
   border-radius: 6px;
   padding: 1rem;
+  margin-bottom: 1rem;
 }
-.run-header h2 { margin: 0 0 0.5rem 0; font-size: 1rem; }
-.run-header .meta { font-size: 0.8rem; color: var(--muted); }
+.summary-status-strip {
+  display: flex;
+  align-items: center;
+  flex-wrap: wrap;
+  gap: 0.75rem;
+  margin-bottom: 0.75rem;
+}
+.summary-status-strip .status-badge {
+  font-size: 0.75rem;
+  font-weight: 600;
+  padding: 0.2rem 0.5rem;
+  border-radius: 4px;
+  text-transform: uppercase;
+}
+.summary-status-strip .status-badge.ok { background: rgba(34, 139, 34, 0.3); border: 1px solid #2e8b2e; color: #7cfc7c; }
+.summary-status-strip .status-badge.error { background: var(--error-bg); border: 1px solid var(--error-border); color: #ff8888; }
+.summary-status-strip .status-badge.running { background: rgba(77, 171, 247, 0.2); border: 1px solid var(--accent); color: var(--accent); }
+.summary-status-strip .run-name { font-weight: 600; font-size: 1rem; }
+.summary-status-strip .run-meta { font-size: 0.8rem; color: var(--muted); }
+.summary-status-strip .run-id-wrap { display: inline-flex; align-items: center; gap: 0.25rem; }
+.summary-status-strip .run-id-wrap .btn-copy-id { font-size: 0.7rem; padding: 0.15rem 0.35rem; border-radius: 4px; border: 1px solid var(--border); background: var(--bg); color: var(--text); cursor: pointer; font-family: inherit; }
+.summary-status-strip .btn-copy-id:hover { background: var(--border); }
+.summary-kpis {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.5rem;
+  margin-bottom: 0.75rem;
+}
+.summary-kpis .kpi-chip {
+  font-size: 0.75rem;
+  padding: 0.25rem 0.5rem;
+  border-radius: 4px;
+  border: 1px solid var(--border);
+  background: var(--bg);
+  color: var(--muted);
+}
+.summary-kpis .kpi-chip .kpi-value { color: var(--text); font-weight: 600; }
+.summary-callouts {
+  margin-bottom: 0.75rem;
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.5rem;
+}
+.summary-callouts .callout {
+  font-size: 0.8rem;
+  padding: 0.25rem 0.5rem;
+  border-radius: 4px;
+  border: 1px solid var(--warning-border);
+  background: var(--warning-bg);
+  color: var(--text);
+  cursor: pointer;
+  font-family: inherit;
+  text-decoration: none;
+  display: inline-block;
+}
+.summary-callouts .callout.error { border-color: var(--error-border); background: var(--error-bg); }
+.summary-callouts .callout:hover { opacity: 0.9; }
+.summary-callouts .callout-refresh { border-color: var(--accent); background: rgba(77, 171, 247, 0.15); }
+.summary-filters {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.25rem;
+  align-items: center;
+}
+.summary-filters .filter-chip {
+  font-size: 0.75rem;
+  padding: 0.2rem 0.5rem;
+  border-radius: 4px;
+  border: 1px solid var(--border);
+  background: var(--surface);
+  color: var(--text);
+  cursor: pointer;
+  font-family: inherit;
+}
+.summary-filters .filter-chip:hover { background: var(--border); }
+.summary-filters .filter-chip.active { border-color: var(--accent); background: rgba(77, 171, 247, 0.15); }
+.event.highlight { animation: highlight-flash 2s ease-out; }
+@keyframes highlight-flash {
+  0% { box-shadow: 0 0 0 2px var(--accent); }
+  100% { box-shadow: none; }
+}
 .timeline-toolbar {
   display: flex;
   align-items: center;
@@ -89,7 +170,6 @@ h1 { font-size: 1.25rem; margin: 0 0 1rem 0; color: var(--accent); }
   margin-bottom: 0.5rem;
 }
 .timeline-toolbar .event-count { font-size: 0.85rem; color: var(--muted); }
-.timeline-toolbar .filters { display: flex; gap: 0.25rem; flex-wrap: wrap; }
 .filter-chip {
   font-size: 0.75rem;
   padding: 0.2rem 0.5rem;


### PR DESCRIPTION
Fixes #3

## 1. **Run Summary panel (HTML + CSS)**

- **`index.html`**: New `#run-summary` region above the timeline with four sections: `#run-summary-status`, `#run-summary-kpis`, `#run-summary-callouts`, `#run-summary-filters`. The old run header was removed; the timeline toolbar now only shows the event count.
- **`styles.css`**: Styles for the Run Summary: status strip (badges OK/ERROR/RUNNING), KPI chips, callouts, filter chips, and a 2s highlight for jump-to-event. Uses existing dark theme variables.

## 2. **Status strip**

- Status badge (OK / ERROR / RUNNING from `run.status`), run name, `started_at`, duration, short run id (first 8 chars) and a **Copy** button (full run ID, with `aria-label="Copy run ID"`).

## 3. **KPI chips**

- From `run.counts`: **LLM**, **Tools**, **Errors**, **Loop warnings**. Missing keys are treated as 0.

## 4. **Notable callouts**

- **errors > 0** and events loaded → “First error at event #N” (button) that switches filter to All, scrolls to that event, expands it, and applies the highlight.
- **loop_warnings > 0** and events loaded → “Loop warning detected” with the same jump behavior to the first `LOOP_WARNING`.
- **status === 'running'** → “Run still in progress — Refresh” (reloads run meta + events).
- Callouts that depend on events are only shown when the events array is available; if events fail, the summary still renders from `run.json` and those links are omitted.

## 5. **Quick filters + URL**

- Filter row: **All**, **LLM**, **Tools**, **Errors**, **State**, **Loops** (event types: `all`, `LLM_CALL`, `TOOL_CALL`, `ERROR`, `STATE_UPDATE`, `LOOP_WARNING`). Clicking filters the timeline in place (no refetch). Default is All. Filter is stored in the query string as `filter=` (e.g. `?run=<id>&filter=errors`) and read on load and `popstate` so refresh keeps the selection.

## 6. **URL / routing**

- Run id is read from **`run`** or **`run_id`** (so `agentdbg view <run_id>` with `?run_id=...` still works). Run id is written as **`run`** when selecting a run. So both “open with no run” and “open with run id” work, and the selected run survives refresh.

## 7. **Accessibility**

- Summary region: `role="region"` and `aria-label="Run summary"`.
- Copy run ID in summary and header copy buttons: `aria-label` set.
- Jump and refresh callouts: `aria-label` (e.g. “Jump to first error, event N”). All controls are focusable buttons.

## 8. **Failure tolerance**

- Summary is driven by `run.json`; if events fail or are missing, status strip and KPI chips still render. Event-based callouts and jump links are only shown when events are present; on events failure we call `renderRunSummary(currentRunMeta, null)` so those callouts are not shown.

## 9. **XSS**

- No `innerHTML` with untrusted data: run name, meta, and counts are set via `textContent` or created nodes; event content continues to use `escapeHtml()` before being inserted.

## 10. **Comments**

- Inline comments in `app.js` describe the Run Summary panel’s structure and state flow (run meta + events, when callouts appear, and failure behavior).

**Files touched**

- `agentdbg/ui_static/index.html` – Run Summary markup, aria-labels on header buttons.
- `agentdbg/ui_static/styles.css` – Run Summary and highlight styles; removed unused `.timeline-toolbar .filters`.
- `agentdbg/ui_static/app.js` – URL helpers (`run`/`run_id`, `getFilterFromUrl`, `setUrlFilter`), `renderRunSummary`, `setSummaryFilterActive`, `jumpToEvent`, `loadRunMeta`/`loadEvents` wiring, `buildEventEl(ev, indexInCurrentEvents)` with `data-event-index`, `renderEvents` with index and filter, popstate filter sync, and failure handling when events don’t load.