### PR TITLE
Add compatibility reader for legacy formats

### DIFF
--- a/maida/assertions.py
+++ b/maida/assertions.py
@@ -15,8 +15,7 @@ if TYPE_CHECKING:
 from maida.baseline import extract_run_metrics
 from maida.config import MaidaConfig, load_config
 from maida.diff import format_diff_markdown, format_diff_text
-from maida.events import spans_to_events
-from maida.storage import load_run_meta, load_spans, resolve_trace_id
+from maida.storage import load_run_for_analysis
 
 
 kDefaultTolerance = 0.5  # 50% global default
@@ -159,10 +158,7 @@ def run_assertions(
     if config is None:
         config = load_config()
 
-    full_id = resolve_trace_id(trace_id, config)
-    meta = load_run_meta(full_id, config)
-    spans = load_spans(full_id, config)
-    events = spans_to_events(spans)
+    full_id, meta, events = load_run_for_analysis(trace_id, config)
     metrics = extract_run_metrics(meta, events)
     summary = metrics["summary"]
     b_summary = (baseline or {}).get("summary")

--- a/maida/baseline.py
+++ b/maida/baseline.py
@@ -12,8 +12,8 @@ from collections import Counter
 from pathlib import Path
 
 from maida.config import MaidaConfig
-from maida.events import EventType, spans_to_events, utc_now_iso_ms_z
-from maida.storage import load_run_meta, load_spans, resolve_trace_id
+from maida.events import EventType, utc_now_iso_ms_z
+from maida.storage import load_run_for_analysis
 
 _BASELINE_SCHEMA_VERSION = "0.2"
 
@@ -92,10 +92,7 @@ def create_baseline(trace_id: str, config: MaidaConfig) -> dict:
         trace_id: The OTel trace ID (or prefix) for the run.
         config: MaidaConfig instance.
     """
-    full_id = resolve_trace_id(trace_id, config)
-    meta = load_run_meta(full_id, config)
-    spans = load_spans(full_id, config)
-    events = spans_to_events(spans)
+    full_id, meta, events = load_run_for_analysis(trace_id, config)
     metrics = extract_run_metrics(meta, events)
     return {
         "schema_version": _BASELINE_SCHEMA_VERSION,

--- a/maida/cli.py
+++ b/maida/cli.py
@@ -30,7 +30,6 @@ from maida.config import load_config
 from maida.constants import LOCAL_DIR_NAME, SPEC_VERSION
 from maida.demo import ensure_demo_env, run_good_agent, run_refactored_agent
 from maida.diff import compute_diff, format_diff_text
-from maida.events import spans_to_events
 from maida.policy import load_policy, merge_policy
 from maida.scaffold import (
     POLICY_RELPATH,
@@ -77,10 +76,15 @@ def _resolve_run_or_latest(run_id: str | None, config) -> str:
     machine-readable.  Raises FileNotFoundError if nothing can be resolved.
     """
     if run_id is None:
-        resolved = storage.resolve_latest_trace_id(config)
+        resolved = storage.resolve_latest_run_id(config)
         typer.echo(f"Using latest run: {resolved[:8]}", err=True)
         return resolved
-    return storage.resolve_trace_id(run_id, config)
+    return storage.resolve_run_id(run_id, config)
+
+
+def _exit_unsupported_trace_format(error: storage.UnsupportedTraceFormatError) -> None:
+    typer.echo(str(error), err=True)
+    raise Exit(EXIT_NOT_FOUND)
 
 
 def _wait_for_port(host: str, port: int, timeout_s: float = 5.0) -> bool:
@@ -190,17 +194,19 @@ def export_cmd(
             typer.echo(f"Run not found: {e}", err=True)
             raise Exit(EXIT_NOT_FOUND)
         try:
-            run_meta = storage.load_run_meta(trace_id, config)
+            _, run_meta, events = storage.load_run_for_analysis(trace_id, config)
+        except storage.UnsupportedTraceFormatError as e:
+            _exit_unsupported_trace_format(e)
         except (ValueError, FileNotFoundError):
             raise Exit(EXIT_NOT_FOUND)
-        spans = storage.load_spans(trace_id, config)
-        events = spans_to_events(spans)
         payload = {"spec_version": SPEC_VERSION, "run": run_meta, "events": events}
         out.parent.mkdir(parents=True, exist_ok=True)
         with open(out, "w", encoding="utf-8") as f:
             json.dump(payload, f, ensure_ascii=False, indent=2)
     except Exit:
         raise
+    except storage.UnsupportedTraceFormatError as e:
+        _exit_unsupported_trace_format(e)
     except Exception as e:
         typer.echo(f"error: {e}", err=True)
         raise Exit(EXIT_INTERNAL)
@@ -315,6 +321,8 @@ def baseline_cmd(
         typer.echo(f"Baseline saved to {out}")
     except Exit:
         raise
+    except storage.UnsupportedTraceFormatError as e:
+        _exit_unsupported_trace_format(e)
     except Exception as e:
         typer.echo(f"error: {e}", err=True)
         raise Exit(EXIT_INTERNAL)
@@ -438,6 +446,8 @@ def assert_cmd(
             raise Exit(1)
     except Exit:
         raise
+    except storage.UnsupportedTraceFormatError as e:
+        _exit_unsupported_trace_format(e)
     except Exception as e:
         typer.echo(f"error: {e}", err=True)
         raise Exit(EXIT_INTERNAL)
@@ -607,7 +617,7 @@ def diff_cmd(
                 raise Exit(EXIT_NOT_FOUND)
         elif run_b is not None:
             try:
-                resolved_b = storage.resolve_trace_id(run_b, config)
+                resolved_b = storage.resolve_run_id(run_b, config)
             except FileNotFoundError:
                 typer.echo(f"Run not found: {run_b}", err=True)
                 raise Exit(EXIT_NOT_FOUND)
@@ -619,6 +629,8 @@ def diff_cmd(
         typer.echo(format_diff_text(d))
     except Exit:
         raise
+    except storage.UnsupportedTraceFormatError as e:
+        _exit_unsupported_trace_format(e)
     except Exception as e:
         typer.echo(f"error: {e}", err=True)
         raise Exit(EXIT_INTERNAL)

--- a/maida/diff.py
+++ b/maida/diff.py
@@ -8,8 +8,7 @@ from dataclasses import dataclass, field
 
 from maida.baseline import extract_run_metrics
 from maida.config import MaidaConfig, load_config
-from maida.events import spans_to_events
-from maida.storage import load_run_meta, load_spans, resolve_trace_id
+from maida.storage import load_run_for_analysis
 
 
 @dataclass
@@ -52,20 +51,14 @@ def compute_diff(
     if config is None:
         config = load_config()
 
-    full_a = resolve_trace_id(run_a_id, config)
-    meta_a = load_run_meta(full_a, config)
-    spans_a = load_spans(full_a, config)
-    events_a = spans_to_events(spans_a)
+    full_a, meta_a, events_a = load_run_for_analysis(run_a_id, config)
     metrics_a = extract_run_metrics(meta_a, events_a)
 
     if baseline is not None:
         metrics_b = _metrics_from_baseline(baseline)
         b_id = baseline.get("source_run_id", "baseline")
     elif run_b_id is not None:
-        full_b = resolve_trace_id(run_b_id, config)
-        meta_b = load_run_meta(full_b, config)
-        spans_b = load_spans(full_b, config)
-        events_b = spans_to_events(spans_b)
+        full_b, meta_b, events_b = load_run_for_analysis(run_b_id, config)
         metrics_b = extract_run_metrics(meta_b, events_b)
         b_id = full_b
     else:

--- a/maida/storage.py
+++ b/maida/storage.py
@@ -30,6 +30,21 @@ logger = logging.getLogger(__name__)
 _TRACE_ID_LEN = 32
 
 
+class UnsupportedTraceFormatError(RuntimeError):
+    """A stored run uses a trace format Maida cannot project safely."""
+
+    def __init__(self, run_id: str, problem: str) -> None:
+        self.run_id = run_id
+        self.problem = problem
+        short = run_id[:8] if isinstance(run_id, str) and run_id else "unknown"
+        super().__init__(
+            f"unsupported trace format for run {short}: {problem}. "
+            "The earliest fully supported trace format is 0.2. "
+            "Next step: rerun the traced agent to create a fresh trace, "
+            "or run `maida demo` to create a known-good local trace."
+        )
+
+
 def _validate_trace_id(trace_id: str) -> str:
     """Validate that trace_id is a 32-char hex string (no path traversal)."""
     if not trace_id or not isinstance(trace_id, str):
@@ -199,6 +214,104 @@ def load_events(run_id: str, config: MaidaConfig) -> list[dict]:
     return events
 
 
+def _current_trace_meta_exists(run_id: str, config: MaidaConfig) -> bool:
+    try:
+        return _meta_path(run_id, config).is_file()
+    except ValueError:
+        return False
+
+
+def _load_legacy_events_jsonl(run_id: str, config: MaidaConfig) -> list[dict]:
+    path = _legacy_run_dir(run_id, config) / EVENTS_JSONL
+    if not path.is_file():
+        return []
+    events: list[dict] = []
+    with open(path, "r", encoding="utf-8") as f:
+        for line_no, line in enumerate(f, start=1):
+            line = line.strip()
+            if not line:
+                continue
+            try:
+                event = json.loads(line)
+            except json.JSONDecodeError:
+                raise UnsupportedTraceFormatError(
+                    run_id, f"{EVENTS_JSONL} line {line_no} is malformed JSON"
+                )
+            if not isinstance(event, dict):
+                raise UnsupportedTraceFormatError(
+                    run_id, f"{EVENTS_JSONL} line {line_no} must be a JSON object"
+                )
+            events.append(event)
+    return events
+
+
+def _normalize_legacy_events(run_id: str, events: list[dict]) -> list[dict]:
+    normalized: list[dict] = []
+    for idx, event in enumerate(events, start=1):
+        event_type = event.get("event_type")
+        if not isinstance(event_type, str) or not event_type:
+            raise UnsupportedTraceFormatError(
+                run_id, f"{EVENTS_JSONL} event {idx} is missing event_type"
+            )
+
+        payload = event.get("payload")
+        if payload is None:
+            payload = {}
+        elif not isinstance(payload, dict):
+            payload = {"value": payload}
+
+        meta = event.get("meta")
+        if meta is None:
+            meta = {}
+        elif not isinstance(meta, dict):
+            meta = {"value": meta}
+
+        normalized.append(
+            {
+                "spec_version": SPEC_VERSION,
+                "event_id": str(event.get("event_id") or ""),
+                "run_id": str(event.get("run_id") or run_id),
+                "parent_id": event.get("parent_id"),
+                "event_type": event_type,
+                "ts": str(event.get("ts") or event.get("timestamp") or ""),
+                "duration_ms": event.get("duration_ms"),
+                "name": str(event.get("name") or ""),
+                "payload": payload,
+                "meta": meta,
+            }
+        )
+    normalized.sort(key=lambda e: e.get("ts", ""))
+    return normalized
+
+
+def load_run_for_analysis(
+    run_id: str, config: MaidaConfig
+) -> tuple[str, dict, list[dict]]:
+    """Load a run as event-like records for baseline/diff/assert analysis.
+
+    Current OTel traces are fully supported. Legacy ``run.json`` /
+    ``events.jsonl`` directories are supported only when they declare the
+    current ``spec_version`` and already contain event-shaped records.
+    """
+    resolved_id = resolve_run_id(run_id, config)
+    meta = load_run_meta(resolved_id, config)
+
+    if _current_trace_meta_exists(resolved_id, config):
+        spans = load_spans(resolved_id, config)
+        return resolved_id, meta, spans_to_events(spans)
+
+    declared_spec = meta.get("spec_version")
+    if declared_spec != SPEC_VERSION:
+        if declared_spec is None:
+            problem = f"{RUN_JSON} is missing spec_version"
+        else:
+            problem = f"{RUN_JSON} declares spec_version {declared_spec!r}"
+        raise UnsupportedTraceFormatError(resolved_id, problem)
+
+    events = _load_legacy_events_jsonl(resolved_id, config)
+    return resolved_id, meta, _normalize_legacy_events(resolved_id, events)
+
+
 def append_event(run_id: str, event: dict, config: MaidaConfig) -> None:
     """Compatibility wrapper for legacy event append callers."""
     path = _legacy_run_dir(run_id, config) / EVENTS_JSONL
@@ -333,6 +446,21 @@ def resolve_latest_trace_id(config: MaidaConfig) -> str:
             "No runs found. Run your traced agent first (or try `maida demo`)."
         )
     return candidates[0][1]
+
+
+def resolve_latest_run_id(config: MaidaConfig) -> str:
+    """Return the most recent run identifier, whether current trace or legacy run."""
+    runs = list_runs(limit=1, config=config)
+    if not runs:
+        raise FileNotFoundError(
+            "No runs found. Run your traced agent first (or try `maida demo`)."
+        )
+    run_id = runs[0].get("trace_id") or runs[0].get("run_id")
+    if not run_id:
+        raise FileNotFoundError(
+            "No runs found. Run your traced agent first (or try `maida demo`)."
+        )
+    return str(run_id)
 
 
 def resolve_run_id(prefix: str, config: MaidaConfig) -> str:

--- a/tests/test_legacy_compat.py
+++ b/tests/test_legacy_compat.py
@@ -1,0 +1,181 @@
+"""Compatibility tests for legacy run.json/events.jsonl storage layouts."""
+
+import json
+
+import pytest
+from typer.testing import CliRunner
+
+from maida.assertions import AssertionPolicy, run_assertions
+from maida.baseline import create_baseline
+from maida.cli import app
+from maida.config import load_config
+from maida.diff import compute_diff
+from maida.events import EventType
+from maida.storage import UnsupportedTraceFormatError, load_run_for_analysis
+
+runner = CliRunner()
+
+
+def _event(run_id, event_type, name, payload=None, *, ts="2026-01-01T00:00:00.000Z"):
+    return {
+        "spec_version": "0.2",
+        "event_id": f"{name}-event",
+        "run_id": run_id,
+        "parent_id": None,
+        "event_type": event_type,
+        "ts": ts,
+        "duration_ms": 10,
+        "name": name,
+        "payload": payload or {},
+        "meta": {},
+    }
+
+
+def _write_legacy_run(config, run_id, *, spec_version="0.2", events=None):
+    run_dir = config.data_dir / "runs" / run_id
+    run_dir.mkdir(parents=True, exist_ok=True)
+    meta = {
+        "spec_version": spec_version,
+        "run_id": run_id,
+        "run_name": f"legacy-{run_id}",
+        "started_at": "2026-01-01T00:00:00.000Z",
+        "ended_at": "2026-01-01T00:00:00.100Z",
+        "duration_ms": 100,
+        "status": "ok",
+        "counts": {"llm_calls": 0, "tool_calls": 1, "errors": 0, "loop_warnings": 0},
+    }
+    (run_dir / "run.json").write_text(json.dumps(meta), encoding="utf-8")
+    lines = [json.dumps(event) for event in events or []]
+    (run_dir / "events.jsonl").write_text("\n".join(lines) + "\n", encoding="utf-8")
+    return meta
+
+
+def test_legacy_02_run_projects_into_structural_paths(temp_data_dir):
+    config = load_config()
+    run_id = "legacy-run-02"
+    baseline_id = "legacy-baseline-02"
+    _write_legacy_run(
+        config,
+        baseline_id,
+        events=[
+            _event(baseline_id, EventType.RUN_START.value, "baseline"),
+            _event(
+                baseline_id,
+                EventType.TOOL_CALL.value,
+                "search",
+                {"tool_name": "search", "args": {}, "result": "ok", "status": "ok"},
+            ),
+            _event(baseline_id, EventType.RUN_END.value, "baseline", {"status": "ok"}),
+        ],
+    )
+    _write_legacy_run(
+        config,
+        run_id,
+        events=[
+            _event(run_id, EventType.RUN_START.value, "current"),
+            _event(
+                run_id,
+                EventType.TOOL_CALL.value,
+                "search",
+                {"tool_name": "search", "args": {}, "result": "ok", "status": "ok"},
+            ),
+            _event(
+                run_id,
+                EventType.TOOL_CALL.value,
+                "parse",
+                {"tool_name": "parse", "args": {}, "result": "ok", "status": "ok"},
+            ),
+            _event(run_id, EventType.RUN_END.value, "current", {"status": "ok"}),
+        ],
+    )
+
+    resolved_id, meta, events = load_run_for_analysis(run_id, config)
+    baseline = create_baseline(baseline_id, config)
+    diff = compute_diff(run_id, baseline=baseline, config=config)
+    report = run_assertions(
+        run_id,
+        AssertionPolicy(no_new_tools=True, max_tool_calls=3, step_tolerance=10.0),
+        baseline=baseline,
+        config=config,
+    )
+
+    assert resolved_id == run_id
+    assert meta["run_name"] == "legacy-legacy-run-02"
+    assert [event["event_type"] for event in events] == [
+        EventType.RUN_START.value,
+        EventType.TOOL_CALL.value,
+        EventType.TOOL_CALL.value,
+        EventType.RUN_END.value,
+    ]
+    assert baseline["summary"]["tool_calls"] == 1
+    assert diff.new_tools == ["parse"]
+    assert not report.passed
+    assert [result.check_name for result in report.results if not result.passed] == [
+        "new_tools"
+    ]
+
+
+def test_unsupported_legacy_trace_fails_with_upgrade_guidance(temp_data_dir):
+    config = load_config()
+    run_id = "legacy-run-01"
+    _write_legacy_run(
+        config,
+        run_id,
+        spec_version="0.1",
+        events=[
+            _event(
+                run_id,
+                EventType.TOOL_CALL.value,
+                "search",
+                {"secret": "sk-test-DO-NOT-LEAK"},
+            )
+        ],
+    )
+
+    with pytest.raises(UnsupportedTraceFormatError) as excinfo:
+        load_run_for_analysis(run_id, config)
+
+    message = str(excinfo.value)
+    assert "unsupported trace format" in message
+    assert "0.2" in message
+    assert "maida demo" in message
+    assert "sk-test-DO-NOT-LEAK" not in message
+
+
+def test_cli_reports_unsupported_legacy_trace_as_user_error(temp_data_dir):
+    config = load_config()
+    run_id = "legacy-cli-01"
+    _write_legacy_run(config, run_id, spec_version="0.1")
+
+    result = runner.invoke(
+        app, ["baseline", run_id, "--out", str(temp_data_dir / "bl.json")]
+    )
+
+    assert result.exit_code == 2
+    assert "unsupported trace format" in result.stderr
+    assert "maida demo" in result.stderr
+
+
+def test_cli_export_uses_supported_legacy_projection(temp_data_dir):
+    config = load_config()
+    run_id = "legacy-export-02"
+    _write_legacy_run(
+        config,
+        run_id,
+        events=[
+            _event(
+                run_id,
+                EventType.TOOL_CALL.value,
+                "search",
+                {"tool_name": "search", "args": {}, "result": "ok", "status": "ok"},
+            )
+        ],
+    )
+    out = temp_data_dir / "legacy-export.json"
+
+    result = runner.invoke(app, ["export", run_id, "--out", str(out)])
+
+    assert result.exit_code == 0
+    payload = json.loads(out.read_text())
+    assert payload["run"]["run_id"] == run_id
+    assert payload["events"][0]["event_type"] == EventType.TOOL_CALL.value


### PR DESCRIPTION
Added a thin compatibility analysis path for legacy `run.json` / `events.jsonl`
runs that declare the current `spec_version: "0.2"` and already contain
event-shaped records. Current OTel `meta.json` / `spans.jsonl` traces remain
the fully supported format. Pre-0.2 legacy traces now fail gracefully with
clear upgrade guidance instead of falling through to generic errors.


- Added `UnsupportedTraceFormatError` with sanitized upgrade guidance.
- Added `load_run_for_analysis()` in `maida.storage` to load:
  - current OTel traces through `spans_to_events()`
  - supported legacy `run.json` / `events.jsonl` traces through a normalized
    event-like projection
- Added `resolve_latest_run_id()` so default read paths can choose either a
  current trace ID or a legacy run ID from the existing `list_runs()` ordering.
- Routed baseline creation, assertions, diffs, and export through the shared
  analysis loader.
- Updated CLI baseline/assert/diff/export handling so unsupported legacy traces
  exit as user-facing not-found/invalid input errors with upgrade guidance.
- Added `tests/test_legacy_compat.py` covering:
  - supported legacy 0.2 projection into baseline/diff/assert paths
  - unsupported 0.1 graceful failure without payload leakage
  - CLI baseline error reporting for unsupported legacy traces
  - CLI export of supported legacy projections

Fixes #53 