### PR TITLE
Fix import placement

### DIFF
--- a/maida/_tracing/_context.py
+++ b/maida/_tracing/_context.py
@@ -16,11 +16,13 @@ from datetime import datetime, timezone
 from typing import Any
 
 from opentelemetry import trace
+from opentelemetry.trace import Status, StatusCode
 
 from maida.config import MaidaConfig, load_config
-from maida.events import utc_now_iso_ms_z
 from maida.constants import default_counts
-from maida.guardrails import GuardrailParams
+from maida.events import utc_now_iso_ms_z
+from maida.guardrails import GuardrailParams, check_after_event
+from maida._tracing._redact import _redact_and_truncate, _redact_argv
 
 _run_id_var: ContextVar[str | None] = ContextVar("maida_run_id", default=None)
 _counts_var: ContextVar[dict | None] = ContextVar("maida_counts", default=None)
@@ -112,8 +114,6 @@ def _finalize_implicit_run() -> None:
     _implicit_event_window = []
     _implicit_loop_emitted = set()
     try:
-        from opentelemetry.trace import Status, StatusCode
-
         if _implicit_root_span is not None:
             _implicit_root_span.set_attribute(
                 "maida.llm_calls", counts.get("llm_calls", 0)
@@ -150,8 +150,6 @@ def _append_event_and_check_guardrails(
     In the OTel-based system, spans are the primary storage unit. This function
     maintains backward compat by tracking the event count for guardrail checks.
     """
-    from maida.guardrails import check_after_event
-
     params = _guardrail_params_var.get()
     if params is None:
         return
@@ -186,8 +184,6 @@ def _run_end_payload(status: str, counts: dict, started_at: str) -> dict[str, di
 
 def _run_start_payload_for_event(run_name: str | None, config: MaidaConfig) -> dict:
     """Build a backward-compatible event-like payload for RUN_START. Used by lifecycle."""
-    from maida._tracing._redact import _redact_argv, _redact_and_truncate
-
     payload = {
         "run_name": run_name,
         "python_version": f"{sys.version_info.major}.{sys.version_info.minor}.{sys.version_info.micro}",

--- a/maida/_tracing/_recorders.py
+++ b/maida/_tracing/_recorders.py
@@ -42,6 +42,7 @@ from maida._tracing._otel import (
 )
 from maida._tracing._redact import (
     _apply_redaction_truncation,
+    _build_error_payload,
     _normalize_usage,
     _redact_and_truncate,
 )
@@ -65,8 +66,6 @@ def _record_llm_call_otel(
     status_val = "ok" if status not in ("ok", "error") else status
     error_obj: dict[str, Any] | None = None
     if status_val == "error" and error is not None:
-        from maida._tracing._redact import _build_error_payload
-
         error_obj = _build_error_payload(error, config, include_stack=True)
 
     attrs = {
@@ -136,8 +135,6 @@ def _record_tool_call_otel(
     status_val = "ok" if status not in ("ok", "error") else status
     error_obj: dict[str, Any] | None = None
     if status_val == "error" and error is not None:
-        from maida._tracing._redact import _build_error_payload
-
         error_obj = _build_error_payload(error, config, include_stack=True)
 
     attrs = {

--- a/maida/assertions.py
+++ b/maida/assertions.py
@@ -13,7 +13,8 @@ if TYPE_CHECKING:
     from maida.diff import RunDiff
 
 from maida.baseline import extract_run_metrics
-from maida.config import MaidaConfig
+from maida.config import MaidaConfig, load_config
+from maida.diff import format_diff_markdown, format_diff_text
 from maida.events import spans_to_events
 from maida.storage import load_run_meta, load_spans, resolve_trace_id
 
@@ -156,8 +157,6 @@ def run_assertions(
         ``AssertionReport`` with all check results.
     """
     if config is None:
-        from maida.config import load_config
-
         config = load_config()
 
     full_id = resolve_trace_id(trace_id, config)
@@ -324,8 +323,6 @@ def format_report_text(report: AssertionReport, diff: "RunDiff | None" = None) -
     else:
         lines.append(f"RESULT: {verdict} ({total} checks passed)")
     if diff is not None and not report.passed:
-        from maida.diff import format_diff_text
-
         lines.append("")
         lines.append(format_diff_text(diff))
     return "\n".join(lines)
@@ -407,8 +404,6 @@ def format_report_markdown(
         lines += ["", "</details>"]
 
     if diff is not None:
-        from maida.diff import format_diff_markdown
-
         diff_md = format_diff_markdown(diff)
         if diff_md:
             if report.passed:

--- a/maida/cli.py
+++ b/maida/cli.py
@@ -17,13 +17,29 @@ import typer
 from typer import Exit
 
 import maida.storage as storage
-from maida.config import load_config
-from maida.constants import SPEC_VERSION
-from maida.server import create_app
-from maida.events import spans_to_events
 from maida import __version__
-
-from maida.constants import LOCAL_DIR_NAME
+from maida.assertions import (
+    AssertionPolicy,
+    format_report_json,
+    format_report_markdown,
+    format_report_text,
+    run_assertions,
+)
+from maida.baseline import create_baseline, load_baseline, save_baseline
+from maida.config import load_config
+from maida.constants import LOCAL_DIR_NAME, SPEC_VERSION
+from maida.demo import ensure_demo_env, run_good_agent, run_refactored_agent
+from maida.diff import compute_diff, format_diff_text
+from maida.events import spans_to_events
+from maida.policy import load_policy, merge_policy
+from maida.scaffold import (
+    POLICY_RELPATH,
+    POLICY_TEMPLATE,
+    WORKFLOW_RELPATH,
+    WORKFLOW_TEMPLATE,
+    write_scaffold,
+)
+from maida.server import create_app
 
 EXIT_NOT_FOUND = 2
 EXIT_INTERNAL = 10
@@ -281,8 +297,6 @@ def baseline_cmd(
     ),
 ) -> None:
     """Capture a baseline snapshot from a completed run."""
-    from maida.baseline import create_baseline, save_baseline
-
     try:
         config = load_config()
         try:
@@ -356,15 +370,6 @@ def assert_cmd(
     ),
 ) -> None:
     """Assert that a run meets behavioral policy checks. Exit 0 = pass, 1 = fail."""
-    from maida.assertions import (
-        AssertionPolicy,
-        format_report_json,
-        format_report_markdown,
-        format_report_text,
-        run_assertions,
-    )
-    from maida.baseline import load_baseline
-
     try:
         config = load_config()
         try:
@@ -374,8 +379,6 @@ def assert_cmd(
             raise Exit(EXIT_NOT_FOUND)
 
         # Build policy: start from file, then overlay CLI flags
-        from maida.policy import load_policy, merge_policy
-
         policy = AssertionPolicy()
         if policy_path is not None:
             policy = load_policy(policy_path)
@@ -416,8 +419,6 @@ def assert_cmd(
 
         run_diff = None
         if bl is not None:
-            from maida.diff import compute_diff
-
             run_diff = compute_diff(run_id, baseline=bl, config=config)
 
         if output_format == "json":
@@ -444,8 +445,6 @@ def assert_cmd(
 
 def _demo_single_run(config) -> None:
     """Run the good demo agent once and print summary + next steps."""
-    from maida.demo import run_good_agent
-
     typer.echo("Running the bundled demo agent (simulated; nothing leaves")
     typer.echo("your machine, no API keys needed)...")
     run_good_agent()
@@ -469,16 +468,6 @@ def _demo_single_run(config) -> None:
 
 def _demo_regression(config) -> None:
     """Baseline a good run, run a regressed one, and show the failing gate."""
-    from maida.assertions import (
-        AssertionPolicy,
-        format_report_markdown,
-        format_report_text,
-        run_assertions,
-    )
-    from maida.baseline import create_baseline, save_baseline
-    from maida.demo import run_good_agent, run_refactored_agent
-    from maida.diff import compute_diff
-
     typer.echo("Maida regression demo: everything below is simulated and local.")
     typer.echo("")
 
@@ -534,14 +523,6 @@ def init_cmd(
     force: bool = typer.Option(False, "--force", help="Overwrite existing files"),
 ) -> None:
     """Scaffold .maida/policy.yaml (and optionally a CI workflow)."""
-    from maida.scaffold import (
-        POLICY_RELPATH,
-        POLICY_TEMPLATE,
-        WORKFLOW_RELPATH,
-        WORKFLOW_TEMPLATE,
-        write_scaffold,
-    )
-
     try:
         targets = [(POLICY_RELPATH, POLICY_TEMPLATE)]
         if github:
@@ -580,8 +561,6 @@ def demo_cmd(
     ),
 ) -> None:
     """Run a bundled simulated agent and trace it. No network, no API keys."""
-    from maida.demo import ensure_demo_env
-
     try:
         ensure_demo_env()
         config = load_config()
@@ -610,9 +589,6 @@ def diff_cmd(
     ),
 ) -> None:
     """Compare two runs or a run against a baseline."""
-    from maida.baseline import load_baseline
-    from maida.diff import compute_diff, format_diff_text
-
     try:
         config = load_config()
         try:

--- a/maida/diff.py
+++ b/maida/diff.py
@@ -7,7 +7,7 @@ from collections import Counter
 from dataclasses import dataclass, field
 
 from maida.baseline import extract_run_metrics
-from maida.config import MaidaConfig
+from maida.config import MaidaConfig, load_config
 from maida.events import spans_to_events
 from maida.storage import load_run_meta, load_spans, resolve_trace_id
 
@@ -50,8 +50,6 @@ def compute_diff(
     Exactly one of *run_b_id* or *baseline* must be provided.
     """
     if config is None:
-        from maida.config import load_config
-
         config = load_config()
 
     full_a = resolve_trace_id(run_a_id, config)

--- a/maida/integrations/langchain.py
+++ b/maida/integrations/langchain.py
@@ -4,6 +4,7 @@ LangChain/LangGraph callback handler that forwards LLM and tool events to Maida.
 Uses only Maida SDK: record_llm_call, record_tool_call. No CLI or server imports.
 """
 
+import json
 from typing import Any
 
 from maida.exceptions import GuardrailExceeded, _MaidaAbortSignal
@@ -252,8 +253,6 @@ class LangChainCallbackHandler(BaseCallbackHandler):
         key = self._key(run_id=run_id, parent_run_id=parent_run_id, **kwargs)
         name = _tool_name_from_serialized(serialized)
         try:
-            import json
-
             args = json.loads(input_str) if input_str.strip() else {}
         except Exception:
             args = input_str if input_str else None

--- a/maida/storage.py
+++ b/maida/storage.py
@@ -11,11 +11,14 @@ Note: trace_id_hex is 32 hex characters (128-bit trace ID).
 import json
 import logging
 import os
+import shutil
 import uuid
 from datetime import datetime, timezone
 from pathlib import Path
 
 from maida.config import MaidaConfig
+from maida.constants import SPEC_VERSION, default_counts
+from maida.events import spans_to_events, utc_now_iso_ms_z
 
 META_JSON = "meta.json"
 SPANS_JSONL = "spans.jsonl"
@@ -173,8 +176,6 @@ def load_events(run_id: str, config: MaidaConfig) -> list[dict]:
     except ValueError:
         spans = []
     if spans:
-        from maida.events import spans_to_events
-
         return spans_to_events(spans)
 
     path = _legacy_run_dir(run_id, config) / EVENTS_JSONL
@@ -210,9 +211,6 @@ def append_event(run_id: str, event: dict, config: MaidaConfig) -> None:
 
 def create_run(run_name: str, config: MaidaConfig) -> dict:
     """Compatibility wrapper for legacy run.json callers."""
-    from maida.constants import SPEC_VERSION, default_counts
-    from maida.events import utc_now_iso_ms_z
-
     run_id = str(uuid.uuid4())
     run_dir = _legacy_run_dir(run_id, config)
     meta = {
@@ -239,8 +237,6 @@ def finalize_run(
     run_id: str, status: str, counts: dict[str, int], config: MaidaConfig
 ) -> dict:
     """Compatibility wrapper for legacy run finalization callers."""
-    from maida.events import utc_now_iso_ms_z
-
     path = _legacy_run_dir(run_id, config) / RUN_JSON
     if not path.is_file():
         raise FileNotFoundError(f"No run found for run_id '{run_id}'")
@@ -430,8 +426,6 @@ def rename_run(trace_id: str, run_name: str, config: MaidaConfig) -> dict:
 
 def delete_run(trace_id: str, config: MaidaConfig) -> None:
     """Delete a run directory and all its contents."""
-    import shutil
-
     run_dir = _trace_dir(trace_id, config)
     if not run_dir.is_dir():
         raise FileNotFoundError(f"No run found for trace_id '{trace_id}'")

--- a/tests/test_import_placement.py
+++ b/tests/test_import_placement.py
@@ -1,0 +1,109 @@
+"""Regression tests for import placement in production code."""
+
+from __future__ import annotations
+
+import ast
+from pathlib import Path
+
+
+_ALLOWED_FUNCTION_IMPORTS = {
+    (
+        "maida/_tracing/_context.py",
+        "_finalize_implicit_run",
+        "from",
+        "opentelemetry",
+        ("context",),
+    ),  # Detach only if an implicit run was activated.
+    (
+        "maida/_tracing/_context.py",
+        "_ensure_run",
+        "from",
+        "maida._tracing._otel",
+        ("_setup_otel", "_get_tracer"),
+    ),  # Avoid import cycle during normal tracing module import.
+    (
+        "maida/_tracing/_context.py",
+        "_ensure_run",
+        "from",
+        "opentelemetry",
+        ("context",),
+    ),  # Only needed when MAIDA_IMPLICIT_RUN creates an OTel context.
+    (
+        "maida/_tracing/_context.py",
+        "_ensure_run",
+        "from",
+        "opentelemetry.trace.propagation",
+        ("set_span_in_context",),
+    ),  # Only needed when MAIDA_IMPLICIT_RUN creates an OTel context.
+    (
+        "maida/_tracing/_otel.py",
+        "_setup_otel",
+        "from",
+        "opentelemetry.exporter.otlp.proto.http.trace_exporter",
+        ("OTLPSpanExporter",),
+    ),  # Optional exporter dependency path, loaded only when configured.
+    (
+        "maida/_tracing/_otel.py",
+        "_shutdown_otel",
+        "import",
+        "opentelemetry.trace",
+        ("opentelemetry.trace",),
+    ),  # Reset OTel module internals for test isolation.
+    (
+        "maida/cli.py",
+        "view_cmd",
+        "import",
+        "uvicorn",
+        ("uvicorn",),
+    ),  # Viewer server dependency is only needed for `maida view`.
+}
+
+
+def _scope_for(node: ast.AST, parents: dict[ast.AST, ast.AST]) -> str | None:
+    scopes: list[str] = []
+    parent = parents.get(node)
+    while parent is not None:
+        if isinstance(parent, (ast.FunctionDef, ast.AsyncFunctionDef)):
+            scopes.append(parent.name)
+        parent = parents.get(parent)
+    return "/".join(reversed(scopes)) if scopes else None
+
+
+def _import_key(
+    path: Path,
+    node: ast.Import | ast.ImportFrom,
+    scope: str,
+) -> tuple[str, str, str, str, tuple[str, ...]]:
+    relpath = path.as_posix()
+    if isinstance(node, ast.Import):
+        modules = tuple(alias.name for alias in node.names)
+        module = modules[0] if len(modules) == 1 else ",".join(modules)
+        return (relpath, scope, "import", module, modules)
+
+    module = "." * node.level + (node.module or "")
+    names = tuple(alias.name for alias in node.names)
+    return (relpath, scope, "from", module, names)
+
+
+def test_function_scoped_imports_are_explicitly_justified() -> None:
+    """Keep imports at module top unless a local import is intentional."""
+    unexpected: list[tuple[str, str, str, str, tuple[str, ...]]] = []
+
+    for path in sorted(Path("maida").rglob("*.py")):
+        tree = ast.parse(path.read_text(encoding="utf-8"), filename=str(path))
+        parents: dict[ast.AST, ast.AST] = {}
+        for parent in ast.walk(tree):
+            for child in ast.iter_child_nodes(parent):
+                parents[child] = parent
+
+        for node in ast.walk(tree):
+            if not isinstance(node, (ast.Import, ast.ImportFrom)):
+                continue
+            scope = _scope_for(node, parents)
+            if scope is None:
+                continue
+            key = _import_key(path, node, scope)
+            if key not in _ALLOWED_FUNCTION_IMPORTS:
+                unexpected.append(key)
+
+    assert unexpected == []


### PR DESCRIPTION
- Hoisted safe imports in `maida/diff.py`, `maida/storage.py`, `maida/assertions.py`, `maida/_tracing/_context.py`, `maida/_tracing/_recorders.py`, `maida/cli.py`, and `maida/integrations/langchain.py`.
- Preserved intentionally local imports for the `maida view` `uvicorn` dependency, optional OTLP exporter setup, OTel shutdown/test-reset internals, and implicit-run OTel context setup.
- Added `tests/test_import_placement.py`, an AST regression test that fails on new function-scoped production imports unless they are explicitly allowlisted with a reason.

Fixes #48 