### PR TITLE
Bump the CI actions versions

### DIFF
--- a/.github/workflows/lint-format.yml
+++ b/.github/workflows/lint-format.yml
@@ -6,6 +6,6 @@ jobs:
   lint:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: astral-sh/ruff-action@v3
+      - uses: actions/checkout@v7
+      - uses: astral-sh/ruff-action@v4.0.0
       - run: ruff format --config=ruff.toml --check

--- a/.github/workflows/runapp.yml
+++ b/.github/workflows/runapp.yml
@@ -5,6 +5,7 @@ on:
     paths:
       - maida/**
       - scripts/**
+      - .github/workflows/**
 
 env:
   PYTHON_VERSION: "3.10"
@@ -18,10 +19,10 @@ jobs:
     timeout-minutes: 15
 
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
 
       - name: Install uv
-        uses: astral-sh/setup-uv@v7
+        uses: astral-sh/setup-uv@v8.2.0
         with:
           version: ${{ env.UV_VERSION }}
           python-version: ${{ env.PYTHON_VERSION }}
@@ -88,7 +89,7 @@ jobs:
 
       - name: Upload server log (on failure)
         if: failure()
-        uses: actions/upload-artifact@v6
+        uses: actions/upload-artifact@v7
         with:
           name: server-log
           path: server.log

--- a/.github/workflows/unittest-fast.yml
+++ b/.github/workflows/unittest-fast.yml
@@ -8,12 +8,14 @@ on:
       - pyproject.toml
       - maida/**
       - tests/**
+      - .github/workflows/**
   pull_request:
     branches: [main]
     paths:
       - pyproject.toml
       - maida/**
       - tests/**
+      - .github/workflows/**
 
 env:
   UV_VERSION: "0.11.14"
@@ -25,9 +27,9 @@ jobs:
       matrix:
         python-version: ["3.10", "3.12", "3.13"]
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
       - name: Install uv
-        uses: astral-sh/setup-uv@v7
+        uses: astral-sh/setup-uv@v8.2.0
         with:
           version: ${{ env.UV_VERSION }}
           python-version: ${{ matrix.python-version }}


### PR DESCRIPTION
- `actions/checkout` -> v7
- `astral-sh/ruff-actions` -> v4.0.0
  - TODO: Once stable, should point to tag `v4`
- `astral-sh/setup-uv` -> v8.2.0
  - TODO: Once stable, should point to tag `v8`

This also forces all actions to run if CI workflow changes