### PR TITLE
Validate trace runs before read operations

### DIFF
--- a/maida/baseline.py
+++ b/maida/baseline.py
@@ -3,8 +3,8 @@
 A baseline captures the structural behavior of a completed run (tool path,
 event sequence, token usage, etc.) for later comparison by ``assertions.py``.
 
-Updated for OTel-based storage: reads span dicts and converts to event-like
-dicts using events.spans_to_events().
+Updated for OTel-based storage: reads event-like records through the shared
+run analysis loader.
 """
 
 import json

--- a/maida/cli.py
+++ b/maida/cli.py
@@ -87,6 +87,11 @@ def _exit_unsupported_trace_format(error: storage.UnsupportedTraceFormatError) -
     raise Exit(EXIT_NOT_FOUND)
 
 
+def _exit_run_validation_error(error: storage.RunValidationError) -> None:
+    typer.echo(str(error), err=True)
+    raise Exit(EXIT_NOT_FOUND)
+
+
 def _wait_for_port(host: str, port: int, timeout_s: float = 5.0) -> bool:
     """Block until *host*:*port* accepts a TCP connection, or *timeout_s* elapses.
 
@@ -197,6 +202,8 @@ def export_cmd(
             _, run_meta, events = storage.load_run_for_analysis(trace_id, config)
         except storage.UnsupportedTraceFormatError as e:
             _exit_unsupported_trace_format(e)
+        except storage.RunValidationError as e:
+            _exit_run_validation_error(e)
         except (ValueError, FileNotFoundError):
             raise Exit(EXIT_NOT_FOUND)
         payload = {"spec_version": SPEC_VERSION, "run": run_meta, "events": events}
@@ -233,13 +240,15 @@ def view_cmd(
                 run_id = runs[0].get("trace_id") or runs[0].get("run_id") or ""
         if run_id:
             try:
-                run_id = storage.resolve_trace_id(run_id, config)
+                run_id = storage.resolve_trace_id_for_read(run_id, config)
             except FileNotFoundError as e:
                 if not json_out:
                     typer.echo(f"Run not found: {e}", err=True)
                 raise Exit(EXIT_NOT_FOUND)
             try:
-                storage.load_run_meta(run_id, config)
+                storage.load_validated_run(run_id, config)
+            except storage.RunValidationError as e:
+                _exit_run_validation_error(e)
             except (ValueError, FileNotFoundError) as e:
                 if not json_out:
                     typer.echo(f"Run not found: {e}", err=True)
@@ -323,6 +332,8 @@ def baseline_cmd(
         raise
     except storage.UnsupportedTraceFormatError as e:
         _exit_unsupported_trace_format(e)
+    except storage.RunValidationError as e:
+        _exit_run_validation_error(e)
     except Exception as e:
         typer.echo(f"error: {e}", err=True)
         raise Exit(EXIT_INTERNAL)
@@ -448,6 +459,8 @@ def assert_cmd(
         raise
     except storage.UnsupportedTraceFormatError as e:
         _exit_unsupported_trace_format(e)
+    except storage.RunValidationError as e:
+        _exit_run_validation_error(e)
     except Exception as e:
         typer.echo(f"error: {e}", err=True)
         raise Exit(EXIT_INTERNAL)
@@ -580,6 +593,8 @@ def demo_cmd(
             _demo_single_run(config)
     except Exit:
         raise
+    except storage.RunValidationError as e:
+        _exit_run_validation_error(e)
     except Exception as e:
         typer.echo(f"error: {e}", err=True)
         raise Exit(EXIT_INTERNAL)
@@ -631,6 +646,8 @@ def diff_cmd(
         raise
     except storage.UnsupportedTraceFormatError as e:
         _exit_unsupported_trace_format(e)
+    except storage.RunValidationError as e:
+        _exit_run_validation_error(e)
     except Exception as e:
         typer.echo(f"error: {e}", err=True)
         raise Exit(EXIT_INTERNAL)

--- a/maida/server.py
+++ b/maida/server.py
@@ -61,14 +61,14 @@ def create_app() -> FastAPI:
     ) -> dict:
         trace_id = _validated_trace_id(trace_id)
         try:
-            storage.load_run_meta(trace_id, config)
+            # TODO: cache or incrementally project events for large live traces.
+            _, spans = storage.load_validated_run(trace_id, config)
         except FileNotFoundError:
             raise HTTPException(status_code=404, detail="run not found")
-        try:
-            # TODO: cache or incrementally project events for large live traces.
-            spans = storage.load_spans(trace_id, config)
         except ValueError:
             raise HTTPException(status_code=400, detail="invalid trace_id")
+        except storage.RunValidationError as e:
+            raise HTTPException(status_code=422, detail=str(e))
         events = spans_to_events(spans)
         return {
             "spec_version": SPEC_VERSION,

--- a/maida/storage.py
+++ b/maida/storage.py
@@ -63,25 +63,27 @@ class UnsupportedTraceFormatError(RuntimeError):
         )
 
 
+def _validate_hex_id(value: object, length: int, field_name: str) -> str:
+    """Validate that *value* is a fixed-length lowercase hex string.
+
+    The hex charset + length check also rejects every path-traversal character
+    (``.``, ``/``, ``\\`` are not hex digits), so callers need no separate guard.
+    """
+    if not value or not isinstance(value, str):
+        raise ValueError(f"invalid {field_name}")
+    v = value.strip().lower()
+    if len(v) != length or not _HEX_CHARS.issuperset(v):
+        raise ValueError(f"invalid {field_name}")
+    return v
+
+
 def _validate_trace_id(trace_id: str) -> str:
     """Validate that trace_id is a 32-char hex string (no path traversal)."""
-    if not trace_id or not isinstance(trace_id, str):
-        raise ValueError("invalid trace_id")
-    t = trace_id.strip().lower()
-    if len(t) != _TRACE_ID_LEN or not all(c in "0123456789abcdef" for c in t.lower()):
-        raise ValueError("invalid trace_id")
-    if ".." in t or "/" in t or "\\" in t:
-        raise ValueError("invalid trace_id")
-    return t
+    return _validate_hex_id(trace_id, _TRACE_ID_LEN, "trace_id")
 
 
 def _validate_span_id(span_id: str, *, field_name: str) -> str:
-    if not span_id or not isinstance(span_id, str):
-        raise ValueError(f"invalid {field_name}")
-    sid = span_id.strip().lower()
-    if len(sid) != _SPAN_ID_LEN or not all(c in "0123456789abcdef" for c in sid):
-        raise ValueError(f"invalid {field_name}")
-    return sid
+    return _validate_hex_id(span_id, _SPAN_ID_LEN, field_name)
 
 
 def _atomic_write_json(path: Path, payload: dict) -> None:
@@ -523,32 +525,26 @@ def _safe_version_display(value: object) -> str:
     return text if _SAFE_VERSION_RE.fullmatch(text) else "<redacted>"
 
 
-def _run_validation_error(trace_id: str, problem: str) -> RunValidationError:
-    return RunValidationError(trace_id, problem)
-
-
 def _read_json_file_for_validation(path: Path, trace_id: str, display: str) -> dict:
     try:
         with open(path, "r", encoding="utf-8") as f:
             payload = json.load(f)
     except json.JSONDecodeError:
-        raise _run_validation_error(trace_id, f"{display} is malformed JSON")
+        raise RunValidationError(trace_id, f"{display} is malformed JSON")
     except OSError:
-        raise _run_validation_error(trace_id, f"{display} could not be read")
+        raise RunValidationError(trace_id, f"{display} could not be read")
     if not isinstance(payload, dict):
-        raise _run_validation_error(trace_id, f"{display} must contain a JSON object")
+        raise RunValidationError(trace_id, f"{display} must contain a JSON object")
     return payload
 
 
 def _validate_counts(trace_id: str, counts: object) -> None:
     if not isinstance(counts, dict):
-        raise _run_validation_error(
-            trace_id, "meta.json field 'counts' must be an object"
-        )
+        raise RunValidationError(trace_id, "meta.json field 'counts' must be an object")
     for key in ("llm_calls", "tool_calls", "errors", "loop_warnings"):
         value = counts.get(key)
         if not isinstance(value, int) or value < 0:
-            raise _run_validation_error(
+            raise RunValidationError(
                 trace_id,
                 f"meta.json counts.{key} must be a non-negative integer",
             )
@@ -557,7 +553,7 @@ def _validate_counts(trace_id: str, counts: object) -> None:
 def _validate_meta(trace_id: str, meta: dict) -> None:
     declared_spec = meta.get("spec_version")
     if declared_spec is not None and declared_spec != SPEC_VERSION:
-        raise _run_validation_error(
+        raise RunValidationError(
             trace_id,
             "meta.json declares unsupported spec_version "
             f"{_safe_version_display(declared_spec)!r}; expected {SPEC_VERSION!r}",
@@ -574,34 +570,32 @@ def _validate_meta(trace_id: str, meta: dict) -> None:
     )
     for field in required:
         if field not in meta:
-            raise _run_validation_error(
-                trace_id, f"meta.json is missing field {field!r}"
-            )
+            raise RunValidationError(trace_id, f"meta.json is missing field {field!r}")
 
     if meta.get("trace_id") != trace_id:
-        raise _run_validation_error(
+        raise RunValidationError(
             trace_id, "meta.json trace_id does not match run directory"
         )
     if meta.get("run_name") is not None and not isinstance(meta.get("run_name"), str):
-        raise _run_validation_error(
+        raise RunValidationError(
             trace_id, "meta.json field 'run_name' must be a string or null"
         )
     if not isinstance(meta.get("started_at"), str):
-        raise _run_validation_error(
+        raise RunValidationError(
             trace_id, "meta.json field 'started_at' must be a string"
         )
     if meta.get("ended_at") is not None and not isinstance(meta.get("ended_at"), str):
-        raise _run_validation_error(
+        raise RunValidationError(
             trace_id, "meta.json field 'ended_at' must be a string or null"
         )
     duration = meta.get("duration_ms")
     if duration is not None and (not isinstance(duration, int) or duration < 0):
-        raise _run_validation_error(
+        raise RunValidationError(
             trace_id,
             "meta.json field 'duration_ms' must be a non-negative integer or null",
         )
     if meta.get("status") not in ("running", "ok", "error"):
-        raise _run_validation_error(
+        raise RunValidationError(
             trace_id, "meta.json field 'status' must be running, ok, or error"
         )
     _validate_counts(trace_id, meta.get("counts"))
@@ -617,42 +611,42 @@ def _load_spans_for_validation(path: Path, trace_id: str) -> list[dict]:
                 try:
                     span = json.loads(line)
                 except json.JSONDecodeError:
-                    raise _run_validation_error(
+                    raise RunValidationError(
                         trace_id,
                         f"spans.jsonl line {line_no} is malformed JSON",
                     )
                 if not isinstance(span, dict):
-                    raise _run_validation_error(
+                    raise RunValidationError(
                         trace_id,
                         f"spans.jsonl line {line_no} must contain a JSON object",
                     )
                 spans.append(span)
     except OSError:
-        raise _run_validation_error(trace_id, "spans.jsonl could not be read")
+        raise RunValidationError(trace_id, "spans.jsonl could not be read")
     if not spans:
-        raise _run_validation_error(trace_id, "spans.jsonl contains no spans")
+        raise RunValidationError(trace_id, "spans.jsonl contains no spans")
     return spans
 
 
 def _validate_span_events(trace_id: str, line_no: int, events: object) -> None:
     if not isinstance(events, list):
-        raise _run_validation_error(
+        raise RunValidationError(
             trace_id, f"spans.jsonl line {line_no} field 'events' must be an array"
         )
     for idx, event in enumerate(events, start=1):
         if not isinstance(event, dict):
-            raise _run_validation_error(
+            raise RunValidationError(
                 trace_id,
                 f"spans.jsonl line {line_no} event {idx} must be an object",
             )
         for field in ("name", "timestamp", "attributes"):
             if field not in event:
-                raise _run_validation_error(
+                raise RunValidationError(
                     trace_id,
                     f"spans.jsonl line {line_no} event {idx} is missing field {field!r}",
                 )
         if not isinstance(event.get("attributes"), dict):
-            raise _run_validation_error(
+            raise RunValidationError(
                 trace_id,
                 f"spans.jsonl line {line_no} event {idx} field 'attributes' must be an object",
             )
@@ -662,7 +656,7 @@ def _require_span_string_field(
     trace_id: str, line_no: int, span: dict, field: str
 ) -> None:
     if not isinstance(span.get(field), str):
-        raise _run_validation_error(
+        raise RunValidationError(
             trace_id, f"spans.jsonl line {line_no} field {field!r} must be a string"
         )
 
@@ -672,7 +666,7 @@ def _require_optional_span_string_field(
 ) -> None:
     value = span.get(field)
     if value is not None and not isinstance(value, str):
-        raise _run_validation_error(
+        raise RunValidationError(
             trace_id,
             f"spans.jsonl line {line_no} field {field!r} must be a string or null",
         )
@@ -683,7 +677,7 @@ def _require_optional_span_non_negative_int_field(
 ) -> None:
     value = span.get(field)
     if value is not None and (not isinstance(value, int) or value < 0):
-        raise _run_validation_error(
+        raise RunValidationError(
             trace_id,
             f"spans.jsonl line {line_no} field {field!r} must be a non-negative integer or null",
         )
@@ -693,7 +687,7 @@ def _require_span_object_field(
     trace_id: str, line_no: int, span: dict, field: str
 ) -> None:
     if not isinstance(span.get(field), dict):
-        raise _run_validation_error(
+        raise RunValidationError(
             trace_id, f"spans.jsonl line {line_no} field {field!r} must be an object"
         )
 
@@ -719,25 +713,25 @@ def _validate_spans(
     for line_no, span in enumerate(spans, start=1):
         declared_spec = span.get("spec_version")
         if declared_spec is not None and declared_spec != SPEC_VERSION:
-            raise _run_validation_error(
+            raise RunValidationError(
                 trace_id,
                 f"spans.jsonl line {line_no} declares unsupported spec_version "
                 f"{_safe_version_display(declared_spec)!r}; expected {SPEC_VERSION!r}",
             )
         for field in required:
             if field not in span:
-                raise _run_validation_error(
+                raise RunValidationError(
                     trace_id, f"spans.jsonl line {line_no} is missing field {field!r}"
                 )
         if span.get("trace_id") != trace_id:
-            raise _run_validation_error(
+            raise RunValidationError(
                 trace_id,
                 f"spans.jsonl line {line_no} trace_id does not match run directory",
             )
         try:
             _validate_span_id(span.get("span_id"), field_name="span_id")
         except ValueError:
-            raise _run_validation_error(
+            raise RunValidationError(
                 trace_id, f"spans.jsonl line {line_no} has an invalid span_id"
             )
         parent_span_id = span.get("parent_span_id")
@@ -747,7 +741,7 @@ def _validate_spans(
             try:
                 _validate_span_id(parent_span_id, field_name="parent_span_id")
             except ValueError:
-                raise _run_validation_error(
+                raise RunValidationError(
                     trace_id,
                     f"spans.jsonl line {line_no} has an invalid parent_span_id",
                 )
@@ -761,13 +755,13 @@ def _validate_spans(
         _require_span_object_field(trace_id, line_no, span, "attributes")
         _validate_span_events(trace_id, line_no, span.get("events"))
         if span.get("status_code") not in ("OK", "ERROR", "UNSET"):
-            raise _run_validation_error(
+            raise RunValidationError(
                 trace_id,
                 f"spans.jsonl line {line_no} field 'status_code' must be OK, ERROR, or UNSET",
             )
         _require_span_string_field(trace_id, line_no, span, "status_description")
     if require_root_span and root_count == 0:
-        raise _run_validation_error(trace_id, "spans.jsonl has no root span")
+        raise RunValidationError(trace_id, "spans.jsonl has no root span")
 
 
 def load_validated_run(trace_id: str, config: MaidaConfig) -> tuple[dict, list[dict]]:
@@ -780,9 +774,9 @@ def load_validated_run(trace_id: str, config: MaidaConfig) -> tuple[dict, list[d
     meta_path = run_dir / META_JSON
     spans_path = run_dir / SPANS_JSONL
     if not meta_path.is_file():
-        raise _run_validation_error(trace_id, "required file meta.json is missing")
+        raise RunValidationError(trace_id, "required file meta.json is missing")
     if not spans_path.is_file():
-        raise _run_validation_error(trace_id, "required file spans.jsonl is missing")
+        raise RunValidationError(trace_id, "required file spans.jsonl is missing")
 
     meta = _read_json_file_for_validation(meta_path, trace_id, META_JSON)
     _validate_meta(trace_id, meta)

--- a/maida/storage.py
+++ b/maida/storage.py
@@ -11,6 +11,7 @@ Note: trace_id_hex is 32 hex characters (128-bit trace ID).
 import json
 import logging
 import os
+import re
 import shutil
 import uuid
 from datetime import datetime, timezone
@@ -28,6 +29,23 @@ EVENTS_JSONL = "events.jsonl"
 logger = logging.getLogger(__name__)
 
 _TRACE_ID_LEN = 32
+_SPAN_ID_LEN = 16
+_HEX_CHARS = frozenset("0123456789abcdef")
+_SAFE_VERSION_RE = re.compile(r"^\d{1,4}(?:\.\d{1,4}){0,3}$")
+
+
+class RunValidationError(RuntimeError):
+    """A stored run exists but does not match the supported trace contract."""
+
+    def __init__(self, trace_id: str, problem: str) -> None:
+        self.trace_id = trace_id
+        self.problem = problem
+        short = trace_id[:8] if isinstance(trace_id, str) and trace_id else "unknown"
+        super().__init__(
+            f"Run validation failed for {short}: {problem}. "
+            "Next step: rerun the traced agent to create a fresh run, "
+            "or run `maida demo` to create a known-good local trace."
+        )
 
 
 class UnsupportedTraceFormatError(RuntimeError):
@@ -55,6 +73,15 @@ def _validate_trace_id(trace_id: str) -> str:
     if ".." in t or "/" in t or "\\" in t:
         raise ValueError("invalid trace_id")
     return t
+
+
+def _validate_span_id(span_id: str, *, field_name: str) -> str:
+    if not span_id or not isinstance(span_id, str):
+        raise ValueError(f"invalid {field_name}")
+    sid = span_id.strip().lower()
+    if len(sid) != _SPAN_ID_LEN or not all(c in "0123456789abcdef" for c in sid):
+        raise ValueError(f"invalid {field_name}")
+    return sid
 
 
 def _atomic_write_json(path: Path, payload: dict) -> None:
@@ -214,13 +241,6 @@ def load_events(run_id: str, config: MaidaConfig) -> list[dict]:
     return events
 
 
-def _current_trace_meta_exists(run_id: str, config: MaidaConfig) -> bool:
-    try:
-        return _meta_path(run_id, config).is_file()
-    except ValueError:
-        return False
-
-
 def _load_legacy_events_jsonl(run_id: str, config: MaidaConfig) -> list[dict]:
     path = _legacy_run_dir(run_id, config) / EVENTS_JSONL
     if not path.is_file():
@@ -294,11 +314,22 @@ def load_run_for_analysis(
     current ``spec_version`` and already contain event-shaped records.
     """
     resolved_id = resolve_run_id(run_id, config)
-    meta = load_run_meta(resolved_id, config)
 
-    if _current_trace_meta_exists(resolved_id, config):
-        spans = load_spans(resolved_id, config)
-        return resolved_id, meta, spans_to_events(spans)
+    try:
+        current_run_dir = _trace_dir(resolved_id, config)
+    except ValueError:
+        current_run_dir = None
+    if current_run_dir is not None and current_run_dir.is_dir():
+        looks_current = (
+            (current_run_dir / META_JSON).exists()
+            or (current_run_dir / SPANS_JSONL).exists()
+            or not (current_run_dir / RUN_JSON).exists()
+        )
+        if looks_current:
+            meta, spans = load_validated_run(resolved_id, config)
+            return resolved_id, meta, spans_to_events(spans)
+
+    meta = load_run_meta(resolved_id, config)
 
     declared_spec = meta.get("spec_version")
     if declared_spec != SPEC_VERSION:
@@ -432,6 +463,30 @@ def resolve_trace_id(prefix: str, config: MaidaConfig) -> str:
     return candidates[0][1]
 
 
+def resolve_trace_id_for_read(prefix: str, config: MaidaConfig) -> str:
+    """Resolve a trace ID for strict read paths, including incomplete run dirs.
+
+    Normal prefix resolution is metadata-driven. For explicit full trace IDs, keep
+    a directory that exists but is missing/corrupt metadata so validation can
+    report the real format problem instead of a generic not-found error.
+    """
+    try:
+        return resolve_trace_id(prefix, config)
+    except FileNotFoundError as original:
+        raw = (prefix or "").strip().lower()
+        try:
+            trace_id = _validate_trace_id(raw)
+        except ValueError:
+            raise original
+        try:
+            run_dir = _trace_dir(trace_id, config)
+        except ValueError:
+            raise original
+        if run_dir.is_dir():
+            return trace_id
+        raise original
+
+
 def resolve_latest_trace_id(config: MaidaConfig) -> str:
     """Return the trace_id of the most recently started run.
 
@@ -463,6 +518,279 @@ def resolve_latest_run_id(config: MaidaConfig) -> str:
     return str(run_id)
 
 
+def _safe_version_display(value: object) -> str:
+    text = str(value)
+    return text if _SAFE_VERSION_RE.fullmatch(text) else "<redacted>"
+
+
+def _run_validation_error(trace_id: str, problem: str) -> RunValidationError:
+    return RunValidationError(trace_id, problem)
+
+
+def _read_json_file_for_validation(path: Path, trace_id: str, display: str) -> dict:
+    try:
+        with open(path, "r", encoding="utf-8") as f:
+            payload = json.load(f)
+    except json.JSONDecodeError:
+        raise _run_validation_error(trace_id, f"{display} is malformed JSON")
+    except OSError:
+        raise _run_validation_error(trace_id, f"{display} could not be read")
+    if not isinstance(payload, dict):
+        raise _run_validation_error(trace_id, f"{display} must contain a JSON object")
+    return payload
+
+
+def _validate_counts(trace_id: str, counts: object) -> None:
+    if not isinstance(counts, dict):
+        raise _run_validation_error(
+            trace_id, "meta.json field 'counts' must be an object"
+        )
+    for key in ("llm_calls", "tool_calls", "errors", "loop_warnings"):
+        value = counts.get(key)
+        if not isinstance(value, int) or value < 0:
+            raise _run_validation_error(
+                trace_id,
+                f"meta.json counts.{key} must be a non-negative integer",
+            )
+
+
+def _validate_meta(trace_id: str, meta: dict) -> None:
+    declared_spec = meta.get("spec_version")
+    if declared_spec is not None and declared_spec != SPEC_VERSION:
+        raise _run_validation_error(
+            trace_id,
+            "meta.json declares unsupported spec_version "
+            f"{_safe_version_display(declared_spec)!r}; expected {SPEC_VERSION!r}",
+        )
+
+    required = (
+        "trace_id",
+        "run_name",
+        "started_at",
+        "ended_at",
+        "duration_ms",
+        "status",
+        "counts",
+    )
+    for field in required:
+        if field not in meta:
+            raise _run_validation_error(
+                trace_id, f"meta.json is missing field {field!r}"
+            )
+
+    if meta.get("trace_id") != trace_id:
+        raise _run_validation_error(
+            trace_id, "meta.json trace_id does not match run directory"
+        )
+    if meta.get("run_name") is not None and not isinstance(meta.get("run_name"), str):
+        raise _run_validation_error(
+            trace_id, "meta.json field 'run_name' must be a string or null"
+        )
+    if not isinstance(meta.get("started_at"), str):
+        raise _run_validation_error(
+            trace_id, "meta.json field 'started_at' must be a string"
+        )
+    if meta.get("ended_at") is not None and not isinstance(meta.get("ended_at"), str):
+        raise _run_validation_error(
+            trace_id, "meta.json field 'ended_at' must be a string or null"
+        )
+    duration = meta.get("duration_ms")
+    if duration is not None and (not isinstance(duration, int) or duration < 0):
+        raise _run_validation_error(
+            trace_id,
+            "meta.json field 'duration_ms' must be a non-negative integer or null",
+        )
+    if meta.get("status") not in ("running", "ok", "error"):
+        raise _run_validation_error(
+            trace_id, "meta.json field 'status' must be running, ok, or error"
+        )
+    _validate_counts(trace_id, meta.get("counts"))
+
+
+def _load_spans_for_validation(path: Path, trace_id: str) -> list[dict]:
+    spans: list[dict] = []
+    try:
+        with open(path, "r", encoding="utf-8") as f:
+            for line_no, line in enumerate(f, start=1):
+                if not line.strip():
+                    continue
+                try:
+                    span = json.loads(line)
+                except json.JSONDecodeError:
+                    raise _run_validation_error(
+                        trace_id,
+                        f"spans.jsonl line {line_no} is malformed JSON",
+                    )
+                if not isinstance(span, dict):
+                    raise _run_validation_error(
+                        trace_id,
+                        f"spans.jsonl line {line_no} must contain a JSON object",
+                    )
+                spans.append(span)
+    except OSError:
+        raise _run_validation_error(trace_id, "spans.jsonl could not be read")
+    if not spans:
+        raise _run_validation_error(trace_id, "spans.jsonl contains no spans")
+    return spans
+
+
+def _validate_span_events(trace_id: str, line_no: int, events: object) -> None:
+    if not isinstance(events, list):
+        raise _run_validation_error(
+            trace_id, f"spans.jsonl line {line_no} field 'events' must be an array"
+        )
+    for idx, event in enumerate(events, start=1):
+        if not isinstance(event, dict):
+            raise _run_validation_error(
+                trace_id,
+                f"spans.jsonl line {line_no} event {idx} must be an object",
+            )
+        for field in ("name", "timestamp", "attributes"):
+            if field not in event:
+                raise _run_validation_error(
+                    trace_id,
+                    f"spans.jsonl line {line_no} event {idx} is missing field {field!r}",
+                )
+        if not isinstance(event.get("attributes"), dict):
+            raise _run_validation_error(
+                trace_id,
+                f"spans.jsonl line {line_no} event {idx} field 'attributes' must be an object",
+            )
+
+
+def _require_span_string_field(
+    trace_id: str, line_no: int, span: dict, field: str
+) -> None:
+    if not isinstance(span.get(field), str):
+        raise _run_validation_error(
+            trace_id, f"spans.jsonl line {line_no} field {field!r} must be a string"
+        )
+
+
+def _require_optional_span_string_field(
+    trace_id: str, line_no: int, span: dict, field: str
+) -> None:
+    value = span.get(field)
+    if value is not None and not isinstance(value, str):
+        raise _run_validation_error(
+            trace_id,
+            f"spans.jsonl line {line_no} field {field!r} must be a string or null",
+        )
+
+
+def _require_optional_span_non_negative_int_field(
+    trace_id: str, line_no: int, span: dict, field: str
+) -> None:
+    value = span.get(field)
+    if value is not None and (not isinstance(value, int) or value < 0):
+        raise _run_validation_error(
+            trace_id,
+            f"spans.jsonl line {line_no} field {field!r} must be a non-negative integer or null",
+        )
+
+
+def _require_span_object_field(
+    trace_id: str, line_no: int, span: dict, field: str
+) -> None:
+    if not isinstance(span.get(field), dict):
+        raise _run_validation_error(
+            trace_id, f"spans.jsonl line {line_no} field {field!r} must be an object"
+        )
+
+
+def _validate_spans(
+    trace_id: str, spans: list[dict], *, require_root_span: bool
+) -> None:
+    root_count = 0
+    required = (
+        "trace_id",
+        "span_id",
+        "parent_span_id",
+        "name",
+        "kind",
+        "start_time",
+        "end_time",
+        "duration_ms",
+        "attributes",
+        "events",
+        "status_code",
+        "status_description",
+    )
+    for line_no, span in enumerate(spans, start=1):
+        declared_spec = span.get("spec_version")
+        if declared_spec is not None and declared_spec != SPEC_VERSION:
+            raise _run_validation_error(
+                trace_id,
+                f"spans.jsonl line {line_no} declares unsupported spec_version "
+                f"{_safe_version_display(declared_spec)!r}; expected {SPEC_VERSION!r}",
+            )
+        for field in required:
+            if field not in span:
+                raise _run_validation_error(
+                    trace_id, f"spans.jsonl line {line_no} is missing field {field!r}"
+                )
+        if span.get("trace_id") != trace_id:
+            raise _run_validation_error(
+                trace_id,
+                f"spans.jsonl line {line_no} trace_id does not match run directory",
+            )
+        try:
+            _validate_span_id(span.get("span_id"), field_name="span_id")
+        except ValueError:
+            raise _run_validation_error(
+                trace_id, f"spans.jsonl line {line_no} has an invalid span_id"
+            )
+        parent_span_id = span.get("parent_span_id")
+        if parent_span_id is None:
+            root_count += 1
+        else:
+            try:
+                _validate_span_id(parent_span_id, field_name="parent_span_id")
+            except ValueError:
+                raise _run_validation_error(
+                    trace_id,
+                    f"spans.jsonl line {line_no} has an invalid parent_span_id",
+                )
+        _require_span_string_field(trace_id, line_no, span, "name")
+        _require_span_string_field(trace_id, line_no, span, "kind")
+        _require_span_string_field(trace_id, line_no, span, "start_time")
+        _require_optional_span_string_field(trace_id, line_no, span, "end_time")
+        _require_optional_span_non_negative_int_field(
+            trace_id, line_no, span, "duration_ms"
+        )
+        _require_span_object_field(trace_id, line_no, span, "attributes")
+        _validate_span_events(trace_id, line_no, span.get("events"))
+        if span.get("status_code") not in ("OK", "ERROR", "UNSET"):
+            raise _run_validation_error(
+                trace_id,
+                f"spans.jsonl line {line_no} field 'status_code' must be OK, ERROR, or UNSET",
+            )
+        _require_span_string_field(trace_id, line_no, span, "status_description")
+    if require_root_span and root_count == 0:
+        raise _run_validation_error(trace_id, "spans.jsonl has no root span")
+
+
+def load_validated_run(trace_id: str, config: MaidaConfig) -> tuple[dict, list[dict]]:
+    """Load and strictly validate a current-format run for user-facing reads."""
+    trace_id = _validate_trace_id(trace_id)
+    run_dir = _trace_dir(trace_id, config)
+    if not run_dir.is_dir():
+        raise FileNotFoundError(f"No run found for trace_id '{trace_id}'")
+
+    meta_path = run_dir / META_JSON
+    spans_path = run_dir / SPANS_JSONL
+    if not meta_path.is_file():
+        raise _run_validation_error(trace_id, "required file meta.json is missing")
+    if not spans_path.is_file():
+        raise _run_validation_error(trace_id, "required file spans.jsonl is missing")
+
+    meta = _read_json_file_for_validation(meta_path, trace_id, META_JSON)
+    _validate_meta(trace_id, meta)
+    spans = _load_spans_for_validation(spans_path, trace_id)
+    _validate_spans(trace_id, spans, require_root_span=meta.get("status") != "running")
+    return meta, spans
+
+
 def resolve_run_id(prefix: str, config: MaidaConfig) -> str:
     """Compatibility wrapper for legacy run IDs and new trace IDs."""
     if not prefix or not prefix.strip():
@@ -471,7 +799,7 @@ def resolve_run_id(prefix: str, config: MaidaConfig) -> str:
     if ".." in prefix or "/" in prefix or "\\" in prefix:
         raise FileNotFoundError("Run ID is required")
     try:
-        return resolve_trace_id(prefix, config)
+        return resolve_trace_id_for_read(prefix, config)
     except FileNotFoundError:
         pass
 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -104,12 +104,14 @@ def _write_run(temp_data_dir, trace_id, run_name):
         "span_id": "0" * 16,
         "parent_span_id": None,
         "name": run_name,
+        "kind": "INTERNAL",
         "start_time": "2026-01-01T00:00:00.000Z",
         "end_time": "2026-01-01T00:00:01.000Z",
         "duration_ms": 1000,
         "attributes": {"maida.run_name": run_name},
         "events": [],
         "status_code": "OK",
+        "status_description": "",
     }
     (run_dir / "spans.jsonl").write_text(json.dumps(root_span) + "\n", encoding="utf-8")
 
@@ -168,14 +170,36 @@ def _write_trace_run(temp_data_dir, trace_id, run_name):
         "span_id": "0" * 16,
         "parent_span_id": None,
         "name": run_name,
+        "kind": "INTERNAL",
         "start_time": "2026-01-01T00:00:00.000Z",
         "end_time": "2026-01-01T00:00:01.000Z",
         "duration_ms": 1000,
         "attributes": {"maida.run_name": run_name},
         "events": [],
         "status_code": "OK",
+        "status_description": "",
     }
     (run_dir / "spans.jsonl").write_text(json.dumps(root_span) + "\n", encoding="utf-8")
+
+
+def _write_run_with_malformed_span(temp_data_dir, trace_id, run_name="bad"):
+    config = load_config()
+    run_dir = config.data_dir / "runs" / trace_id
+    run_dir.mkdir(parents=True, exist_ok=True)
+    meta = {
+        "trace_id": trace_id,
+        "run_name": run_name,
+        "started_at": "2026-01-01T00:00:00.000Z",
+        "ended_at": "2026-01-01T00:00:01.000Z",
+        "duration_ms": 1000,
+        "status": "ok",
+        "counts": {"llm_calls": 0, "tool_calls": 0, "errors": 0, "loop_warnings": 0},
+    }
+    (run_dir / "meta.json").write_text(json.dumps(meta), encoding="utf-8")
+    (run_dir / "spans.jsonl").write_text(
+        '{"api_key":"sk-test-DO-NOT-LEAK",\n',
+        encoding="utf-8",
+    )
 
 
 def test_list_json_outputs_valid_json_spec_version_and_runs(empty_data_dir):
@@ -233,6 +257,36 @@ def test_view_defaults_to_latest_trace_id(monkeypatch, empty_data_dir):
     data = json.loads(result.output)
     assert data["run_id"] == trace_id
     assert f"run_id={trace_id}" in data["url"]
+
+
+@pytest.mark.parametrize(
+    "command_builder",
+    [
+        lambda bad, good, tmp: ["view", bad, "--no-browser", "--json", "--port", "0"],
+        lambda bad, good, tmp: ["baseline", bad, "--out", str(tmp / "bl.json")],
+        lambda bad, good, tmp: ["assert", bad, "--max-steps", "10"],
+        lambda bad, good, tmp: ["diff", bad, good],
+    ],
+)
+def test_run_loading_commands_report_validation_errors(
+    command_builder,
+    empty_data_dir,
+):
+    bad_trace_id = "badbad10" + "a" * 24
+    good_trace_id = "face0010" + "b" * 24
+    _write_run_with_malformed_span(empty_data_dir, bad_trace_id)
+    _write_trace_run(empty_data_dir, good_trace_id, "good")
+
+    result = runner.invoke(
+        app,
+        command_builder(bad_trace_id, good_trace_id, empty_data_dir),
+    )
+
+    assert result.exit_code == 2
+    assert "Run validation failed" in result.stderr
+    assert "spans.jsonl line 1" in result.stderr
+    assert "Next step:" in result.stderr
+    assert "sk-test-DO-NOT-LEAK" not in result.stderr
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_diff.py
+++ b/tests/test_diff.py
@@ -45,12 +45,14 @@ def _write_trace_run(config, trace_id, run_name):
         "span_id": "0" * 16,
         "parent_span_id": None,
         "name": run_name,
+        "kind": "INTERNAL",
         "start_time": "2026-01-01T00:00:00.000Z",
         "end_time": "2026-01-01T00:00:01.000Z",
         "duration_ms": 1000,
         "attributes": {"maida.run_name": run_name},
         "events": [],
         "status_code": "OK",
+        "status_description": "",
     }
     (run_dir / "spans.jsonl").write_text(json.dumps(root_span) + "\n", encoding="utf-8")
 

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -33,14 +33,36 @@ def _write_run(config, trace_id, run_name="test"):
         "span_id": "0" * 16,
         "parent_span_id": None,
         "name": run_name,
+        "kind": "INTERNAL",
         "start_time": "2026-01-01T12:00:00.000Z",
         "end_time": "2026-01-01T12:00:01.000Z",
         "duration_ms": 1000,
         "attributes": {"maida.run_name": run_name},
         "events": [],
         "status_code": "OK",
+        "status_description": "",
     }
     (run_dir / "spans.jsonl").write_text(json.dumps(root_span) + "\n", encoding="utf-8")
+
+
+def _write_run_with_malformed_span(config, trace_id):
+    runs_base = config.data_dir / "runs"
+    run_dir = runs_base / trace_id
+    run_dir.mkdir(parents=True, exist_ok=True)
+    meta = {
+        "trace_id": trace_id,
+        "run_name": "bad",
+        "started_at": "2026-01-01T12:00:00.000Z",
+        "ended_at": "2026-01-01T12:00:01.000Z",
+        "duration_ms": 1000,
+        "status": "ok",
+        "counts": {"llm_calls": 0, "tool_calls": 0, "errors": 0, "loop_warnings": 0},
+    }
+    (run_dir / "meta.json").write_text(json.dumps(meta), encoding="utf-8")
+    (run_dir / "spans.jsonl").write_text(
+        '{"token":"sk-test-DO-NOT-LEAK",\n',
+        encoding="utf-8",
+    )
 
 
 # ---------------------------------------------------------------------------
@@ -78,6 +100,21 @@ def test_server_returns_400_for_invalid_run_id_spans(temp_data_dir):
     r = client.get("/api/runs/short/spans")
     assert r.status_code == 400, r.json()
     assert "invalid" in (r.json().get("detail") or "").lower()
+
+
+def test_server_spans_returns_422_for_invalid_run_format(temp_data_dir):
+    config = load_config()
+    trace_id = "abcabc20" + "a" * 24
+    _write_run_with_malformed_span(config, trace_id)
+    client = TestClient(create_app())
+
+    r = client.get(f"/api/runs/{trace_id}/spans")
+
+    assert r.status_code == 422
+    detail = r.json().get("detail") or ""
+    assert "spans.jsonl line 1" in detail
+    assert "Next step:" in detail
+    assert "sk-test-DO-NOT-LEAK" not in detail
 
 
 def test_server_returns_404_for_valid_but_missing_run_id(temp_data_dir):

--- a/tests/test_storage.py
+++ b/tests/test_storage.py
@@ -10,12 +10,15 @@ import pytest
 from maida.config import load_config
 from maida.events import EventType, spans_to_events
 from maida.storage import (
+    RunValidationError,
     _validate_trace_id,
     delete_run,
     list_runs,
+    load_validated_run,
     load_run_meta,
     load_spans,
     rename_run,
+    resolve_trace_id_for_read,
     resolve_trace_id,
 )
 
@@ -102,6 +105,50 @@ def _write_spans(run_dir, trace_id, spans):
     (run_dir / "spans.jsonl").write_text("\n".join(lines), encoding="utf-8")
 
 
+def _valid_meta(trace_id, *, run_name="validated"):
+    return {
+        "trace_id": trace_id,
+        "run_name": run_name,
+        "started_at": "2026-01-01T12:00:00.000Z",
+        "ended_at": "2026-01-01T12:00:01.000Z",
+        "duration_ms": 1000,
+        "status": "ok",
+        "counts": {"llm_calls": 0, "tool_calls": 0, "errors": 0, "loop_warnings": 0},
+    }
+
+
+def _valid_root_span(trace_id, *, span_id="1" * 16, run_name="validated"):
+    return {
+        "trace_id": trace_id,
+        "span_id": span_id,
+        "parent_span_id": None,
+        "name": run_name,
+        "kind": "INTERNAL",
+        "start_time": "2026-01-01T12:00:00.000Z",
+        "end_time": "2026-01-01T12:00:01.000Z",
+        "duration_ms": 1000,
+        "attributes": {"maida.run_name": run_name},
+        "events": [],
+        "status_code": "OK",
+        "status_description": "",
+    }
+
+
+def _write_validated_run(config, trace_id, *, meta=None, spans=None):
+    run_dir = config.data_dir / "runs" / trace_id
+    run_dir.mkdir(parents=True, exist_ok=True)
+    (run_dir / "meta.json").write_text(
+        json.dumps(meta if meta is not None else _valid_meta(trace_id)),
+        encoding="utf-8",
+    )
+    span_lines = [
+        json.dumps(span)
+        for span in (spans if spans is not None else [_valid_root_span(trace_id)])
+    ]
+    (run_dir / "spans.jsonl").write_text("\n".join(span_lines) + "\n", encoding="utf-8")
+    return run_dir
+
+
 def test_load_spans_returns_spans(temp_data_dir):
     config = load_config()
     trace_id = "d" * 32
@@ -145,6 +192,147 @@ def test_load_spans_missing_file_returns_empty(temp_data_dir):
     meta = {"trace_id": trace_id, "status": "ok", "counts": {}}
     (run_dir / "meta.json").write_text(json.dumps(meta), encoding="utf-8")
     assert load_spans(trace_id, config) == []
+
+
+# ---------------------------------------------------------------------------
+# strict run validation
+# ---------------------------------------------------------------------------
+
+
+def test_load_validated_run_accepts_current_trace_contract(temp_data_dir):
+    config = load_config()
+    trace_id = "abcabc12" + "a" * 24
+    _write_validated_run(config, trace_id)
+
+    meta, spans = load_validated_run(trace_id, config)
+
+    assert meta["trace_id"] == trace_id
+    assert spans[0]["trace_id"] == trace_id
+
+
+def test_resolve_trace_id_for_read_keeps_incomplete_exact_trace_for_validation(
+    temp_data_dir,
+):
+    config = load_config()
+    trace_id = "abcabc13" + "a" * 24
+    (config.data_dir / "runs" / trace_id).mkdir(parents=True)
+
+    assert resolve_trace_id_for_read(trace_id, config) == trace_id
+
+
+def test_load_validated_run_missing_required_file_has_next_step(temp_data_dir):
+    config = load_config()
+    trace_id = "abcabc14" + "a" * 24
+    run_dir = config.data_dir / "runs" / trace_id
+    run_dir.mkdir(parents=True)
+    (run_dir / "meta.json").write_text(
+        json.dumps(_valid_meta(trace_id)), encoding="utf-8"
+    )
+
+    with pytest.raises(RunValidationError) as excinfo:
+        load_validated_run(trace_id, config)
+
+    message = str(excinfo.value)
+    assert "spans.jsonl" in message
+    assert "Next step:" in message
+    assert "maida demo" in message
+
+
+def test_load_validated_run_malformed_span_is_sanitized(temp_data_dir):
+    config = load_config()
+    trace_id = "abcabc15" + "a" * 24
+    run_dir = config.data_dir / "runs" / trace_id
+    run_dir.mkdir(parents=True)
+    (run_dir / "meta.json").write_text(
+        json.dumps(_valid_meta(trace_id)), encoding="utf-8"
+    )
+    (run_dir / "spans.jsonl").write_text(
+        '{"secret":"sk-test-DO-NOT-LEAK",\n',
+        encoding="utf-8",
+    )
+
+    with pytest.raises(RunValidationError) as excinfo:
+        load_validated_run(trace_id, config)
+
+    message = str(excinfo.value)
+    assert "spans.jsonl line 1" in message
+    assert "malformed JSON" in message
+    assert "sk-test-DO-NOT-LEAK" not in message
+
+
+def test_load_validated_run_unsupported_spec_version(temp_data_dir):
+    config = load_config()
+    trace_id = "abcabc16" + "a" * 24
+    meta = _valid_meta(trace_id) | {"spec_version": "0.1"}
+    _write_validated_run(config, trace_id, meta=meta)
+
+    with pytest.raises(RunValidationError) as excinfo:
+        load_validated_run(trace_id, config)
+
+    assert "unsupported spec_version" in str(excinfo.value)
+    assert "0.1" in str(excinfo.value)
+
+
+def test_load_validated_run_unsupported_spec_version_redacts_non_version_value(
+    temp_data_dir,
+):
+    config = load_config()
+    trace_id = "abcabc20" + "a" * 24
+    meta = _valid_meta(trace_id) | {"spec_version": "sk-test-DO-NOT-LEAK"}
+    _write_validated_run(config, trace_id, meta=meta)
+
+    with pytest.raises(RunValidationError) as excinfo:
+        load_validated_run(trace_id, config)
+
+    message = str(excinfo.value)
+    assert "unsupported spec_version" in message
+    assert "<redacted>" in message
+    assert "sk-test-DO-NOT-LEAK" not in message
+
+
+def test_load_validated_run_missing_span_field(temp_data_dir):
+    config = load_config()
+    trace_id = "abcabc17" + "a" * 24
+    span = _valid_root_span(trace_id)
+    span.pop("status_code")
+    _write_validated_run(config, trace_id, spans=[span])
+
+    with pytest.raises(RunValidationError) as excinfo:
+        load_validated_run(trace_id, config)
+
+    assert "spans.jsonl line 1" in str(excinfo.value)
+    assert "status_code" in str(excinfo.value)
+
+
+def test_load_validated_run_allows_running_trace_without_root_span(temp_data_dir):
+    config = load_config()
+    trace_id = "abcabc18" + "a" * 24
+    meta = _valid_meta(trace_id) | {
+        "status": "running",
+        "ended_at": None,
+        "duration_ms": None,
+    }
+    child_span = _valid_root_span(trace_id)
+    child_span["parent_span_id"] = "2" * 16
+    _write_validated_run(config, trace_id, meta=meta, spans=[child_span])
+
+    loaded_meta, loaded_spans = load_validated_run(trace_id, config)
+
+    assert loaded_meta["status"] == "running"
+    assert loaded_spans[0]["parent_span_id"] == "2" * 16
+
+
+def test_load_validated_run_completed_trace_requires_root_span(temp_data_dir):
+    config = load_config()
+    trace_id = "abcabc19" + "a" * 24
+    child_span = _valid_root_span(trace_id)
+    child_span["parent_span_id"] = "2" * 16
+    _write_validated_run(config, trace_id, spans=[child_span])
+
+    with pytest.raises(RunValidationError) as excinfo:
+        load_validated_run(trace_id, config)
+
+    assert "no root span" in str(excinfo.value)
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
Note, although this fixes #52, there is no true backwards compatibility. There is only a thin BC layer to support throwing loud messages :)

- Added `RunValidationError` plus `load_validated_run()` in `maida.storage` for strict current-format trace validation before user-facing reads.
- Added read-path trace resolution that preserves explicit full trace IDs for incomplete/corrupt run directories, so validation can return an actionable format error instead of a generic not-found.
- Routed `baseline`, `assert`, `diff`, `export`, `view`, and the viewer spans API through the validator.
- Kept the legacy `run.json` / `events.jsonl` helpers as a thin compatibility layer; legacy storage is not expanded into full production support.
- Validation checks required files, required `meta.json` fields, required span envelope fields, malformed JSONL, unsupported `spec_version`, trace/span ID shape, status/count types, and completed-run root-span presence.
- Validation errors include a next-step hint and avoid echoing malformed raw payload content.
- Preserved live viewer behavior for active runs by allowing `status: "running"` traces to validate before the root span has been exported.