### PR TITLE
Commit review skill

### DIFF
--- a/.agents/skills/commit-stack-review/SKILL.md
+++ b/.agents/skills/commit-stack-review/SKILL.md
@@ -1,0 +1,154 @@
+---
+name: commit-stack-review
+description: Address GitHub pull request review comments per atomic commit in a stacked or multi-commit PR. Use when the user wants to preserve commit structure while fixing PR review comments, run one safe interactive rebase over the PR stack, group comments by commit with the bundled GitHub helper, maintain a local review-resolution report, draft optional replies, avoid broad staging, and never push rewritten history without explicit instruction.
+---
+
+# Commit Stack Review
+
+Use this skill to address GitHub PR review comments inside the commits where they belong while preserving an atomic commit stack.
+
+## Resources
+
+- `scripts/get-review-comments`: fetch grouped PR review comments as JSON. Invoke this by skill-relative path from the repository root.
+- `scripts/pr-review-comments.graphql`: GraphQL query used by the helper.
+- `scripts/group-by-commit.jq`: jq transformer used by the helper.
+- `assets/review-report-template.md`: local report skeleton.
+- `assets/reply-template.md`: optional reply patterns.
+
+Do not reimplement the helper scripts unless they fail and the user asks for debugging.
+
+## Safety Invariants
+
+- Require a clean working tree before history rewriting, or ask the user how to preserve dirty work.
+- Create a backup branch before rebasing.
+- Use one interactive rebase from the PR merge base; do not run independent rebases per commit.
+- Never squash, drop, reorder, or push commits unless the user explicitly asks.
+- Never run `git add .`, `git add -A`, `git add --all`, `git add -u`, or `git commit -a`.
+- Stage only explicit files relevant to the current review comment and current atomic commit.
+- Keep `_review_report/` local and unstaged unless the user asks to include it in the PR.
+- Never post GitHub replies automatically; draft optional replies in the report.
+- Use editor-safe rebase continuation: `GIT_EDITOR=true git rebase --continue`.
+
+## Workflow
+
+1. Identify `OWNER`, `REPO`, `PR`, `BASE_REF`, and `BASE`.
+2. Check `git status --porcelain`; stop on dirty state unless the user directs preservation.
+3. Create `BACKUP_BRANCH="backup/pr-${PR}-before-review-fixes-$(date +%Y%m%d-%H%M%S)"` with `git branch "$BACKUP_BRANCH"`.
+4. Extract review comments into `_review_report/pr-${PR}-comments-$(date +%Y%m%d).json`.
+5. Create or update `_review_report/pr-${PR}-$(date +%Y%m%d).md` from `assets/review-report-template.md`.
+6. Stop before rebasing if any actionable comment is unmatched or mapped only by unsafe subject assumptions.
+7. Start one interactive rebase from `BASE` and mark only commented commits as `edit`.
+8. At each stop, inspect the matching comments, make only commit-local fixes, stage explicit files, amend if needed, and continue with `GIT_EDITOR=true git rebase --continue`.
+9. Resolve conflicts conservatively; after staging resolved files, continue with `GIT_EDITOR=true git rebase --continue`.
+10. Run relevant validation, then `git range-diff "$BACKUP_BRANCH"...HEAD` and `git log --oneline "$BASE"..HEAD`.
+11. Summarize the backup branch, report path, amended commits, validation, rebase status, and that no push was performed.
+
+## Extract Comments
+
+Infer missing PR context when needed:
+
+```bash
+OWNER="$(gh repo view --json owner --jq '.owner.login')"
+REPO="$(gh repo view --json name --jq '.name')"
+PR="$(gh pr view --json number --jq '.number')"
+BASE_REF="$(gh pr view "$PR" --repo "$OWNER/$REPO" --json baseRefName --jq '.baseRefName')"
+git fetch origin "$BASE_REF"
+BASE="$(git merge-base HEAD "origin/$BASE_REF")"
+```
+
+Run the helper from the repository root using the skill path:
+
+```bash
+SKILL_DIR=".agents/skills/commit-stack-review"
+mkdir -p _review_report
+COMMENTS_JSON="_review_report/pr-${PR}-comments-$(date +%Y%m%d).json"
+"$SKILL_DIR/scripts/get-review-comments" -o "$OWNER" -r "$REPO" -p "$PR" -u > "$COMMENTS_JSON"
+```
+
+The `-u` flag enables subject-based remapping after the helper verifies current PR commit subjects are unique. Without `-u`, comments map by SHA only. If the helper fails, report the command and error and do not start the rebase.
+
+List commented commits:
+
+```bash
+jq -r '
+  .[]
+  | [.commit_order, .short_commit, .subject, .count, (.mapping_reasons | join(","))]
+  | @tsv
+' "$COMMENTS_JSON"
+```
+
+Stop before rebasing if any group has `is_current_commit: false`, `commit_order: 999999`, or `mapping_reasons` containing `unmatched`, unless the user provides a manual mapping.
+
+## Report
+
+Use `assets/review-report-template.md` as the report shape. For every review comment, set exactly one status:
+
+- `resolved`: changed the relevant commit, or verified the code already satisfies the concern.
+- `outdated`: the referenced code no longer exists, moved, or was superseded later in the stack.
+- `need follow-up`: clarification, product judgment, security/legal review, or design approval is needed.
+- `rejected`: intentionally not applied; include a concise technical rationale.
+
+Use `assets/reply-template.md` only when a GitHub reply would be useful. Keep replies optional and do not post them without explicit user instruction.
+
+## Rebase Stops
+
+At each `edit` stop, identify the current commit:
+
+```bash
+CURRENT_SHA="$(git rev-parse HEAD)"
+CURRENT_SHORT="$(git rev-parse --short HEAD)"
+CURRENT_SUBJECT="$(git log -1 --format=%s)"
+```
+
+Find matching comments:
+
+```bash
+jq --arg sha "$CURRENT_SHA" --arg short "$CURRENT_SHORT" --arg subject "$CURRENT_SUBJECT" '
+  .[]
+  | select(.commit == $sha or (.short_commit | startswith($short)) or .subject == $subject)
+' "$COMMENTS_JSON"
+```
+
+For each comment, inspect the referenced file and nearby code before deciding. If code changes are needed, stage explicit pathspecs only:
+
+```bash
+git status --short
+git add path/to/relevant_file path/to/relevant_test
+git diff --cached --name-only
+git diff --cached
+git commit --amend --no-edit
+GIT_EDITOR=true git rebase --continue
+```
+
+If no code changes are needed, update only the local report and continue:
+
+```bash
+GIT_EDITOR=true git rebase --continue
+```
+
+During an `edit` stop, `git add` plus `git rebase --continue` does not include new changes in the stopped commit. Run `git commit --amend --no-edit` before continuing when files changed.
+
+## Conflicts
+
+Resolve conflicts by preserving the intended changes of the commit currently being replayed. Avoid unrelated cleanup. After resolving:
+
+```bash
+git add path/to/resolved_file
+GIT_EDITOR=true git rebase --continue
+```
+
+If unsure, stop. Tell the user they can recover with `git rebase --abort` and that `BACKUP_BRANCH` still points to the pre-rebase state.
+
+## Final Response
+
+Report:
+
+- backup branch name
+- report path
+- commits amended
+- comment counts by status
+- validation commands run
+- whether the rebase completed
+- that no push was performed
+
+Prefer concise, evidence-backed status over a long narrative.

--- a/.agents/skills/commit-stack-review/agents/openai.yaml
+++ b/.agents/skills/commit-stack-review/agents/openai.yaml
@@ -1,0 +1,7 @@
+interface:
+  display_name: "Commit Stack Review"
+  short_description: "Fix PR comments inside atomic commits"
+  default_prompt: "Use $commit-stack-review to address this PR's review comments while preserving its atomic commit stack."
+
+policy:
+  allow_implicit_invocation: true

--- a/.agents/skills/commit-stack-review/assets/reply-template.md
+++ b/.agents/skills/commit-stack-review/assets/reply-template.md
@@ -1,0 +1,23 @@
+# Optional Reply Templates
+
+Use these only as report drafts. Do not post replies to GitHub unless the user explicitly asks.
+
+## Resolved
+
+Addressed in the relevant commit by <brief change>. Thanks for catching this.
+
+## Already Satisfied
+
+I left this unchanged after checking the surrounding code because <brief rationale>.
+
+## Outdated
+
+This now appears outdated because <brief reason>. The current code path is <brief current state>.
+
+## Need Follow-Up
+
+Could you clarify whether you prefer <option A> or <option B> here?
+
+## Rejected
+
+I left this unchanged because <brief technical rationale>. Happy to adjust if you prefer the alternative.

--- a/.agents/skills/commit-stack-review/assets/review-report-template.md
+++ b/.agents/skills/commit-stack-review/assets/review-report-template.md
@@ -1,0 +1,30 @@
+# PR <PR_NUMBER> Review Resolution Report
+
+Generated: <DATE>
+Repository: <OWNER>/<REPO>
+PR: <PR_NUMBER>
+Backup branch: <BACKUP_BRANCH>
+Comments JSON: <COMMENTS_JSON>
+
+## Summary
+
+| Commit | Subject | Comments | Resolved | Outdated | Need follow-up | Rejected |
+|---|---|---:|---:|---:|---:|---:|
+
+## Commits
+
+## <SHORT_COMMIT> <COMMIT_SUBJECT>
+
+Mapping reasons: <MAPPING_REASONS>
+
+### Comment: <AUTHOR> on `<PATH>:<LINE>`
+
+Source: <COMMENT_URL>
+
+> <COMMENT_BODY>
+
+Resolution: <resolved | outdated | need follow-up | rejected>
+
+Notes:
+
+Optional reply:

--- a/.agents/skills/commit-stack-review/scripts/get-review-comments
+++ b/.agents/skills/commit-stack-review/scripts/get-review-comments
@@ -1,0 +1,57 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+if ! command -v gh &> /dev/null; then
+    echo "error: gh could not be found" >&2
+    exit 1
+fi
+
+if ! command -v jq &> /dev/null; then
+    echo "error: jq could not be found" >&2
+    exit 1
+fi
+
+OWNER=""
+REPO=""
+PR=""
+ALLOW_SUBJECT_MAPPING="false"
+
+while getopts "o:r:p:u" opt; do
+    case $opt in
+        o) OWNER=$OPTARG;;
+        r) REPO=$OPTARG;;
+        p) PR=$OPTARG;;
+        u) ALLOW_SUBJECT_MAPPING="true";;
+        *) echo "Invalid option: -$OPTARG" >&2
+           exit 1;;
+    esac
+done
+
+if [ -z "$PR" ]; then
+    PR=$(gh pr view --json number --jq '.number' 2>/dev/null || true)
+fi
+
+if [ -z "$OWNER" ]; then
+    OWNER=$(gh repo view --json owner --jq '.owner.login' 2>/dev/null || true)
+fi
+
+if [ -z "$REPO" ]; then
+    REPO=$(gh repo view --json name --jq '.name' 2>/dev/null || true)
+fi
+
+if [ -z "$OWNER" ] || [ -z "$REPO" ] || [ -z "$PR" ]; then
+    echo "error: owner, repo, and PR are required" >&2
+    echo "usage: $0 -o OWNER -r REPO -p PR [-u]" >&2
+    exit 1
+fi
+
+gh api graphql \
+    --paginate \
+    --slurp \
+    -F owner="$OWNER" \
+    -F repo="$REPO" \
+    -F pr="$PR" \
+    -F query=@"$SCRIPT_DIR/pr-review-comments.graphql" \
+| jq --argjson allow_subject_mapping "$ALLOW_SUBJECT_MAPPING" -f "$SCRIPT_DIR/group-by-commit.jq"

--- a/.agents/skills/commit-stack-review/scripts/group-by-commit.jq
+++ b/.agents/skills/commit-stack-review/scripts/group-by-commit.jq
@@ -1,0 +1,170 @@
+def fail($message): error("get-review-comments: \($message)");
+
+.[0].data.repository.pullRequest as $pr
+
+| if ($pr.commits.totalCount // 0) > ($pr.commits.nodes | length) then
+    fail("PR has \($pr.commits.totalCount) commits, but this helper fetched \($pr.commits.nodes | length); commit pagination is not yet supported")
+  elif any($pr.reviewThreads.nodes[]?; ((.comments.totalCount // 0) > (.comments.nodes | length))) then
+    fail("at least one review thread has more comments than fetched; nested comment pagination is not yet supported")
+  else
+    .
+  end
+
+# Current PR commits, in the same order GitHub shows them.
+| (
+    $pr.commits.nodes
+    | to_entries
+    | map({
+        oid: .value.commit.oid,
+        short: .value.commit.abbreviatedOid,
+        subject: .value.commit.messageHeadline,
+        order: .key
+      })
+  ) as $current_commits
+
+| (
+    $current_commits
+    | sort_by(.subject)
+    | group_by(.subject)
+    | map(select(length > 1) | .[0].subject)
+  ) as $duplicate_subjects
+
+| if $allow_subject_mapping and ($duplicate_subjects | length) > 0 then
+    fail("commit subjects are not unique: \($duplicate_subjects | join(", "))")
+  else
+    .
+  end
+
+# SHA -> current commit metadata.
+| (
+    $current_commits
+    | map({
+        key: .oid,
+        value: .
+      })
+    | from_entries
+  ) as $by_oid
+
+# messageHeadline -> current commit metadata.
+# Used only when subject mapping is explicitly enabled and subjects are unique.
+| (
+    $current_commits
+    | map({
+        key: .subject,
+        value: .
+      })
+    | from_entries
+  ) as $by_subject
+
+# Flatten all review comments.
+| [
+    .[]
+    | .data.repository.pullRequest.reviewThreads.nodes[]?
+    | . as $thread
+    | $thread.comments.nodes[]?
+    | {
+        original_commit: .originalCommit.oid,
+        original_short_commit: .originalCommit.abbreviatedOid,
+        original_subject: .originalCommit.messageHeadline,
+
+        current_commit: .commit.oid,
+        current_short_commit: .commit.abbreviatedOid,
+        current_subject: .commit.messageHeadline,
+
+        # Resolve to current PR-stack commit metadata.
+        resolved_commit: (
+          if $by_oid[.originalCommit.oid] != null then
+            $by_oid[.originalCommit.oid]
+          elif $by_oid[.commit.oid] != null then
+            $by_oid[.commit.oid]
+          elif $allow_subject_mapping and $by_subject[.originalCommit.messageHeadline] != null then
+            $by_subject[.originalCommit.messageHeadline]
+          elif $allow_subject_mapping and $by_subject[.commit.messageHeadline] != null then
+            $by_subject[.commit.messageHeadline]
+          else
+            null
+          end
+        ),
+
+        mapping_reason: (
+          if $by_oid[.originalCommit.oid] != null then
+            "original_sha"
+          elif $by_oid[.commit.oid] != null then
+            "current_sha"
+          elif $allow_subject_mapping and $by_subject[.originalCommit.messageHeadline] != null then
+            "original_subject"
+          elif $allow_subject_mapping and $by_subject[.commit.messageHeadline] != null then
+            "current_subject"
+          else
+            "unmatched"
+          end
+        ),
+
+        thread_id: $thread.id,
+        comment_id: .id,
+        author: .author.login,
+        createdAt,
+        path: (.path // $thread.path),
+        line: (.line // .originalLine // $thread.line),
+        isResolved: $thread.isResolved,
+        isOutdated: $thread.isOutdated,
+        url,
+        body: .bodyText
+      }
+  ]
+
+# Add normalized report fields.
+| map(
+    . + {
+      report_commit: (
+        if .resolved_commit != null then
+          .resolved_commit.oid
+        else
+          (.original_commit // .current_commit)
+        end
+      ),
+      report_short_commit: (
+        if .resolved_commit != null then
+          .resolved_commit.short
+        else
+          (.original_short_commit // .current_short_commit)
+        end
+      ),
+      report_subject: (
+        if .resolved_commit != null then
+          .resolved_commit.subject
+        else
+          (.original_subject // .current_subject)
+        end
+      ),
+      commit_order: (
+        if .resolved_commit != null then
+          .resolved_commit.order
+        else
+          999999
+        end
+      ),
+      is_current_commit: (.resolved_commit != null)
+    }
+  )
+
+# group_by requires sorting by the grouping key first.
+| sort_by(.report_commit, .path, (.line // 0), .createdAt)
+
+# Group by resolved/current report commit.
+| group_by(.report_commit)
+
+# Build report groups.
+| map({
+    commit: .[0].report_commit,
+    short_commit: .[0].report_short_commit,
+    subject: .[0].report_subject,
+    commit_order: .[0].commit_order,
+    is_current_commit: .[0].is_current_commit,
+    mapping_reasons: ([.[].mapping_reason] | unique),
+    count: length,
+    comments: .
+  })
+
+# Sort groups by GitHub PR commit order.
+| sort_by(.commit_order, .short_commit)

--- a/.agents/skills/commit-stack-review/scripts/pr-review-comments.graphql
+++ b/.agents/skills/commit-stack-review/scripts/pr-review-comments.graphql
@@ -1,0 +1,84 @@
+query(
+  $owner: String!
+  $repo: String!
+  $pr: Int!
+  $endCursor: String
+) {
+  repository(owner: $owner, name: $repo) {
+    pullRequest(number: $pr) {
+      number
+      title
+
+      commits(first: 100) {
+        totalCount
+        pageInfo {
+          hasNextPage
+          endCursor
+        }
+        nodes {
+            commit {
+                oid
+                abbreviatedOid
+                messageHeadline
+            }
+        }
+      }
+
+      reviewThreads(first: 100, after: $endCursor) {
+        pageInfo {
+          hasNextPage
+          endCursor
+        }
+        nodes {
+          id
+          isResolved
+          isOutdated
+          path
+          line
+          startLine
+          diffSide
+          subjectType
+
+          comments(first: 100) {
+            totalCount
+            nodes {
+              id
+              url
+              bodyText
+              createdAt
+              updatedAt
+              author {
+                login
+              }
+
+              path
+              line
+              originalLine
+              diffHunk
+
+              commit {
+                oid
+                abbreviatedOid
+                messageHeadline
+              }
+
+              originalCommit {
+                oid
+                abbreviatedOid
+                messageHeadline
+              }
+
+              pullRequestReview {
+                state
+                submittedAt
+                author {
+                  login
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+}

--- a/.gitignore
+++ b/.gitignore
@@ -11,6 +11,9 @@ _README.md
 !schemas/*.json
 !schemas/*.jsonl
 
+# Local reports
+_review_report/
+
 # Byte-compiled / optimized / DLL files
 __pycache__/
 *.py[codz]


### PR DESCRIPTION
Skill name: commit-stack-review

Description: Use this skill when addressing GitHub PR review comments per atomic commit in a large PR. It extracts comments with scripts/get-review-comments, performs a safe one-pass interactive rebase, preserves atomic commits, writes a review report, stages only relevant files, and never pushes without explicit instruction.

THis skill reviews each commit in the PR stack individually. Assumption is that reviewers were adding comments to the individual commits, not the entire PR.

Files that are created:

1. SKILL.md --> main skill
2. scripts/get-review-comments -> Bash script that uses `gh` to extract the existing comments in the PR
3. scripts/pr-review-comments.graphql -> GraphQL to get comments from GitHub
4. scripts/group-by-commit.jq -> jq sorting and grouping filter
5. asserts/*.md -> templates to reply and review