### PR TITLE
JSON schemas reflect the OTel migration

### DIFF
--- a/docs/reference/trace-format.md
+++ b/docs/reference/trace-format.md
@@ -10,7 +10,7 @@ This page describes the **public trace format** for Maida (`spec_version: "0.2"`
 
 - **Per run:** One directory `runs/<trace_id_hex>/` containing:
   - **spans.jsonl** - append-only; one JSON object per line (one OTel span per line).
-  - **meta.json** - run metadata; written at run end (overwritten on finalize).
+  - **meta.json** - run metadata; created while the run is active and finalized when the root span ends.
 - **Ordering:** Spans in `spans.jsonl` are in export order; `start_time` provides logical ordering.
 - **Span hierarchy:** Root span (no `parent_span_id`) represents the run itself; child spans represent LLM calls, tool calls, etc.
 
@@ -164,7 +164,7 @@ Error payloads use a consistent shape (same for standalone ERROR events and nest
 
 ## meta.json schema
 
-Each run has a `meta.json` file in its directory. It is written when the root span ends.
+Each run has a `meta.json` file in its directory. It is created as running metadata when child spans are exported and overwritten with final metadata when the root span ends.
 
 **Required fields:**
 
@@ -175,7 +175,7 @@ Each run has a `meta.json` file in its directory. It is written when the root sp
 | `started_at` | string | UTC ISO8601 with µs and `Z` |
 | `ended_at` | string \| null | Set when run finishes |
 | `duration_ms` | integer \| null | Total run duration in ms |
-| `status` | string | `"ok"` \| `"error"` |
+| `status` | string | `"running"` \| `"ok"` \| `"error"` |
 | `counts` | object | See below |
 
 **counts** object:
@@ -191,14 +191,16 @@ Each run has a `meta.json` file in its directory. It is written when the root sp
 
 ### Lifecycle semantics
 
-- **On run start:** No file is written until the root span ends.
-- **On run end:** `meta.json` is written with final `status`, `ended_at`, `duration_ms`, and `counts`.
+- **During a run:** child spans are appended to `spans.jsonl`; `meta.json` may appear with `status: "running"` so the local viewer can discover active runs.
+- **On run end:** `meta.json` is overwritten with final `status`, `ended_at`, `duration_ms`, and `counts`.
 
 ---
 
 ## Versioning note
 
 The trace format is a **public contract** versioned independently from the Maida package version. All releases using `spec_version "0.2"` share this format. Additive changes (e.g. new optional fields, new event types) are allowed without a spec version bump. Breaking changes (removing fields, changing types or semantics) will be accompanied by a new `spec_version`. The markdown reference on this page is **canonical**; JSON schemas in the repo root `schemas/` folder are best-effort for tooling.
+
+TODO(#43): Clarify whether `spec_version` is only an API/export/event-projection envelope field or should also be written into local `meta.json` for self-describing trace directories. This is not expected to be a breaking change for the `0.2` format.
 
 ### Changes from v0.1
 

--- a/schemas/event.schema.json
+++ b/schemas/event.schema.json
@@ -1,23 +1,40 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
   "$id": "https://github.com/maida-ai/maida/schemas/event.schema.json",
-  "title": "Maida event (envelope)",
-  "description": "Event envelope for Maida v0.1. One event per line in events.jsonl. Best-effort schema for tooling; canonical reference is docs/reference/trace-format.md.",
+  "title": "Maida span (spans.jsonl record)",
+  "description": "OpenTelemetry span record for Maida trace format spec_version 0.2. One span per line in spans.jsonl. Best-effort schema for tooling; canonical reference is docs/reference/trace-format.md.",
   "type": "object",
-  "required": ["spec_version", "event_id", "run_id", "parent_id", "event_type", "ts", "duration_ms", "name", "payload", "meta"],
+  "required": ["trace_id", "span_id", "parent_span_id", "name", "kind", "start_time", "end_time", "duration_ms", "attributes", "events", "status_code", "status_description"],
   "properties": {
-    "spec_version": { "const": "0.1" },
-    "event_id": { "type": "string", "format": "uuid" },
-    "run_id": { "type": "string", "format": "uuid" },
-    "parent_id": { "type": ["string", "null"], "format": "uuid" },
-    "event_type": {
-      "enum": ["RUN_START", "RUN_END", "LLM_CALL", "TOOL_CALL", "STATE_UPDATE", "ERROR", "LOOP_WARNING"]
+    "trace_id": { "type": "string", "pattern": "^[0-9a-f]{32}$" },
+    "span_id": { "type": "string", "pattern": "^[0-9a-f]{16}$" },
+    "parent_span_id": {
+      "anyOf": [
+        { "type": "string", "pattern": "^[0-9a-f]{16}$" },
+        { "type": "null" }
+      ]
     },
-    "ts": { "type": "string", "format": "date-time" },
-    "duration_ms": { "type": ["integer", "null"] },
     "name": { "type": "string" },
-    "payload": { "type": "object", "description": "Event-type-specific; see trace-format.md" },
-    "meta": { "type": "object", "description": "Freeform metadata" }
+    "kind": { "enum": ["INTERNAL", "CLIENT", "SERVER", "PRODUCER", "CONSUMER"] },
+    "start_time": { "type": "string", "format": "date-time" },
+    "end_time": { "type": ["string", "null"], "format": "date-time" },
+    "duration_ms": { "type": ["integer", "null"], "minimum": 0 },
+    "attributes": { "type": "object" },
+    "events": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": ["name", "timestamp", "attributes"],
+        "properties": {
+          "name": { "type": "string" },
+          "timestamp": { "type": "string", "format": "date-time" },
+          "attributes": { "type": "object" }
+        },
+        "additionalProperties": false
+      }
+    },
+    "status_code": { "enum": ["OK", "ERROR", "UNSET"] },
+    "status_description": { "type": "string" }
   },
   "additionalProperties": false
 }

--- a/schemas/run.schema.json
+++ b/schemas/run.schema.json
@@ -1,13 +1,12 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
   "$id": "https://github.com/maida-ai/maida/schemas/run.schema.json",
-  "title": "Maida run.json",
-  "description": "Run metadata file (run.json) for Maida v0.1. Best-effort schema for tooling; canonical reference is docs/reference/trace-format.md.",
+  "title": "Maida meta.json",
+  "description": "Run metadata file (meta.json) for Maida trace format spec_version 0.2. Best-effort schema for tooling; canonical reference is docs/reference/trace-format.md.",
   "type": "object",
-  "required": ["spec_version", "run_id", "run_name", "started_at", "ended_at", "duration_ms", "status", "counts", "last_event_ts"],
+  "required": ["trace_id", "run_name", "started_at", "ended_at", "duration_ms", "status", "counts"],
   "properties": {
-    "spec_version": { "const": "0.1" },
-    "run_id": { "type": "string", "format": "uuid" },
+    "trace_id": { "type": "string", "pattern": "^[0-9a-f]{32}$" },
     "run_name": { "type": ["string", "null"] },
     "started_at": { "type": "string", "format": "date-time" },
     "ended_at": { "type": ["string", "null"], "format": "date-time" },
@@ -23,8 +22,7 @@
         "loop_warnings": { "type": "integer", "minimum": 0 }
       },
       "additionalProperties": false
-    },
-    "last_event_ts": { "type": ["string", "null"], "format": "date-time" }
+    }
   },
   "additionalProperties": false
 }


### PR DESCRIPTION
This changes the existing schemas to include info on the OTel.

Future: There is one thing we need to resolve still: (#43) Do we need the `spec_version` in the meta schema?

Fixes #37 