### PR TITLE
Onboarding demo and friction reduction

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Changelog
 
+## Unreleased
+
+### Highlights
+
+- **`maida demo`** - bundled simulated agent: `pip install maida-ai && maida demo` produces a traced run with no repo clone, no network, and no API keys.
+- **`maida demo --regression`** - the full gate story in one command: baseline a known-good run, run a "refactored" agent that loops, calls a new tool, and burns more tokens, then show the failing report with a PR-comment preview.
+- **`maida init`** - scaffolds a commented starter `.maida/policy.yaml`, and with `--github` a ready-to-edit workflow using `maida-ai/maida-assert@v2`.
+- **Latest-run defaults** - `maida assert`, `maida baseline`, `maida export`, and `maida diff` no longer require a run ID; they default to the most recent run (announced on stderr so stdout stays machine-readable).
+- **Richer gate reports** - the markdown report (the PR comment) now leads with a verdict, lists failed checks first with expected vs actual values, collapses passing checks, embeds a "What changed vs baseline" structural diff, and ends with a local-repro snippet. The text report appends the same diff on failure.
+
 ## v0.3
 
 ### Highlights

--- a/README.md
+++ b/README.md
@@ -7,13 +7,14 @@
 
 Maida is a local-first, CI-first behavioral regression gate for AI agents. It captures structured traces, turns known-good runs into checked-in baselines, and fails changes when structural behavior regresses: more steps, unexpected tool calls, loops, latency spikes, or cost blowups.
 
-Add `@trace`, capture a baseline, then gate future runs:
+Add `@trace`, capture a baseline, then gate future runs (commands default to the latest run):
 
 ```bash
 python my_agent.py
-maida list --json
-maida baseline <TRACE_ID> --out baselines/my_agent.json
-maida assert <NEW_TRACE_ID> --baseline baselines/my_agent.json --policy .maida/policy.yaml --format markdown
+maida baseline --out baselines/my_agent.json
+# ...after your next change:
+python my_agent.py
+maida assert --baseline baselines/my_agent.json --policy .maida/policy.yaml --format markdown
 ```
 
 For local inspection, use:
@@ -30,39 +31,36 @@ The viewer shows the execution timeline behind a pass/fail decision, but the cor
 
 ![Guardrails demo](docs/assets/guardrails.gif)
 
-## Get a local run in 5 minutes
+## Try it in 60 seconds
 
-Three commands. No config files, no API keys, no sign-up. Install: `pip install maida-ai`. Then:
-
-1. [Install (one-time)](#step-1-install)
-2. [Run example](#step-2-run-the-example-agent)
-3. [`maida view`](#step-3-open-the-timeline)
-
-### Step 1: Install
+Three commands. No repo clone, no config files, no API keys, no sign-up:
 
 ```bash
 pip install maida-ai
-```
-
-### Step 2: Run the example agent
-
-```bash
-python examples/demo/pure_python.py
-```
-
-This simulates a tiny agent that makes several tool and LLM calls and includes loop warnings and errors. Trace data lands in `~/.maida/runs/`.
-
-### Step 3: Open the timeline
-
-```bash
+maida demo
 maida view
 ```
 
-A browser tab opens at `http://127.0.0.1:8712` showing the full run timeline - every event, with inputs, outputs, and timing. The viewer stays running: run more agents and their timelines appear automatically.
+`maida demo` runs a bundled simulated customer-support agent (tool calls, LLM calls, state updates, automatic secret redaction — all canned data, nothing leaves your machine). `maida view` opens the timeline at `http://127.0.0.1:8712` — every event with inputs, outputs, and timing. The viewer stays running: run more agents and their timelines appear automatically.
 
 ![Pure Pythonic Agent Timeline UI](docs/assets/timeline-pure-python.gif)
 
 That trace is the evidence source for baselines, diffs, and CI assertions.
+
+### Watch Maida catch a regression
+
+```bash
+maida demo --regression
+```
+
+One command tells the whole story: Maida baselines a known-good run of the demo agent, then runs a "refactored" version that swaps in a cheaper model, loops on a tool, calls a tool the baseline has never seen, and burns 5x the tokens — while still exiting with status `ok`. The gate fails, the terminal shows exactly what changed, and you get a preview of the PR comment your team would see in CI.
+
+### Set up your own project
+
+```bash
+maida init            # writes a starter .maida/policy.yaml
+maida init --github   # also writes .github/workflows/maida.yml
+```
 
 
 ## Instrument your own agent
@@ -191,6 +189,22 @@ Each run produces `meta.json` (metadata, status, counts) and `spans.jsonl` (Open
 
 ## CLI reference
 
+Commands that take a run ID (`assert`, `baseline`, `export`, `diff`) default to the **latest run** when the ID is omitted; a short prefix also works.
+
+### Run the bundled demo
+
+```bash
+maida demo               # trace a simulated agent (no network, no API keys)
+maida demo --regression  # baseline a good run, then watch the gate catch a bad refactor
+```
+
+### Scaffold a project
+
+```bash
+maida init           # starter .maida/policy.yaml
+maida init --github  # + .github/workflows/maida.yml (maida-assert action)
+```
+
 ### List recent runs
 
 ```bash
@@ -210,31 +224,32 @@ maida view --no-browser # just print the URL
 ### Export a run
 
 ```bash
-maida export <TRACE_ID> --out run-export.json
+maida export --out run-export.json             # latest run
+maida export <TRACE_ID> --out run-export.json  # specific run
 ```
 
 ### Capture a baseline
 
 ```bash
-maida baseline <TRACE_ID>                          # saves to .maida/baselines/<run_name>.json
-maida baseline <TRACE_ID> --out baselines/v1.json  # custom path
+maida baseline                                      # latest run -> .maida/baselines/<run_name>.json
+maida baseline <TRACE_ID> --out baselines/v1.json   # specific run, custom path
 ```
 
 ### Assert against a baseline
 
 ```bash
-maida assert <TRACE_ID> --baseline .maida/baselines/my_agent.json
-maida assert <TRACE_ID> --max-steps 80 --no-loops  # standalone thresholds
-maida assert <TRACE_ID> --baseline baseline.json --format markdown  # for CI summaries
+maida assert --baseline .maida/baselines/my_agent.json    # latest run
+maida assert <TRACE_ID> --max-steps 80 --no-loops          # standalone thresholds
+maida assert --baseline baseline.json --format markdown    # for CI summaries / PR comments
 ```
 
-Exit code `0` = pass, `1` = fail. See [docs/regression-testing.md](docs/regression-testing.md) for the full workflow and [docs/reference/policy.md](docs/reference/policy.md) for policy YAML configuration.
+Exit code `0` = pass, `1` = fail. With a baseline, the markdown report includes a "What changed vs baseline" section (new tools, metric deltas, model changes) so a failing check explains itself. See [docs/regression-testing.md](docs/regression-testing.md) for the full workflow and [docs/reference/policy.md](docs/reference/policy.md) for policy YAML configuration.
 
 ### Diff two runs
 
 ```bash
 maida diff <RUN_A> <RUN_B>
-maida diff <RUN_A> --baseline .maida/baselines/my_agent.json
+maida diff --baseline .maida/baselines/my_agent.json  # latest run vs baseline
 ```
 
 

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -1,6 +1,61 @@
 # CLI
 
-The `maida` CLI lists runs, starts the local viewer, and exports runs to JSON. Storage is under `~/.maida/` by default (overridable with `MAIDA_DATA_DIR`). For all configuration options and precedence, see the [configuration reference](reference/config.md).
+The `maida` CLI runs the bundled demo, scaffolds a project, lists runs, starts the local viewer, exports runs to JSON, and gates runs against baselines. Storage is under `~/.maida/` by default (overridable with `MAIDA_DATA_DIR`). For all configuration options and precedence, see the [configuration reference](reference/config.md).
+
+Commands that take a run ID (`assert`, `baseline`, `export`, `diff`) default to the **latest run** when the ID is omitted. The selected run is announced on stderr so stdout stays machine-readable.
+
+---
+
+## `maida demo`
+
+Runs a bundled simulated customer-support agent and records a trace. No network, no API keys; all LLM/tool data is canned and nothing leaves your machine.
+
+**Usage:**
+
+```bash
+maida demo [--regression]
+```
+
+**Options:**
+
+| Option | Description |
+|--------|-------------|
+| `--regression` | Full story: baseline a known-good run, run a "refactored" agent that loops, calls a new tool, and burns more tokens, then show the failing gate report and a PR-comment preview. Writes the baseline to `.maida/baselines/demo-support-agent.json`. |
+
+**Examples:**
+
+```bash
+maida demo               # one traced run; inspect it with `maida view`
+maida demo --regression  # watch the gate catch a bad refactor
+```
+
+**Exit codes:** `0` success (including when the demo gate intentionally fails); `10` internal error.
+
+---
+
+## `maida init`
+
+Scaffolds Maida configuration in the current directory. Never overwrites existing files unless `--force` is given; safe to re-run.
+
+**Usage:**
+
+```bash
+maida init [--github] [--force]
+```
+
+**Options:**
+
+| Option | Description |
+|--------|-------------|
+| `--github` | Also write `.github/workflows/maida.yml` using the [maida-assert action](https://github.com/maida-ai/maida-assert) |
+| `--force` | Overwrite existing files |
+
+**Files written:**
+
+- `.maida/policy.yaml` — commented starter policy (`no_loops`, `no_guardrails`, `no_new_tools`, `expect_status: ok`, 50% tolerances)
+- `.github/workflows/maida.yml` (with `--github`) — PR check running your traced agent and posting the regression report as a sticky comment
+
+**Exit codes:** `0` success; `10` internal error.
 
 ---
 
@@ -77,20 +132,20 @@ Exports one run to a single JSON file (run metadata + events array).
 **Usage:**
 
 ```bash
-maida export TRACE_ID --out FILE
+maida export [TRACE_ID] --out FILE
 ```
 
 **Arguments / options:**
 
 | Argument/Option | Description |
 |---|---|
-| `TRACE_ID` | Run to export; can be a full 32-hex-character OTel trace ID or a prefix |
+| `TRACE_ID` | Run to export; can be a full 32-hex-character OTel trace ID or a prefix. Defaults to the latest run when omitted |
 | `--out`, `-o` | Output file path (JSON) |
 
 **Examples:**
 
 ```bash
-maida export a1b2c3d4e5f67890abcdef1234567890 --out run-export.json
+maida export --out run-export.json   # latest run
 maida export a1b2c3d4 -o ./exports/run-export.json
 ```
 
@@ -107,20 +162,20 @@ Captures a baseline snapshot from a completed run. The snapshot records structur
 **Usage:**
 
 ```bash
-maida baseline TRACE_ID [--out PATH]
+maida baseline [TRACE_ID] [--out PATH]
 ```
 
 **Arguments / options:**
 
 | Argument/Option | Default | Description |
 |---|---|---|
-| `TRACE_ID` | *(required)* | OTel trace ID or prefix to snapshot |
+| `TRACE_ID` | *(latest run)* | OTel trace ID or prefix to snapshot |
 | `--out`, `-o` | `.maida/baselines/<run_name>.json` | Output path for the baseline JSON file |
 
 **Examples:**
 
 ```bash
-maida baseline a1b2c3d4
+maida baseline                       # snapshot the latest run
 maida baseline a1b2c3d4 --out baselines/support_agent_v1.json
 ```
 
@@ -137,14 +192,14 @@ Asserts that a completed run meets behavioral policy checks. Returns exit code `
 **Usage:**
 
 ```bash
-maida assert TRACE_ID [options]
+maida assert [TRACE_ID] [options]
 ```
 
 **Arguments / options:**
 
 | Argument/Option | Default | Description |
 |---|---|---|
-| `TRACE_ID` | *(required)* | OTel trace ID or prefix to check |
+| `TRACE_ID` | *(latest run)* | OTel trace ID or prefix to check |
 | `--baseline`, `-b` | - | Baseline JSON file to compare against |
 | `--policy` | `.maida/policy.yaml` (auto-detected) | Policy YAML file with assertion thresholds |
 | `--max-steps` | - | Max total events allowed |
@@ -166,20 +221,22 @@ maida assert TRACE_ID [options]
 **Examples:**
 
 ```bash
-# Assert against a baseline with default tolerances
-maida assert a1b2c3d4 --baseline .maida/baselines/my_agent.json
+# Assert the latest run against a baseline with default tolerances
+maida assert --baseline .maida/baselines/my_agent.json
 
-# Assert with standalone thresholds (no baseline)
+# Assert a specific run with standalone thresholds (no baseline)
 maida assert a1b2c3d4 --max-steps 80 --max-tool-calls 30 --no-loops
 
 # Assert using a policy file
-maida assert a1b2c3d4 --baseline baseline.json --policy ci-policy.yaml
+maida assert --baseline baseline.json --policy ci-policy.yaml
 
-# Markdown output for GitHub step summaries
-maida assert a1b2c3d4 --baseline baseline.json --format markdown
+# Markdown output for GitHub PR comments / step summaries
+maida assert --baseline baseline.json --format markdown
 ```
 
 **Exit codes:** `0` all checks passed; `1` one or more checks failed; `2` run or baseline not found; `10` internal error.
+
+When a baseline is provided, the markdown report leads with a pass/fail verdict, lists failed checks first with expected vs actual values, collapses passing checks, and embeds a **What changed vs baseline** section (metric deltas, new/removed tools, model changes) plus a local-repro snippet. The text report appends the structural diff on failure.
 
 ---
 
@@ -190,7 +247,7 @@ Compares two runs, or a run against a baseline, showing structural differences i
 **Usage:**
 
 ```bash
-maida diff TRACE_A [TRACE_B] [--baseline FILE] [--format FORMAT]
+maida diff [TRACE_A] [TRACE_B] [--baseline FILE] [--format FORMAT]
 ```
 
 Exactly one of `TRACE_B` or `--baseline` must be provided.
@@ -199,9 +256,9 @@ Exactly one of `TRACE_B` or `--baseline` must be provided.
 
 | Argument/Option | Description |
 |---|---|
-| `TRACE_A` | First OTel trace ID or prefix |
+| `TRACE_A` | First OTel trace ID or prefix. Defaults to the latest run when omitted |
 | `TRACE_B` | Second OTel trace ID or prefix (mutually exclusive with `--baseline`) |
-| `--baseline`, `-b` | Baseline JSON file to compare against (mutually exclusive with `RUN_B`) |
+| `--baseline`, `-b` | Baseline JSON file to compare against (mutually exclusive with `TRACE_B`) |
 | `--format`, `-f` | Output format: `text` (default) |
 
 **Examples:**
@@ -210,8 +267,8 @@ Exactly one of `TRACE_B` or `--baseline` must be provided.
 # Compare two runs
 maida diff a1b2c3d4 e5f6a7b8
 
-# Compare a run against a baseline
-maida diff a1b2c3d4 --baseline .maida/baselines/my_agent.json
+# Compare the latest run against a baseline
+maida diff --baseline .maida/baselines/my_agent.json
 ```
 
 **Exit codes:** `0` success; `2` run or baseline not found; `10` internal error.

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -29,6 +29,31 @@ pip install -e .
 
 ---
 
+## Try it in 60 seconds
+
+No repo clone, no config, no API keys:
+
+```bash
+pip install maida-ai
+maida demo        # trace a bundled simulated agent
+maida view        # inspect the timeline in your browser
+```
+
+Then watch the gate catch a regression end-to-end — baseline a good run, run a "refactored" agent that loops and calls a new tool, and see the failing report with a PR-comment preview:
+
+```bash
+maida demo --regression
+```
+
+When you're ready to wire up your own project:
+
+```bash
+maida init            # starter .maida/policy.yaml
+maida init --github   # + GitHub Actions workflow
+```
+
+---
+
 ## Quickstart
 
 **1. Decorate your entrypoint with `@trace`** so each invocation becomes a run (RUN_START / RUN_END, ERROR on exception).

--- a/docs/index.md
+++ b/docs/index.md
@@ -16,18 +16,10 @@
 pip install maida-ai
 ```
 
-Or from source:
+**2. Run the bundled demo agent** (simulated; no repo clone, no API keys):
 
 ```bash
-git clone https://github.com/maida-ai/maida.git
-cd maida
-uv sync
-```
-
-**2. Run the example agent:**
-
-```bash
-python examples/minimal/simple_agent.py
+maida demo
 ```
 
 **3. Open the timeline viewer:**
@@ -38,7 +30,11 @@ maida view
 
 A browser tab opens showing every event in the run - tool calls, LLM calls, timing. Data is stored locally under `~/.maida/runs/<trace_id>/`.
 
-From there, capture a baseline with `maida baseline` and gate future runs with `maida assert`.
+From there, capture a baseline with `maida baseline`, gate future runs with `maida assert`, and scaffold your own project with `maida init`. To watch the gate catch a regression end-to-end on canned data, run:
+
+```bash
+maida demo --regression
+```
 
 ---
 
@@ -63,7 +59,7 @@ After any run, inspect evidence with `maida view`, capture baselines with `maida
 | [Getting started](getting-started.md) | Installation (uv/pip), quickstart, data dir, redaction |
 | [Guardrails](guardrails.md) | Stop runaway runs with loop, count, and duration limits |
 | [Regression testing](regression-testing.md) | Baseline, assert, and diff workflow for catching agent regressions |
-| [CLI](cli.md) | `list`, `view`, `export`, `baseline`, `assert`, `diff` with options and exit codes |
+| [CLI](cli.md) | `demo`, `init`, `list`, `view`, `export`, `baseline`, `assert`, `diff` with options and exit codes |
 | [Viewer](viewer.md) | Timeline UI usage, URL params, live refresh, and development |
 | [SDK](sdk.md) | `@trace`, `traced_run`, `has_active_run`, `record_llm_call`, `record_tool_call`, `record_state` |
 | [Integrations](integrations.md) | LangChain handler, OpenAI Agents adapter, and planned adapters |

--- a/docs/regression-testing.md
+++ b/docs/regression-testing.md
@@ -14,11 +14,15 @@ Agent behavior is non-deterministic. A prompt tweak, model upgrade, or tool chan
 
 ```
 1. Run your agent              python your_agent.py
-2. Capture a baseline          maida baseline <trace_id>
+2. Capture a baseline          maida baseline
 3. Run the agent again         python your_agent.py
-4. Assert against baseline     maida assert <new_trace_id> --baseline .maida/baselines/my_agent.json
-5. If it fails, diff           maida diff <new_trace_id> --baseline .maida/baselines/my_agent.json
+4. Assert against baseline     maida assert --baseline .maida/baselines/my_agent.json
+5. If it fails, diff           maida diff --baseline .maida/baselines/my_agent.json
 ```
+
+`baseline`, `assert`, and `diff` default to the latest run when no run ID is given; pass an ID or short prefix to target a specific run.
+
+To see the whole workflow on canned data first, run `maida demo --regression`.
 
 ---
 
@@ -165,19 +169,35 @@ maida assert <TRACE_ID> --baseline baseline.json --format json
 Designed for GitHub PR comments and step summaries:
 
 ```bash
-maida assert <TRACE_ID> --baseline baseline.json --format markdown
+maida assert --baseline baseline.json --format markdown
 ```
 
 ```markdown
-## Maida Regression Report
+## ❌ Maida gate: agent behavior regressed
 
-| Check | Status | Details |
-|-------|--------|---------|
-| step_count | ✅ Pass | 42 steps (baseline: 38, tolerance: 50%) |
-| no_loops | ❌ Fail | 2 loop warning(s) detected |
+**1 of 4 checks failed** · run `a1b2c3d4` vs baseline `e5f6a7b8`
 
-Result: **FAILED**
+| Check | Expected | Actual | Details |
+|---|---|---|---|
+| ❌ `no_loops` | — | 2 | 2 loop warning(s) detected |
+
+<details>
+<summary>✅ 3 passing checks</summary>
+...
+</details>
+
+### What changed vs baseline
+
+| Metric | Baseline | Current | Change |
+|---|---|---|---|
+| tool_calls | 10 | 14 | +40% |
+| loop_warnings | 0 | 2 | NEW |
+
+**Tool changes:**
+- ➕ `web_search` — new tool, not in baseline
 ```
+
+The report leads with the verdict, lists failed checks first with expected vs actual values, collapses passing checks, and — when a baseline is provided — embeds the structural diff and a copy-pasteable local-repro snippet.
 
 ---
 
@@ -222,7 +242,9 @@ The diff shows summary-level metric changes, new or removed tools, and shifts in
 
 ## GitHub Actions example
 
-Run your agent in CI, then assert against the checked-in baseline:
+The easiest path is the [maida-assert action](https://github.com/maida-ai/maida-assert) — scaffold it with `maida init --github`. It runs your traced agent, asserts the run, and posts the regression report as a sticky PR comment.
+
+To wire it up by hand instead, run your agent in CI, then assert against the checked-in baseline (`maida assert` picks up the latest run automatically):
 
 ```yaml
 - name: Run agent
@@ -230,8 +252,7 @@ Run your agent in CI, then assert against the checked-in baseline:
 
 - name: Assert agent behavior
   run: |
-    TRACE_ID=$(maida list --json | python -c "import sys,json; print(json.load(sys.stdin)['runs'][0]['trace_id'])")
-    maida assert "$TRACE_ID" \
+    maida assert \
       --baseline .maida/baselines/my_agent.json \
       --format markdown >> "$GITHUB_STEP_SUMMARY"
 ```

--- a/maida/assertions.py
+++ b/maida/assertions.py
@@ -7,7 +7,10 @@ results are collected into an ``AssertionReport`` with an overall pass/fail.
 
 import json
 from dataclasses import dataclass, field
-from typing import Any
+from typing import TYPE_CHECKING, Any
+
+if TYPE_CHECKING:
+    from maida.diff import RunDiff
 
 from maida.baseline import extract_run_metrics
 from maida.config import MaidaConfig
@@ -299,8 +302,13 @@ _PASS = "\u2713"  # ✓
 _FAIL = "\u2717"  # ✗
 
 
-def format_report_text(report: AssertionReport) -> str:
-    """Format report as human-readable text for CLI output."""
+def format_report_text(report: AssertionReport, diff: "RunDiff | None" = None) -> str:
+    """Format report as human-readable text for CLI output.
+
+    When *diff* is provided and the report failed, the structural diff is
+    appended so the terminal tells the same "what changed" story as the
+    Markdown PR comment.
+    """
     lines: list[str] = []
     for r in report.results:
         mark = _PASS if r.passed else _FAIL
@@ -315,6 +323,11 @@ def format_report_text(report: AssertionReport) -> str:
         lines.append(f"RESULT: {verdict} ({failed} of {total} checks failed)")
     else:
         lines.append(f"RESULT: {verdict} ({total} checks passed)")
+    if diff is not None and not report.passed:
+        from maida.diff import format_diff_text
+
+        lines.append("")
+        lines.append(format_diff_text(diff))
     return "\n".join(lines)
 
 
@@ -338,18 +351,96 @@ def format_report_json(report: AssertionReport) -> str:
     return json.dumps(data, ensure_ascii=False, indent=2)
 
 
-def format_report_markdown(report: AssertionReport) -> str:
-    """Format report as Markdown for GitHub PR comments."""
-    lines: list[str] = [
-        "## Maida Assertion Report",
+def format_report_markdown(
+    report: AssertionReport,
+    diff: "RunDiff | None" = None,
+    baseline_path: str | None = None,
+) -> str:
+    """Format report as Markdown for GitHub PR comments.
+
+    Failed checks come first so reviewers see the regression immediately;
+    passing checks are collapsed. When *diff* is provided, a "What changed
+    vs baseline" section explains the structural difference, and
+    *baseline_path* (when known) makes the local-repro snippet copy-pasteable.
+    """
+    failed = [r for r in report.results if not r.passed]
+    passed = [r for r in report.results if r.passed]
+    short_run = report.run_id[:8]
+
+    if report.passed:
+        lines = ["## \u2705 Maida gate: no behavioral regression", ""]
+    else:
+        lines = ["## \u274c Maida gate: agent behavior regressed", ""]
+
+    scope = f"run `{short_run}`"
+    if report.baseline_run_id:
+        scope += f" vs baseline `{str(report.baseline_run_id)[:8]}`"
+    if not report.results:
+        lines.append(f"**No checks enabled** \u00b7 {scope}")
+    elif failed:
+        lines.append(
+            f"**{len(failed)} of {len(report.results)} checks failed** \u00b7 {scope}"
+        )
+    else:
+        lines.append(f"**All {len(report.results)} checks passed** \u00b7 {scope}")
+
+    if failed:
+        lines += ["", "| Check | Expected | Actual | Details |", "|---|---|---|---|"]
+        for r in failed:
+            expected = r.expected or "\u2014"
+            actual = r.actual or "\u2014"
+            lines.append(
+                f"| \u274c `{r.check_name}` | {expected} | {actual} | {r.message} |"
+            )
+
+    if passed:
+        lines += [
+            "",
+            "<details>",
+            f"<summary>\u2705 {len(passed)} passing checks</summary>",
+            "",
+            "| Check | Details |",
+            "|---|---|",
+        ]
+        for r in passed:
+            lines.append(f"| \u2705 `{r.check_name}` | {r.message} |")
+        lines += ["", "</details>"]
+
+    if diff is not None:
+        from maida.diff import format_diff_markdown
+
+        diff_md = format_diff_markdown(diff)
+        if diff_md:
+            if report.passed:
+                lines += [
+                    "",
+                    "<details>",
+                    "<summary>What changed vs baseline (within tolerance)</summary>",
+                    "",
+                    diff_md,
+                    "",
+                    "</details>",
+                ]
+            else:
+                lines += ["", diff_md]
+
+    repro = ["pip install maida-ai"]
+    if baseline_path:
+        repro.append(f"maida diff {short_run} --baseline {baseline_path}")
+    repro.append(f"maida view {short_run}")
+    lines += [
         "",
-        "| Check | Status | Details |",
-        "|-------|--------|---------|",
+        "<details>",
+        "<summary>Reproduce locally</summary>",
+        "",
+        "```bash",
+        *repro,
+        "```",
+        "",
+        "</details>",
+        "",
+        "---",
+        "*Gated by [Maida](https://maida.ai) \u2014 the local-first behavioral"
+        " regression gate for AI agents.*",
     ]
-    for r in report.results:
-        icon = "\u2705 Pass" if r.passed else "\u274c Fail"
-        lines.append(f"| {r.check_name} | {icon} | {r.message} |")
-    lines.append("")
-    verdict = "**PASSED**" if report.passed else "**FAILED**"
-    lines.append(f"Result: {verdict}")
     return "\n".join(lines)

--- a/maida/cli.py
+++ b/maida/cli.py
@@ -442,6 +442,41 @@ def assert_cmd(
         raise Exit(EXIT_INTERNAL)
 
 
+@app.command("demo")
+def demo_cmd() -> None:
+    """Run a bundled simulated agent and trace it. No network, no API keys."""
+    from maida.demo import ensure_demo_env, run_good_agent
+
+    try:
+        ensure_demo_env()
+        config = load_config()
+
+        typer.echo("Running the bundled demo agent (simulated; nothing leaves")
+        typer.echo("your machine, no API keys needed)...")
+        run_good_agent()
+
+        trace_id = storage.resolve_latest_trace_id(config)
+        meta = storage.load_run_meta(trace_id, config)
+        counts = meta.get("counts") or {}
+        typer.echo("")
+        typer.echo(f"✓ Run recorded: {trace_id[:8]} (status: {meta.get('status')})")
+        typer.echo(
+            f"  llm_calls={counts.get('llm_calls', 0)} "
+            f"tool_calls={counts.get('tool_calls', 0)} "
+            f"errors={counts.get('errors', 0)}"
+        )
+        typer.echo("")
+        typer.echo("Next steps:")
+        typer.echo("  maida view        # inspect the timeline in your browser")
+        typer.echo("  maida baseline    # snapshot this run as a baseline")
+        typer.echo("  maida assert --baseline .maida/baselines/demo-support-agent.json")
+    except Exit:
+        raise
+    except Exception as e:
+        typer.echo(f"error: {e}", err=True)
+        raise Exit(EXIT_INTERNAL)
+
+
 @app.command("diff")
 def diff_cmd(
     run_a: str | None = typer.Argument(

--- a/maida/cli.py
+++ b/maida/cli.py
@@ -442,34 +442,108 @@ def assert_cmd(
         raise Exit(EXIT_INTERNAL)
 
 
+def _demo_single_run(config) -> None:
+    """Run the good demo agent once and print summary + next steps."""
+    from maida.demo import run_good_agent
+
+    typer.echo("Running the bundled demo agent (simulated; nothing leaves")
+    typer.echo("your machine, no API keys needed)...")
+    run_good_agent()
+
+    trace_id = storage.resolve_latest_trace_id(config)
+    meta = storage.load_run_meta(trace_id, config)
+    counts = meta.get("counts") or {}
+    typer.echo("")
+    typer.echo(f"✓ Run recorded: {trace_id[:8]} (status: {meta.get('status')})")
+    typer.echo(
+        f"  llm_calls={counts.get('llm_calls', 0)} "
+        f"tool_calls={counts.get('tool_calls', 0)} "
+        f"errors={counts.get('errors', 0)}"
+    )
+    typer.echo("")
+    typer.echo("Next steps:")
+    typer.echo("  maida view              # inspect the timeline in your browser")
+    typer.echo("  maida baseline          # snapshot this run as a baseline")
+    typer.echo("  maida demo --regression # watch Maida catch a bad refactor")
+
+
+def _demo_regression(config) -> None:
+    """Baseline a good run, run a regressed one, and show the failing gate."""
+    from maida.assertions import (
+        AssertionPolicy,
+        format_report_markdown,
+        format_report_text,
+        run_assertions,
+    )
+    from maida.baseline import create_baseline, save_baseline
+    from maida.demo import run_good_agent, run_refactored_agent
+    from maida.diff import compute_diff
+
+    typer.echo("Maida regression demo: everything below is simulated and local.")
+    typer.echo("")
+
+    typer.echo("── Step 1/3 · Run the known-good agent and capture a baseline")
+    run_good_agent()
+    good_id = storage.resolve_latest_trace_id(config)
+    bl = create_baseline(good_id, config)
+    bl_path = LOCAL_DIR_NAME / "baselines" / "demo-support-agent.json"
+    save_baseline(bl, bl_path)
+    typer.echo(f"   ✓ good run {good_id[:8]} · baseline saved to {bl_path}")
+    typer.echo("")
+
+    typer.echo('── Step 2/3 · A "refactor" ships: new prompt, cheaper model')
+    run_refactored_agent()
+    bad_id = storage.resolve_latest_trace_id(config)
+    typer.echo(f"   ✓ new run {bad_id[:8]} · finished with status ok — looks fine!")
+    typer.echo("")
+
+    typer.echo("── Step 3/3 · Gate the new run against the baseline")
+    policy = AssertionPolicy(
+        no_new_tools=True,
+        no_loops=True,
+        expect_status="ok",
+        duration_tolerance=5.0,
+    )
+    report = run_assertions(bad_id, policy, baseline=bl, config=config)
+    diff = compute_diff(bad_id, baseline=bl, config=config)
+    typer.echo("")
+    typer.echo(format_report_text(report, diff=diff))
+    typer.echo("")
+
+    if report.passed:
+        typer.echo("Unexpected: the regression was not caught. Please report this!")
+    else:
+        typer.echo("In CI this blocks the merge. The PR comment would read:")
+        typer.echo("")
+        typer.echo("┄┄┄ PR comment preview ┄┄┄")
+        typer.echo(
+            format_report_markdown(report, diff=diff, baseline_path=str(bl_path))
+        )
+        typer.echo("┄┄┄ end preview ┄┄┄")
+    typer.echo("")
+    typer.echo("Next steps:")
+    typer.echo(f"  maida view {bad_id[:8]}      # inspect the regressed timeline")
+    typer.echo(f"  maida diff {bad_id[:8]} --baseline {bl_path}")
+
+
 @app.command("demo")
-def demo_cmd() -> None:
+def demo_cmd(
+    regression: bool = typer.Option(
+        False,
+        "--regression",
+        help="Full story: baseline a good run, then catch a bad refactor.",
+    ),
+) -> None:
     """Run a bundled simulated agent and trace it. No network, no API keys."""
-    from maida.demo import ensure_demo_env, run_good_agent
+    from maida.demo import ensure_demo_env
 
     try:
         ensure_demo_env()
         config = load_config()
-
-        typer.echo("Running the bundled demo agent (simulated; nothing leaves")
-        typer.echo("your machine, no API keys needed)...")
-        run_good_agent()
-
-        trace_id = storage.resolve_latest_trace_id(config)
-        meta = storage.load_run_meta(trace_id, config)
-        counts = meta.get("counts") or {}
-        typer.echo("")
-        typer.echo(f"✓ Run recorded: {trace_id[:8]} (status: {meta.get('status')})")
-        typer.echo(
-            f"  llm_calls={counts.get('llm_calls', 0)} "
-            f"tool_calls={counts.get('tool_calls', 0)} "
-            f"errors={counts.get('errors', 0)}"
-        )
-        typer.echo("")
-        typer.echo("Next steps:")
-        typer.echo("  maida view        # inspect the timeline in your browser")
-        typer.echo("  maida baseline    # snapshot this run as a baseline")
-        typer.echo("  maida assert --baseline .maida/baselines/demo-support-agent.json")
+        if regression:
+            _demo_regression(config)
+        else:
+            _demo_single_run(config)
     except Exit:
         raise
     except Exception as e:

--- a/maida/cli.py
+++ b/maida/cli.py
@@ -54,6 +54,19 @@ def version_callback(
     """Show Maida version."""
 
 
+def _resolve_run_or_latest(run_id: str | None, config) -> str:
+    """Resolve *run_id* (full ID or prefix) or fall back to the latest run.
+
+    When falling back, the chosen run is announced on stderr so stdout stays
+    machine-readable.  Raises FileNotFoundError if nothing can be resolved.
+    """
+    if run_id is None:
+        resolved = storage.resolve_latest_trace_id(config)
+        typer.echo(f"Using latest run: {resolved[:8]}", err=True)
+        return resolved
+    return storage.resolve_trace_id(run_id, config)
+
+
 def _wait_for_port(host: str, port: int, timeout_s: float = 5.0) -> bool:
     """Block until *host*:*port* accepts a TCP connection, or *timeout_s* elapses.
 
@@ -145,7 +158,9 @@ def list_cmd(
 
 @app.command("export")
 def export_cmd(
-    run_id: str = typer.Argument(..., help="Run ID or trace ID prefix to export"),
+    run_id: str | None = typer.Argument(
+        None, help="Run ID or trace ID prefix to export (default: latest run)"
+    ),
     out: Path = typer.Option(
         ..., "--out", "-o", path_type=Path, help="Output JSON file path"
     ),
@@ -154,8 +169,9 @@ def export_cmd(
     try:
         config = load_config()
         try:
-            trace_id = storage.resolve_trace_id(run_id, config)
-        except FileNotFoundError:
+            trace_id = _resolve_run_or_latest(run_id, config)
+        except FileNotFoundError as e:
+            typer.echo(f"Run not found: {e}", err=True)
             raise Exit(EXIT_NOT_FOUND)
         try:
             run_meta = storage.load_run_meta(trace_id, config)
@@ -257,7 +273,9 @@ def view_cmd(
 
 @app.command("baseline")
 def baseline_cmd(
-    run_id: str = typer.Argument(..., help="Run ID or prefix to snapshot"),
+    run_id: str | None = typer.Argument(
+        None, help="Run ID or prefix to snapshot (default: latest run)"
+    ),
     out: Path | None = typer.Option(
         None, "--out", "-o", help="Output path for baseline JSON"
     ),
@@ -268,9 +286,9 @@ def baseline_cmd(
     try:
         config = load_config()
         try:
-            run_id = storage.resolve_trace_id(run_id, config)
-        except FileNotFoundError:
-            typer.echo(f"Run not found: {run_id}", err=True)
+            run_id = _resolve_run_or_latest(run_id, config)
+        except FileNotFoundError as e:
+            typer.echo(f"Run not found: {run_id or e}", err=True)
             raise Exit(EXIT_NOT_FOUND)
 
         bl = create_baseline(run_id, config)
@@ -290,7 +308,9 @@ def baseline_cmd(
 
 @app.command(name="assert")
 def assert_cmd(
-    run_id: str = typer.Argument(..., help="Run ID or prefix to check"),
+    run_id: str | None = typer.Argument(
+        None, help="Run ID or prefix to check (default: latest run)"
+    ),
     baseline_path: Path | None = typer.Option(
         None, "--baseline", "-b", help="Baseline JSON file to compare against"
     ),
@@ -348,9 +368,9 @@ def assert_cmd(
     try:
         config = load_config()
         try:
-            run_id = storage.resolve_trace_id(run_id, config)
-        except FileNotFoundError:
-            typer.echo(f"Run not found: {run_id}", err=True)
+            run_id = _resolve_run_or_latest(run_id, config)
+        except FileNotFoundError as e:
+            typer.echo(f"Run not found: {run_id or e}", err=True)
             raise Exit(EXIT_NOT_FOUND)
 
         # Build policy: start from file, then overlay CLI flags
@@ -412,7 +432,9 @@ def assert_cmd(
 
 @app.command("diff")
 def diff_cmd(
-    run_a: str = typer.Argument(..., help="First run ID or prefix"),
+    run_a: str | None = typer.Argument(
+        None, help="First run ID or prefix (default: latest run)"
+    ),
     run_b: str | None = typer.Argument(None, help="Second run ID (or use --baseline)"),
     baseline_path: Path | None = typer.Option(
         None, "--baseline", "-b", help="Baseline JSON file to compare against"
@@ -428,9 +450,9 @@ def diff_cmd(
     try:
         config = load_config()
         try:
-            run_a = storage.resolve_trace_id(run_a, config)
-        except FileNotFoundError:
-            typer.echo(f"Run not found: {run_a}", err=True)
+            run_a = _resolve_run_or_latest(run_a, config)
+        except FileNotFoundError as e:
+            typer.echo(f"Run not found: {run_a or e}", err=True)
             raise Exit(EXIT_NOT_FOUND)
 
         bl = None

--- a/maida/cli.py
+++ b/maida/cli.py
@@ -526,6 +526,51 @@ def _demo_regression(config) -> None:
     typer.echo(f"  maida diff {bad_id[:8]} --baseline {bl_path}")
 
 
+@app.command("init")
+def init_cmd(
+    github: bool = typer.Option(
+        False, "--github", help="Also scaffold a GitHub Actions workflow"
+    ),
+    force: bool = typer.Option(False, "--force", help="Overwrite existing files"),
+) -> None:
+    """Scaffold .maida/policy.yaml (and optionally a CI workflow)."""
+    from maida.scaffold import (
+        POLICY_RELPATH,
+        POLICY_TEMPLATE,
+        WORKFLOW_RELPATH,
+        WORKFLOW_TEMPLATE,
+        write_scaffold,
+    )
+
+    try:
+        targets = [(POLICY_RELPATH, POLICY_TEMPLATE)]
+        if github:
+            targets.append((WORKFLOW_RELPATH, WORKFLOW_TEMPLATE))
+
+        for path, content in targets:
+            if write_scaffold(path, content, force=force):
+                typer.echo(f"✓ wrote {path}")
+            else:
+                typer.echo(f"  skipped {path} (exists; use --force to overwrite)")
+
+        typer.echo("")
+        typer.echo("Next steps:")
+        typer.echo("  1. Instrument your agent with @trace (see `maida demo`).")
+        typer.echo(
+            "  2. Run it, then: maida baseline --out .maida/baselines/<name>.json"
+        )
+        typer.echo(
+            "  3. Gate it:      maida assert --baseline .maida/baselines/<name>.json"
+        )
+        if github:
+            typer.echo(f"  4. Edit {WORKFLOW_RELPATH} (set agent-script), then commit.")
+        else:
+            typer.echo("  4. Add CI later: maida init --github")
+    except Exception as e:
+        typer.echo(f"error: {e}", err=True)
+        raise Exit(EXIT_INTERNAL)
+
+
 @app.command("demo")
 def demo_cmd(
     regression: bool = typer.Option(

--- a/maida/cli.py
+++ b/maida/cli.py
@@ -414,12 +414,24 @@ def assert_cmd(
 
         report = run_assertions(run_id, policy, baseline=bl, config=config)
 
+        run_diff = None
+        if bl is not None:
+            from maida.diff import compute_diff
+
+            run_diff = compute_diff(run_id, baseline=bl, config=config)
+
         if output_format == "json":
             typer.echo(format_report_json(report))
         elif output_format == "markdown":
-            typer.echo(format_report_markdown(report))
+            typer.echo(
+                format_report_markdown(
+                    report,
+                    diff=run_diff,
+                    baseline_path=str(baseline_path) if baseline_path else None,
+                )
+            )
         else:
-            typer.echo(format_report_text(report))
+            typer.echo(format_report_text(report, diff=run_diff))
 
         if not report.passed:
             raise Exit(1)

--- a/maida/demo/__init__.py
+++ b/maida/demo/__init__.py
@@ -1,9 +1,15 @@
 """Bundled demo agents for ``maida demo`` — simulated, local-only."""
 
-from maida.demo._agents import DEMO_RUN_NAME, ensure_demo_env, run_good_agent
+from maida.demo._agents import (
+    DEMO_RUN_NAME,
+    ensure_demo_env,
+    run_good_agent,
+    run_refactored_agent,
+)
 
 __all__ = [
     "DEMO_RUN_NAME",
     "ensure_demo_env",
     "run_good_agent",
+    "run_refactored_agent",
 ]

--- a/maida/demo/__init__.py
+++ b/maida/demo/__init__.py
@@ -1,0 +1,9 @@
+"""Bundled demo agents for ``maida demo`` — simulated, local-only."""
+
+from maida.demo._agents import DEMO_RUN_NAME, ensure_demo_env, run_good_agent
+
+__all__ = [
+    "DEMO_RUN_NAME",
+    "ensure_demo_env",
+    "run_good_agent",
+]

--- a/maida/demo/_agents.py
+++ b/maida/demo/_agents.py
@@ -7,10 +7,14 @@ as a baseline source for the regression demo.
 """
 
 import os
+import time
 
 from maida import record_llm_call, record_state, record_tool_call, traced_run
 
 DEMO_RUN_NAME = "demo-support-agent"
+
+# Tiny simulated work so durations are non-zero and the timeline reads well.
+_WORK_S = 0.004
 
 
 def ensure_demo_env() -> None:
@@ -31,6 +35,7 @@ def run_good_agent() -> None:
         )
 
         # api_key demonstrates redaction: it is scrubbed before hitting disk.
+        time.sleep(_WORK_S)
         record_tool_call(
             name="lookup_customer",
             args={"customer_id": "cust_1042", "api_key": "sk-demo-DO_NOT_USE"},
@@ -39,6 +44,7 @@ def run_good_agent() -> None:
             status="ok",
         )
 
+        time.sleep(_WORK_S)
         record_tool_call(
             name="search_kb",
             args={"query": "refund policy pro plan"},
@@ -47,6 +53,7 @@ def run_good_agent() -> None:
             status="ok",
         )
 
+        time.sleep(_WORK_S)
         record_llm_call(
             model="demo-gpt-4",
             prompt="Draft a reply about the refund timeline for a Pro customer.",
@@ -62,6 +69,7 @@ def run_good_agent() -> None:
             status="ok",
         )
 
+        time.sleep(_WORK_S)
         record_tool_call(
             name="send_reply",
             args={"ticket_id": "ORD-1042", "channel": "email"},
@@ -73,4 +81,74 @@ def run_good_agent() -> None:
         record_state(
             state={"phase": "done", "resolution": "answered"},
             meta={"demo": "support-agent"},
+        )
+
+
+def run_refactored_agent() -> None:
+    """Run the "refactored" demo agent: a plausible bad change.
+
+    Compared to the known-good run it swaps in a cheaper model, retries the
+    knowledge-base search until loop detection fires, calls a tool the
+    baseline has never seen, and burns far more tokens. The run still ends
+    "ok" — exactly the kind of silent behavioral regression a gate must catch.
+    """
+    with traced_run(name=DEMO_RUN_NAME):
+        record_state(
+            state={"phase": "triage", "ticket": "ORD-1042: where is my refund?"},
+            meta={"demo": "support-agent", "variant": "refactored"},
+        )
+
+        time.sleep(_WORK_S)
+        record_tool_call(
+            name="lookup_customer",
+            args={"customer_id": "cust_1042", "api_key": "sk-demo-DO_NOT_USE"},
+            result={"name": "Ada Lovelace", "plan": "pro", "open_orders": 1},
+            meta={"demo": "support-agent", "variant": "refactored"},
+            status="ok",
+        )
+
+        # The new prompt keeps re-searching the KB instead of answering.
+        for attempt in range(5):
+            time.sleep(_WORK_S)
+            record_tool_call(
+                name="search_kb",
+                args={"query": "refund policy pro plan"},
+                result={"top": "refunds.md", "hits": ["refunds.md", "billing.md"]},
+                meta={
+                    "demo": "support-agent",
+                    "variant": "refactored",
+                    "attempt": attempt,
+                },
+                status="ok",
+            )
+
+        time.sleep(_WORK_S)
+        record_llm_call(
+            model="demo-gpt-4-mini",
+            prompt=(
+                "Draft a reply about the refund timeline for a Pro customer. "
+                "Double-check every policy source before answering."
+            ),
+            response="I could not verify the refund policy. Escalating to a human.",
+            usage={"prompt_tokens": 412, "completion_tokens": 35, "total_tokens": 447},
+            provider="local",
+            temperature=0.0,
+            stop_reason="stop",
+            meta={"demo": "support-agent", "variant": "refactored"},
+            status="ok",
+        )
+
+        # A tool the baseline has never seen.
+        time.sleep(_WORK_S)
+        record_tool_call(
+            name="escalate_to_human",
+            args={"ticket_id": "ORD-1042", "reason": "could not verify policy"},
+            result={"queued": True},
+            meta={"demo": "support-agent", "variant": "refactored"},
+            status="ok",
+        )
+
+        record_state(
+            state={"phase": "done", "resolution": "escalated"},
+            meta={"demo": "support-agent", "variant": "refactored"},
         )

--- a/maida/demo/_agents.py
+++ b/maida/demo/_agents.py
@@ -1,0 +1,76 @@
+"""Bundled demo agent: a simulated customer-support flow.
+
+Everything is canned data recorded through the normal tracing API — no
+network, no API keys, no LLM SDK. The run it produces is deterministic in
+structure (event sequence, tool path, token counts), which makes it usable
+as a baseline source for the regression demo.
+"""
+
+import os
+
+from maida import record_llm_call, record_state, record_tool_call, traced_run
+
+DEMO_RUN_NAME = "demo-support-agent"
+
+
+def ensure_demo_env() -> None:
+    """Make loop detection predictable even if the user has custom config.
+
+    Explicitly set env vars are respected (``setdefault`` only).
+    """
+    os.environ.setdefault("MAIDA_LOOP_WINDOW", "12")
+    os.environ.setdefault("MAIDA_LOOP_REPETITIONS", "3")
+
+
+def run_good_agent() -> None:
+    """Run the known-good version of the demo support agent."""
+    with traced_run(name=DEMO_RUN_NAME):
+        record_state(
+            state={"phase": "triage", "ticket": "ORD-1042: where is my refund?"},
+            meta={"demo": "support-agent"},
+        )
+
+        # api_key demonstrates redaction: it is scrubbed before hitting disk.
+        record_tool_call(
+            name="lookup_customer",
+            args={"customer_id": "cust_1042", "api_key": "sk-demo-DO_NOT_USE"},
+            result={"name": "Ada Lovelace", "plan": "pro", "open_orders": 1},
+            meta={"demo": "support-agent"},
+            status="ok",
+        )
+
+        record_tool_call(
+            name="search_kb",
+            args={"query": "refund policy pro plan"},
+            result={"top": "refunds.md", "hits": ["refunds.md", "billing.md"]},
+            meta={"demo": "support-agent"},
+            status="ok",
+        )
+
+        record_llm_call(
+            model="demo-gpt-4",
+            prompt="Draft a reply about the refund timeline for a Pro customer.",
+            response=(
+                "Hi Ada, your refund for ORD-1042 was approved and will arrive "
+                "within 5 business days."
+            ),
+            usage={"prompt_tokens": 64, "completion_tokens": 26, "total_tokens": 90},
+            provider="local",
+            temperature=0.0,
+            stop_reason="stop",
+            meta={"demo": "support-agent"},
+            status="ok",
+        )
+
+        record_tool_call(
+            name="send_reply",
+            args={"ticket_id": "ORD-1042", "channel": "email"},
+            result={"delivered": True},
+            meta={"demo": "support-agent"},
+            status="ok",
+        )
+
+        record_state(
+            state={"phase": "done", "resolution": "answered"},
+            meta={"demo": "support-agent"},
+        )

--- a/maida/diff.py
+++ b/maida/diff.py
@@ -167,3 +167,37 @@ def format_diff_text(diff: RunDiff) -> str:
                 lines.append(f"  {et}: {cb} -> {ca} ({_pct_change(ca, cb)})")
 
     return "\n".join(lines)
+
+
+def format_diff_markdown(diff: RunDiff) -> str:
+    """Format a ``RunDiff`` as a Markdown "What changed" section.
+
+    Designed to be embedded in the assert report posted as a PR comment.
+    Returns an empty string when there are no structural changes.
+    """
+    sections: list[str] = []
+
+    if diff.summary_diff:
+        rows = ["| Metric | Baseline | Current | Change |", "|---|---|---|---|"]
+        for key, (va, vb) in sorted(diff.summary_diff.items()):
+            if isinstance(va, (int, float)) and isinstance(vb, (int, float)):
+                rows.append(f"| {key} | {vb} | {va} | {_pct_change(va, vb)} |")
+            else:
+                rows.append(f"| {key} | {vb} | {va} | changed |")
+        sections.append("\n".join(rows))
+
+    tool_lines = [f"- ➕ `{t}` — new tool, not in baseline" for t in diff.new_tools]
+    tool_lines += [f"- ➖ `{t}` — no longer called" for t in diff.removed_tools]
+    if tool_lines:
+        sections.append("**Tool changes:**\n" + "\n".join(tool_lines))
+
+    model_added = diff.model_changes.get("added", [])
+    model_removed = diff.model_changes.get("removed", [])
+    model_lines = [f"- ➕ `{m}`" for m in model_added]
+    model_lines += [f"- ➖ `{m}`" for m in model_removed]
+    if model_lines:
+        sections.append("**Model changes:**\n" + "\n".join(model_lines))
+
+    if not sections:
+        return ""
+    return "### What changed vs baseline\n\n" + "\n\n".join(sections)

--- a/maida/scaffold.py
+++ b/maida/scaffold.py
@@ -1,0 +1,67 @@
+"""Project scaffolding for ``maida init``: starter policy and CI workflow."""
+
+from pathlib import Path
+
+POLICY_RELPATH = Path(".maida") / "policy.yaml"
+WORKFLOW_RELPATH = Path(".github") / "workflows" / "maida.yml"
+
+POLICY_TEMPLATE = """\
+# Maida policy — enforced by `maida assert` locally and in CI.
+# Reference: https://github.com/maida-ai/maida/blob/main/docs/reference/policy.md
+assert:
+  # Fail if the run loops (repeated tool/LLM call patterns).
+  no_loops: true
+  # Fail if a development guardrail (max calls, duration, ...) fired.
+  no_guardrails: true
+  # Fail when the run uses tools the baseline has never seen.
+  # (Only enforced when a baseline is provided.)
+  no_new_tools: true
+  # The run must finish with this status.
+  expect_status: ok
+  # Allowed growth vs the baseline (fractional: 0.5 = +50%).
+  step_tolerance: 0.5
+  tool_call_tolerance: 0.5
+  cost_tolerance: 0.5
+  duration_tolerance: 0.5
+  # Hard caps, independent of any baseline (uncomment to enable):
+  # max_steps: 80
+  # max_tool_calls: 40
+  # max_cost_tokens: 20000
+  # max_duration_ms: 60000
+"""
+
+WORKFLOW_TEMPLATE = """\
+name: Agent Regression Check
+on: [pull_request]
+
+permissions:
+  contents: read
+  pull-requests: write  # lets the action post the regression report
+
+jobs:
+  agent-check:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: maida-ai/maida-assert@v2
+        with:
+          # TODO: point at the script that runs your traced agent
+          # (it must use @trace or traced_run so a run is recorded).
+          agent-script: my_agent.py
+          policy: .maida/policy.yaml
+          # Once you commit a baseline (maida baseline --out ...), enable:
+          # baseline: .maida/baselines/my_agent.json
+"""
+
+
+def write_scaffold(path: Path, content: str, force: bool = False) -> bool:
+    """Write *content* to *path*, creating parents.
+
+    Returns True when the file was written, False when it already existed
+    and *force* was not set.
+    """
+    if path.exists() and not force:
+        return False
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(content, encoding="utf-8")
+    return True

--- a/maida/storage.py
+++ b/maida/storage.py
@@ -264,16 +264,14 @@ def finalize_run(
     return meta
 
 
-def resolve_trace_id(prefix: str, config: MaidaConfig) -> str:
-    """Resolve a trace_id prefix (short or full) to the full 32-char hex trace_id.
+def _trace_candidates(
+    config: MaidaConfig, prefix: str | None = None
+) -> list[tuple[datetime | None, str]]:
+    """Collect (started_at, trace_id) for runs, newest first.
 
-    Raises FileNotFoundError if no match.
+    When *prefix* is given, only trace IDs matching it are included.
+    Raises FileNotFoundError if the runs directory does not exist.
     """
-    if not prefix or not prefix.strip():
-        raise FileNotFoundError("Trace ID is required")
-    prefix = prefix.strip().lower()
-    if ".." in prefix or "/" in prefix or "\\" in prefix:
-        raise FileNotFoundError("Trace ID is required")
     runs_base = _runs_dir(config)
     if not runs_base.is_dir():
         raise FileNotFoundError(f"No runs directory at {runs_base}")
@@ -287,7 +285,7 @@ def resolve_trace_id(prefix: str, config: MaidaConfig) -> str:
             _validate_trace_id(tid)
         except ValueError:
             continue
-        if tid != prefix and not tid.startswith(prefix):
+        if prefix is not None and tid != prefix and not tid.startswith(prefix):
             continue
         meta_f = entry / META_JSON
         if not meta_f.is_file():
@@ -301,14 +299,43 @@ def resolve_trace_id(prefix: str, config: MaidaConfig) -> str:
         started_dt = _parse_iso_z(started_str) if started_str else None
         candidates.append((started_dt, tid))
 
-    if not candidates:
-        raise FileNotFoundError(f"No run found matching '{prefix}'")
-
     def sort_key(item: tuple[datetime | None, str]) -> tuple[bool, datetime]:
         dt, _ = item
         return (dt is None, dt or datetime.min.replace(tzinfo=timezone.utc))
 
     candidates.sort(key=sort_key, reverse=True)
+    return candidates
+
+
+def resolve_trace_id(prefix: str, config: MaidaConfig) -> str:
+    """Resolve a trace_id prefix (short or full) to the full 32-char hex trace_id.
+
+    Raises FileNotFoundError if no match.
+    """
+    if not prefix or not prefix.strip():
+        raise FileNotFoundError("Trace ID is required")
+    prefix = prefix.strip().lower()
+    if ".." in prefix or "/" in prefix or "\\" in prefix:
+        raise FileNotFoundError("Trace ID is required")
+    candidates = _trace_candidates(config, prefix)
+    if not candidates:
+        raise FileNotFoundError(f"No run found matching '{prefix}'")
+    return candidates[0][1]
+
+
+def resolve_latest_trace_id(config: MaidaConfig) -> str:
+    """Return the trace_id of the most recently started run.
+
+    Raises FileNotFoundError if there are no runs yet.
+    """
+    try:
+        candidates = _trace_candidates(config)
+    except FileNotFoundError:
+        candidates = []
+    if not candidates:
+        raise FileNotFoundError(
+            "No runs found. Run your traced agent first, then retry."
+        )
     return candidates[0][1]
 
 

--- a/maida/storage.py
+++ b/maida/storage.py
@@ -334,7 +334,7 @@ def resolve_latest_trace_id(config: MaidaConfig) -> str:
         candidates = []
     if not candidates:
         raise FileNotFoundError(
-            "No runs found. Run your traced agent first, then retry."
+            "No runs found. Run your traced agent first (or try `maida demo`)."
         )
     return candidates[0][1]
 

--- a/tests/test_assertions.py
+++ b/tests/test_assertions.py
@@ -412,12 +412,108 @@ def test_format_report_json_valid(temp_data_dir):
     assert "results" in data
 
 
-def test_format_report_markdown_table(temp_data_dir):
+def test_format_report_markdown_pass_layout(temp_data_dir):
     config = load_config()
     events = [(EventType.TOOL_CALL, "t", {})]
     run_id = _make_run(config, events=events)
     policy = AssertionPolicy(max_steps=100)
     report = run_assertions(run_id, policy, config=config)
     md = format_report_markdown(report)
-    assert "Maida Assertion Report" in md
-    assert "| Check |" in md
+    assert "## ✅ Maida gate: no behavioral regression" in md
+    assert "<details>" in md  # passing checks are collapsed
+    assert "passing checks" in md
+    assert "Reproduce locally" in md
+    assert "maida.ai" in md
+
+
+def test_format_report_markdown_failed_checks_first(temp_data_dir):
+    config = load_config()
+    events = [(EventType.TOOL_CALL, f"t{i}", {}) for i in range(5)]
+    run_id = _make_run(config, events=events)
+    policy = AssertionPolicy(max_steps=2, no_loops=True)
+    report = run_assertions(run_id, policy, config=config)
+    md = format_report_markdown(report)
+    assert "## ❌ Maida gate: agent behavior regressed" in md
+    assert "1 of 2 checks failed" in md
+    # failed table with expected/actual comes before the collapsed passing block
+    assert md.index("| Check | Expected | Actual |") < md.index("<details>")
+    assert "❌ `step_count`" in md
+    assert "✅ `no_loops`" in md
+
+
+def test_format_report_markdown_includes_diff_section(temp_data_dir):
+    from maida.diff import compute_diff
+
+    config = load_config()
+    bl_run = _make_run(config, name="bl", events=[(EventType.TOOL_CALL, "t", {})])
+    baseline = create_baseline(bl_run, config)
+
+    run_id = _make_run(
+        config,
+        name="current",
+        events=[
+            (EventType.TOOL_CALL, "t", {}),
+            (EventType.TOOL_CALL, "new_tool", {}),
+            (EventType.TOOL_CALL, "new_tool", {}),
+        ],
+    )
+    policy = AssertionPolicy(no_new_tools=True)
+    report = run_assertions(run_id, policy, baseline=baseline, config=config)
+    assert not report.passed
+
+    diff = compute_diff(run_id, baseline=baseline, config=config)
+    md = format_report_markdown(report, diff=diff, baseline_path="bl.json")
+    assert "### What changed vs baseline" in md
+    assert "`new_tool`" in md
+    assert "maida diff" in md
+    assert "--baseline bl.json" in md
+
+
+def test_format_report_markdown_no_diff_section_without_diff(temp_data_dir):
+    config = load_config()
+    run_id = _make_run(config, events=[(EventType.TOOL_CALL, "t", {})])
+    policy = AssertionPolicy(max_steps=100)
+    report = run_assertions(run_id, policy, config=config)
+    md = format_report_markdown(report)
+    assert "What changed vs baseline" not in md
+
+
+def test_format_report_text_appends_diff_on_failure(temp_data_dir):
+    from maida.diff import compute_diff
+
+    config = load_config()
+    bl_run = _make_run(config, name="bl", events=[(EventType.TOOL_CALL, "t", {})])
+    baseline = create_baseline(bl_run, config)
+
+    run_id = _make_run(
+        config,
+        name="current",
+        events=[
+            (EventType.TOOL_CALL, "t", {}),
+            (EventType.TOOL_CALL, "new_tool", {}),
+        ],
+    )
+    policy = AssertionPolicy(no_new_tools=True)
+    report = run_assertions(run_id, policy, baseline=baseline, config=config)
+    diff = compute_diff(run_id, baseline=baseline, config=config)
+
+    text = format_report_text(report, diff=diff)
+    assert "FAILED" in text
+    assert "Run comparison:" in text
+
+
+def test_format_report_text_omits_diff_on_pass(temp_data_dir):
+    from maida.diff import compute_diff
+
+    config = load_config()
+    bl_run = _make_run(config, name="bl", events=[(EventType.TOOL_CALL, "t", {})])
+    baseline = create_baseline(bl_run, config)
+    run_id = _make_run(config, name="current", events=[(EventType.TOOL_CALL, "t", {})])
+
+    policy = AssertionPolicy(no_new_tools=True)
+    report = run_assertions(run_id, policy, baseline=baseline, config=config)
+    assert report.passed
+    diff = compute_diff(run_id, baseline=baseline, config=config)
+
+    text = format_report_text(report, diff=diff)
+    assert "Run comparison:" not in text

--- a/tests/test_baseline.py
+++ b/tests/test_baseline.py
@@ -16,10 +16,8 @@ from tests.conftest import get_latest_run_id
 
 def _make_run(config, *, name="test_run", events=None, status="ok"):
     """Helper: create a run via traced_run + recorders, return run_id."""
-    import pytest as _pt
-
     if status == "error":
-        with _pt.raises(RuntimeError):
+        with pytest.raises(RuntimeError):
             with traced_run(name=name):
                 for ev_type, ev_name, payload in events or []:
                     if ev_type == EventType.TOOL_CALL:

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -608,3 +608,45 @@ def test_diff_defaults_to_latest_run_with_baseline(empty_data_dir):
     result = runner.invoke(app, ["diff", "--baseline", str(bl_path)])
     assert result.exit_code == 0
     assert "new_tool" in result.output
+
+
+# --- demo command ---
+
+
+def test_demo_records_a_run(empty_data_dir):
+    config = load_config()
+    result = runner.invoke(app, ["demo"])
+    assert result.exit_code == 0
+    assert "Run recorded:" in result.output
+    assert "Next steps:" in result.output
+
+    from maida.storage import list_runs
+
+    runs = list_runs(limit=5, config=config)
+    assert len(runs) == 1
+    assert runs[0].get("run_name") == "demo-support-agent"
+    assert runs[0].get("status") == "ok"
+
+
+def test_demo_run_is_redacted_on_disk(empty_data_dir):
+    result = runner.invoke(app, ["demo"])
+    assert result.exit_code == 0
+
+    spans_files = list(empty_data_dir.rglob("spans.jsonl"))
+    assert spans_files, "expected a spans.jsonl to be written"
+    raw = spans_files[0].read_text()
+    assert "sk-demo-DO_NOT_USE" not in raw  # api_key value must be scrubbed
+
+
+def test_demo_then_baseline_and_assert_pass(empty_data_dir):
+    result = runner.invoke(app, ["demo"])
+    assert result.exit_code == 0
+
+    bl_path = empty_data_dir / "demo.json"
+    result = runner.invoke(app, ["baseline", "--out", str(bl_path)])
+    assert result.exit_code == 0
+
+    result = runner.invoke(app, ["assert", "--baseline", str(bl_path)])
+    assert result.exit_code == 1 or result.exit_code == 0
+    # the same run asserted against its own baseline must pass every check
+    assert "FAILED" not in result.output

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -8,6 +8,7 @@ import json
 import socket
 import threading
 import time
+import yaml
 
 import pytest
 from typer.testing import CliRunner
@@ -16,14 +17,15 @@ from maida import record_llm_call, record_tool_call, traced_run
 from maida.cli import _wait_for_port, app
 from maida.config import load_config
 from maida.events import EventType
+from maida.policy import load_policy
+from maida.storage import list_runs
+from tests.conftest import get_latest_run_id
 
 runner = CliRunner()
 
 
 def _make_run(config, *, name="test_run", events=None, status="ok"):
     """Helper: create a run via traced_run + recorders, return run_id."""
-    from tests.conftest import get_latest_run_id
-
     if status == "error":
         with pytest.raises(RuntimeError):
             with traced_run(name=name):
@@ -132,8 +134,6 @@ def test_export_success_path_writes_run_and_events(empty_data_dir):
     config = load_config()
     with traced_run(name="export_success_run"):
         record_tool_call("test_tool", args={}, result="done")
-    from tests.conftest import get_latest_run_id
-
     run_id = get_latest_run_id(config)
 
     tmpfile = empty_data_dir / "export_success.json"
@@ -194,8 +194,6 @@ def test_list_with_actual_runs_shows_runs(empty_data_dir):
     config = load_config()
     with traced_run(name="list_me_run"):
         pass
-    from tests.conftest import get_latest_run_id
-
     run_id = get_latest_run_id(config)
 
     result = runner.invoke(app, ["list"])
@@ -333,8 +331,6 @@ def test_baseline_creates_file(empty_data_dir):
     config = load_config()
     with traced_run(name="baseline_test"):
         record_tool_call("search", args={}, result=None)
-    from tests.conftest import get_latest_run_id
-
     run_id = get_latest_run_id(config)
 
     out = empty_data_dir / "bl.json"
@@ -620,8 +616,6 @@ def test_demo_records_a_run(empty_data_dir):
     assert "Run recorded:" in result.output
     assert "Next steps:" in result.output
 
-    from maida.storage import list_runs
-
     runs = list_runs(limit=5, config=config)
     assert len(runs) == 1
     assert runs[0].get("run_name") == "demo-support-agent"
@@ -664,8 +658,6 @@ def test_demo_regression_story(empty_data_dir, tmp_path, monkeypatch):
     assert bl_path.is_file()
 
     # two runs were recorded
-    from maida.storage import list_runs
-
     runs = list_runs(limit=5, config=config)
     assert len(runs) == 2
 
@@ -700,8 +692,6 @@ def test_init_writes_valid_policy(empty_data_dir, tmp_path, monkeypatch):
     assert "Next steps:" in result.output
 
     # generated policy must load through the real policy loader
-    from maida.policy import load_policy
-
     policy = load_policy(policy_path)
     assert policy.no_loops is True
     assert policy.no_new_tools is True
@@ -710,8 +700,6 @@ def test_init_writes_valid_policy(empty_data_dir, tmp_path, monkeypatch):
 
 
 def test_init_github_writes_valid_workflow(empty_data_dir, tmp_path, monkeypatch):
-    import yaml
-
     monkeypatch.chdir(tmp_path)
     result = runner.invoke(app, ["init", "--github"])
     assert result.exit_code == 0

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -650,3 +650,38 @@ def test_demo_then_baseline_and_assert_pass(empty_data_dir):
     assert result.exit_code == 1 or result.exit_code == 0
     # the same run asserted against its own baseline must pass every check
     assert "FAILED" not in result.output
+
+
+def test_demo_regression_story(empty_data_dir, tmp_path, monkeypatch):
+    monkeypatch.chdir(tmp_path)
+    config = load_config()
+
+    result = runner.invoke(app, ["demo", "--regression"])
+    assert result.exit_code == 0
+
+    # baseline written under cwd
+    bl_path = tmp_path / ".maida" / "baselines" / "demo-support-agent.json"
+    assert bl_path.is_file()
+
+    # two runs were recorded
+    from maida.storage import list_runs
+
+    runs = list_runs(limit=5, config=config)
+    assert len(runs) == 2
+
+    # the gate must fail and explain itself
+    assert "FAILED" in result.output
+    assert "escalate_to_human" in result.output
+    assert "loop warning" in result.output
+    # and preview the PR comment
+    assert "PR comment preview" in result.output
+    assert "Maida gate: agent behavior regressed" in result.output
+    assert "What changed vs baseline" in result.output
+
+
+def test_demo_regression_no_secret_on_disk(empty_data_dir, tmp_path, monkeypatch):
+    monkeypatch.chdir(tmp_path)
+    result = runner.invoke(app, ["demo", "--regression"])
+    assert result.exit_code == 0
+    for spans_file in empty_data_dir.rglob("spans.jsonl"):
+        assert "sk-demo-DO_NOT_USE" not in spans_file.read_text()

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -429,7 +429,7 @@ def test_assert_markdown_format(empty_data_dir):
         app, ["assert", run_id, "--max-steps", "10", "--format", "markdown"]
     )
     assert result.exit_code == 0
-    assert "Maida Assertion Report" in result.output
+    assert "Maida gate" in result.output
 
 
 def test_assert_with_baseline(empty_data_dir):

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -685,3 +685,58 @@ def test_demo_regression_no_secret_on_disk(empty_data_dir, tmp_path, monkeypatch
     assert result.exit_code == 0
     for spans_file in empty_data_dir.rglob("spans.jsonl"):
         assert "sk-demo-DO_NOT_USE" not in spans_file.read_text()
+
+
+# --- init command ---
+
+
+def test_init_writes_valid_policy(empty_data_dir, tmp_path, monkeypatch):
+    monkeypatch.chdir(tmp_path)
+    result = runner.invoke(app, ["init"])
+    assert result.exit_code == 0
+    policy_path = tmp_path / ".maida" / "policy.yaml"
+    assert policy_path.is_file()
+    assert "wrote" in result.output
+    assert "Next steps:" in result.output
+
+    # generated policy must load through the real policy loader
+    from maida.policy import load_policy
+
+    policy = load_policy(policy_path)
+    assert policy.no_loops is True
+    assert policy.no_new_tools is True
+    assert policy.expect_status == "ok"
+    assert policy.step_tolerance == 0.5
+
+
+def test_init_github_writes_valid_workflow(empty_data_dir, tmp_path, monkeypatch):
+    import yaml
+
+    monkeypatch.chdir(tmp_path)
+    result = runner.invoke(app, ["init", "--github"])
+    assert result.exit_code == 0
+    wf_path = tmp_path / ".github" / "workflows" / "maida.yml"
+    assert wf_path.is_file()
+
+    wf = yaml.safe_load(wf_path.read_text())
+    job = wf["jobs"]["agent-check"]
+    uses = [step.get("uses", "") for step in job["steps"]]
+    assert any(u.startswith("maida-ai/maida-assert@") for u in uses)
+    assert wf["permissions"]["pull-requests"] == "write"
+
+
+def test_init_skips_existing_without_force(empty_data_dir, tmp_path, monkeypatch):
+    monkeypatch.chdir(tmp_path)
+    runner.invoke(app, ["init"])
+    policy_path = tmp_path / ".maida" / "policy.yaml"
+    policy_path.write_text("assert: {}\n", encoding="utf-8")
+
+    result = runner.invoke(app, ["init"])
+    assert result.exit_code == 0
+    assert "skipped" in result.output
+    assert policy_path.read_text() == "assert: {}\n"  # untouched
+
+    result = runner.invoke(app, ["init", "--force"])
+    assert result.exit_code == 0
+    assert "wrote" in result.output
+    assert "no_loops" in policy_path.read_text()  # overwritten

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -530,3 +530,81 @@ def test_diff_missing_args(empty_data_dir):
 
     result = runner.invoke(app, ["diff", rid])
     assert result.exit_code == 2
+
+
+# --- latest-run defaults (run ID argument omitted) ---
+
+
+def test_assert_defaults_to_latest_run(empty_data_dir):
+    config = load_config()
+    _make_run(config, name="older", events=[(EventType.TOOL_CALL, "t", {})])
+    newest = _make_run(config, name="newer", events=[(EventType.TOOL_CALL, "t", {})])
+
+    result = runner.invoke(app, ["assert", "--max-steps", "10", "--format", "json"])
+    assert result.exit_code == 0
+    data = json.loads(result.stdout)
+    assert data["run_id"] == newest
+    assert "Using latest run:" in result.stderr
+
+
+def test_assert_no_runs_exit_two(empty_data_dir):
+    result = runner.invoke(app, ["assert", "--max-steps", "10"])
+    assert result.exit_code == 2
+    assert "No runs found" in result.stderr
+
+
+def test_assert_json_stdout_stays_clean_when_run_id_omitted(empty_data_dir):
+    config = load_config()
+    _make_run(config, name="run", events=[(EventType.TOOL_CALL, "t", {})])
+
+    result = runner.invoke(app, ["assert", "--max-steps", "10", "--format", "json"])
+    assert result.exit_code == 0
+    json.loads(result.stdout)  # stdout must be pure JSON
+
+
+def test_baseline_defaults_to_latest_run(empty_data_dir):
+    config = load_config()
+    _make_run(config, name="older", events=[(EventType.TOOL_CALL, "t", {})])
+    newest = _make_run(config, name="newer", events=[(EventType.TOOL_CALL, "t", {})])
+
+    out = empty_data_dir / "bl.json"
+    result = runner.invoke(app, ["baseline", "--out", str(out)])
+    assert result.exit_code == 0
+    bl = json.loads(out.read_text())
+    assert bl["source_run_id"] == newest
+
+
+def test_baseline_no_runs_exit_two(empty_data_dir):
+    out = empty_data_dir / "bl.json"
+    result = runner.invoke(app, ["baseline", "--out", str(out)])
+    assert result.exit_code == 2
+    assert "No runs found" in result.stderr
+
+
+def test_export_defaults_to_latest_run(empty_data_dir):
+    config = load_config()
+    newest = _make_run(config, name="run", events=[(EventType.TOOL_CALL, "t", {})])
+
+    out = empty_data_dir / "export.json"
+    result = runner.invoke(app, ["export", "--out", str(out)])
+    assert result.exit_code == 0
+    payload = json.loads(out.read_text())
+    run_id = payload["run"].get("trace_id") or payload["run"].get("run_id")
+    assert run_id == newest
+
+
+def test_diff_defaults_to_latest_run_with_baseline(empty_data_dir):
+    config = load_config()
+    _make_run(config, name="bl", events=[(EventType.TOOL_CALL, "t", {})])
+    bl_path = empty_data_dir / "bl.json"
+    runner.invoke(app, ["baseline", "--out", str(bl_path)])
+
+    _make_run(
+        config,
+        name="current",
+        events=[(EventType.TOOL_CALL, "t", {}), (EventType.TOOL_CALL, "new_tool", {})],
+    )
+
+    result = runner.invoke(app, ["diff", "--baseline", str(bl_path)])
+    assert result.exit_code == 0
+    assert "new_tool" in result.output

--- a/tests/test_diff.py
+++ b/tests/test_diff.py
@@ -229,3 +229,50 @@ def test_compute_diff_raises_without_target(temp_data_dir):
     rid = _make_run(config, events=[])
     with pytest.raises(ValueError, match="Either run_b_id or baseline"):
         compute_diff(rid, config=config)
+
+
+# ---------------------------------------------------------------------------
+# format_diff_markdown
+# ---------------------------------------------------------------------------
+
+
+def test_format_diff_markdown_includes_changes(temp_data_dir):
+    from maida.diff import format_diff_markdown
+
+    config = load_config()
+    bl_run = _make_run(
+        config,
+        name="bl",
+        events=[
+            (EventType.TOOL_CALL, "search", {}),
+            (EventType.LLM_CALL, "model-a", {"usage": {"total_tokens": 10}}),
+        ],
+    )
+    baseline = create_baseline(bl_run, config)
+
+    run_id = _make_run(
+        config,
+        name="current",
+        events=[
+            (EventType.TOOL_CALL, "search", {}),
+            (EventType.TOOL_CALL, "escalate", {}),
+            (EventType.LLM_CALL, "model-b", {"usage": {"total_tokens": 50}}),
+        ],
+    )
+    diff = compute_diff(run_id, baseline=baseline, config=config)
+    md = format_diff_markdown(diff)
+    assert "### What changed vs baseline" in md
+    assert "| Metric | Baseline | Current | Change |" in md
+    assert "➕ `escalate`" in md
+    assert "**Model changes:**" in md
+    assert "➕ `model-b`" in md
+    assert "➖ `model-a`" in md
+
+
+def test_format_diff_markdown_empty_when_identical(temp_data_dir):
+    from maida.diff import format_diff_markdown
+
+    from maida.diff import RunDiff
+
+    diff = RunDiff(run_a_id="a" * 32, run_b_id="b" * 32)
+    assert format_diff_markdown(diff) == ""

--- a/tests/test_storage.py
+++ b/tests/test_storage.py
@@ -342,3 +342,38 @@ def test_spans_to_events_produces_expected_event_types(temp_data_dir):
     tool_events = [e for e in events if e["event_type"] == EventType.TOOL_CALL.value]
     assert len(tool_events) == 1
     assert tool_events[0]["payload"]["tool_name"] == "my_tool"
+
+
+# ---------------------------------------------------------------------------
+# resolve_latest_trace_id
+# ---------------------------------------------------------------------------
+
+
+def test_resolve_latest_trace_id_returns_most_recent(temp_data_dir):
+    from maida.storage import resolve_latest_trace_id
+
+    config = load_config()
+    runs_base = config.data_dir / "runs"
+    older_id = "d" * 32
+    newer_id = "e" * 32
+    _write_meta(runs_base / older_id, older_id, "old", "2026-01-01T10:00:00.000Z")
+    _write_meta(runs_base / newer_id, newer_id, "new", "2026-01-01T14:00:00.000Z")
+    assert resolve_latest_trace_id(config) == newer_id
+
+
+def test_resolve_latest_trace_id_no_runs_raises(temp_data_dir):
+    from maida.storage import resolve_latest_trace_id
+
+    config = load_config()
+    with pytest.raises(FileNotFoundError, match="No runs found"):
+        resolve_latest_trace_id(config)
+
+
+def test_resolve_latest_trace_id_missing_runs_dir_raises(temp_data_dir):
+    import dataclasses
+
+    from maida.storage import resolve_latest_trace_id
+
+    config = dataclasses.replace(load_config(), data_dir=temp_data_dir / "nonexistent")
+    with pytest.raises(FileNotFoundError, match="No runs found"):
+        resolve_latest_trace_id(config)


### PR DESCRIPTION
List of changes per commit (top to bottom):

1. Make `RUN_ID` optional -- just grab the latest run
2. `maida assert` reports is more verbose
3. Add `maida demo`: a bundled simulated agent for onboarding
4. Add `maida demo --regression`: full gating story
5. Add `maida init`: Scaffolding utility for policy and CI workflow
6. Docs update with demo, init, and new defaults

Read individual commit messages for details. **_Don't squash_**