### PR TITLE
Randomize test

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -43,8 +43,9 @@ dev = [
     "httpx>=0.28.1",
     "pre-commit>=4.5.1",
     "pytest>=9.0.2",
-    "pytest-cov>=7.0.0",
-    "pytest-xdist>=3.8.0",
+    "pytest-cov>=7.0.0",       # Coverage
+    "pytest-randomly>=4.1.0",  # Random test order
+    "pytest-xdist>=3.8.0",     # Parallel tests
     "ruff>=0.15.1",
 ]
 

--- a/tests/integrations/test_imports.py
+++ b/tests/integrations/test_imports.py
@@ -21,14 +21,19 @@ INTEGRATIONS = [  # name, dependency
 
 @pytest.fixture
 def reload_integrations():
+    global integrations
+
+    integrations = importlib.import_module("maida.integrations")
     sys.modules.pop("maida.integrations.crewai", None)
     sys.modules.pop("maida.integrations.langchain", None)
+    sys.modules.pop("maida.integrations.openai_agents", None)
 
     integrations.__dict__.pop("crewai", None)
     integrations.__dict__.pop("langchain", None)
+    integrations.__dict__.pop("openai_agents", None)
     integrations.__dict__.pop("LangChainCallbackHandler", None)
 
-    importlib.reload(integrations)
+    integrations = importlib.reload(integrations)
 
 
 def test_no_eager_imports(reload_integrations):

--- a/uv.lock
+++ b/uv.lock
@@ -1670,6 +1670,7 @@ dev = [
     { name = "pre-commit" },
     { name = "pytest" },
     { name = "pytest-cov" },
+    { name = "pytest-randomly" },
     { name = "pytest-xdist" },
     { name = "ruff" },
 ]
@@ -1697,6 +1698,7 @@ dev = [
     { name = "pre-commit", specifier = ">=4.5.1" },
     { name = "pytest", specifier = ">=9.0.2" },
     { name = "pytest-cov", specifier = ">=7.0.0" },
+    { name = "pytest-randomly", specifier = ">=4.1.0" },
     { name = "pytest-xdist", specifier = ">=3.8.0" },
     { name = "ruff", specifier = ">=0.15.1" },
 ]
@@ -3188,6 +3190,18 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/b1/51/a849f96e117386044471c8ec2bd6cfebacda285da9525c9106aeb28da671/pytest_cov-7.1.0.tar.gz", hash = "sha256:30674f2b5f6351aa09702a9c8c364f6a01c27aae0c1366ae8016160d1efc56b2", size = 55592, upload-time = "2026-03-21T20:11:16.284Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/9d/7a/d968e294073affff457b041c2be9868a40c1c71f4a35fcc1e45e5493067b/pytest_cov-7.1.0-py3-none-any.whl", hash = "sha256:a0461110b7865f9a271aa1b51e516c9a95de9d696734a2f71e3e78f46e1d4678", size = 22876, upload-time = "2026-03-21T20:11:14.438Z" },
+]
+
+[[package]]
+name = "pytest-randomly"
+version = "4.1.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pytest" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/27/b3/36192dacc0f470ac2cc516f73e01739c9a48a8224f76beada4f85e1c8a89/pytest_randomly-4.1.0.tar.gz", hash = "sha256:47f1d9746c3bc3efabd53ae1ebfb8bb385cf3d4df4b505b6d58d9c97a3dfe70f", size = 14302, upload-time = "2026-04-20T13:01:51.831Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/9a/db/2df9a1fca597a273f957a559c20c2d95d629928384507b2afa43ba6909d1/pytest_randomly-4.1.0-py3-none-any.whl", hash = "sha256:f55e89e53367b090c0c053697d7f9d77595543d0e0516c93978b50c0f6b252f9", size = 8353, upload-time = "2026-04-20T13:01:50.382Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
Unittests might be state-dependent. This randomizes the order to make sure we catch regressions