### PR TITLE
Add regression reason codes

### DIFF
--- a/docs/cli.md
+++ b/docs/cli.md
@@ -236,7 +236,7 @@ maida assert --baseline baseline.json --format markdown
 
 **Exit codes:** `0` all checks passed; `1` one or more checks failed; `2` run or baseline not found; `10` internal error.
 
-When a baseline is provided, the markdown report leads with a pass/fail verdict, lists failed checks first with expected vs actual values, collapses passing checks, and embeds a **What changed vs baseline** section (metric deltas, new/removed tools, model changes) plus a local-repro snippet. The text report appends the structural diff on failure.
+Each assertion result includes a stable `reason_code`; JSON output also includes a top-level `reason_codes` array for failed checks. Markdown output groups failed checks by reason code so PR comments can cluster related failures. When a baseline is provided, the markdown report embeds a **What changed vs baseline** section (metric deltas, new/removed tools, model changes) plus a local-repro snippet. The text report appends the structural diff on failure.
 
 ---
 

--- a/docs/reference/policy.md
+++ b/docs/reference/policy.md
@@ -91,6 +91,26 @@ for that metric.
 
 ---
 
+## Reason codes
+
+`maida assert` emits stable reason codes in text, JSON, and Markdown output. Passing checks use `no_regression`; failed checks use one of the product-facing codes below.
+
+| Reason code | Check |
+|---|---|
+| `step_count_exceeded` | Step/event count exceeded the baseline envelope or hard cap |
+| `new_tool_path` | A tool appeared that was not present in the baseline |
+| `tool_call_count_exceeded` | Tool call count exceeded the baseline envelope or hard cap |
+| `loop_detected` | One or more `LOOP_WARNING` events were detected |
+| `cycle_detected` | Reserved (not yet emitted) for graph/cycle checks that detect cyclic behavior |
+| `terminal_state_missing` | The run did not end in the expected terminal status |
+| `guardrail_event_changed` | Guardrail-triggered events were detected |
+| `latency_envelope_exceeded` | Run duration exceeded the baseline envelope or hard cap |
+| `cost_envelope_exceeded` | Token usage exceeded the baseline envelope or hard cap |
+
+Machine-readable JSON includes a top-level `reason_codes` array containing the failed reason codes in result order, plus `reason_code` on every individual result. Markdown groups failed checks by reason code for PR comments.
+
+---
+
 ## Override rules
 
 When `maida assert` loads a policy file and also receives CLI flags, `merge_policy` applies these rules:

--- a/docs/regression-testing.md
+++ b/docs/regression-testing.md
@@ -126,10 +126,10 @@ maida assert <TRACE_ID> --baseline baseline.json
 ```
 
 ```
-  ✓ step_count: 42 steps (baseline: 38, tolerance: 50%)
-  ✓ tool_calls: 12 tool calls (baseline: 10, tolerance: 50%)
-  ✗ no_loops: 2 loop warning(s) detected
-  ✓ expect_status: status is 'ok'
+  ✓ step_count [no_regression]: 42 steps (baseline: 38, tolerance: 50%)
+  ✓ tool_calls [no_regression]: 12 tool calls (baseline: 10, tolerance: 50%)
+  ✗ no_loops [loop_detected]: 2 loop warning(s) detected
+  ✓ expect_status [no_regression]: status is 'ok'
 
 RESULT: FAILED (1 of 4 checks failed)
 ```
@@ -145,10 +145,12 @@ maida assert <TRACE_ID> --baseline baseline.json --format json
   "run_id": "a1b2c3d4-...",
   "baseline_run_id": "e5f6a7b8-...",
   "passed": false,
+  "reason_codes": ["loop_detected"],
   "results": [
     {
       "check_name": "step_count",
       "passed": true,
+      "reason_code": "no_regression",
       "message": "42 steps (baseline: 38, tolerance: 50%)",
       "expected": "57",
       "actual": "42"
@@ -156,6 +158,7 @@ maida assert <TRACE_ID> --baseline baseline.json --format json
     {
       "check_name": "no_loops",
       "passed": false,
+      "reason_code": "loop_detected",
       "message": "2 loop warning(s) detected",
       "expected": null,
       "actual": "2"
@@ -177,6 +180,10 @@ maida assert --baseline baseline.json --format markdown
 
 **1 of 4 checks failed** · run `a1b2c3d4` vs baseline `e5f6a7b8`
 
+### Failed checks by reason
+
+#### `loop_detected`
+
 | Check | Expected | Actual | Details |
 |---|---|---|---|
 | ❌ `no_loops` | — | 2 | 2 loop warning(s) detected |
@@ -197,7 +204,7 @@ maida assert --baseline baseline.json --format markdown
 - ➕ `web_search` — new tool, not in baseline
 ```
 
-The report leads with the verdict, lists failed checks first with expected vs actual values, collapses passing checks, and — when a baseline is provided — embeds the structural diff and a copy-pasteable local-repro snippet.
+The report leads with the verdict, groups failed checks by stable reason code, collapses passing checks, and — when a baseline is provided — embeds the structural diff and a copy-pasteable local-repro snippet.
 
 ---
 

--- a/maida/assertions.py
+++ b/maida/assertions.py
@@ -7,6 +7,7 @@ results are collected into an ``AssertionReport`` with an overall pass/fail.
 
 import json
 from dataclasses import dataclass, field
+from enum import Enum
 from typing import TYPE_CHECKING, Any
 
 if TYPE_CHECKING:
@@ -19,6 +20,21 @@ from maida.storage import load_run_for_analysis
 
 
 kDefaultTolerance = 0.5  # 50% global default
+
+
+class RegressionReasonCode(str, Enum):
+    """Stable reason codes for assertion decisions and PR comment grouping."""
+
+    NO_REGRESSION = "no_regression"
+    STEP_COUNT_EXCEEDED = "step_count_exceeded"
+    NEW_TOOL_PATH = "new_tool_path"
+    TOOL_CALL_COUNT_EXCEEDED = "tool_call_count_exceeded"
+    LOOP_DETECTED = "loop_detected"
+    CYCLE_DETECTED = "cycle_detected"  # reserved - not yet emitted
+    TERMINAL_STATE_MISSING = "terminal_state_missing"
+    GUARDRAIL_EVENT_CHANGED = "guardrail_event_changed"
+    LATENCY_ENVELOPE_EXCEEDED = "latency_envelope_exceeded"
+    COST_ENVELOPE_EXCEEDED = "cost_envelope_exceeded"
 
 
 @dataclass
@@ -57,6 +73,7 @@ class AssertionResult:
     check_name: str
     passed: bool
     message: str
+    reason_code: RegressionReasonCode = RegressionReasonCode.NO_REGRESSION
     expected: str | None = None
     actual: str | None = None
 
@@ -75,6 +92,27 @@ class AssertionReport:
         if not result.passed:
             self.passed = False
 
+    @property
+    def reason_codes(self) -> list[RegressionReasonCode]:
+        """Failure reason codes in result order, de-duplicated for machines."""
+        return list(
+            dict.fromkeys(
+                result.reason_code for result in self.results if not result.passed
+            )
+        )
+
+
+def _reason_code_for(
+    passed: bool, failure_code: RegressionReasonCode
+) -> RegressionReasonCode:
+    return RegressionReasonCode.NO_REGRESSION if passed else failure_code
+
+
+def _reason_code_text(reason_code: RegressionReasonCode | str) -> str:
+    if isinstance(reason_code, RegressionReasonCode):
+        return reason_code.value
+    return str(reason_code)
+
 
 def _check_threshold(
     actual: int | float,
@@ -82,6 +120,7 @@ def _check_threshold(
     tolerance: float,
     standalone_max: int | float | None,
     check_name: str,
+    reason_code: RegressionReasonCode,
     unit: str,
 ) -> AssertionResult | None:
     """Shared threshold/tolerance comparison for numeric metrics.
@@ -104,6 +143,7 @@ def _check_threshold(
                 f"{int(actual)} {unit} (baseline: {int(baseline_value)}, "
                 f"tolerance: {tolerance:.0%}, cap: {standalone_max})"
             ),
+            reason_code=_reason_code_for(passed, reason_code),
             expected=str(int(limit)),
             actual=str(int(actual)),
         )
@@ -121,6 +161,7 @@ def _check_threshold(
                 f"{int(actual)} {unit} (baseline: {int(baseline_value)}, "
                 f"tolerance: {tolerance:.0%})"
             ),
+            reason_code=_reason_code_for(passed, reason_code),
             expected=str(int(limit)),
             actual=str(int(actual)),
         )
@@ -131,6 +172,7 @@ def _check_threshold(
             check_name=check_name,
             passed=passed,
             message=f"{int(actual)} {unit} (max: {standalone_max})",
+            reason_code=_reason_code_for(passed, reason_code),
             expected=str(standalone_max),
             actual=str(int(actual)),
         )
@@ -175,6 +217,7 @@ def run_assertions(
         tolerance=policy.step_tolerance,
         standalone_max=policy.max_steps,
         check_name="step_count",
+        reason_code=RegressionReasonCode.STEP_COUNT_EXCEEDED,
         unit="steps",
     )
     if r:
@@ -187,6 +230,7 @@ def run_assertions(
         tolerance=policy.tool_call_tolerance,
         standalone_max=policy.max_tool_calls,
         check_name="tool_calls",
+        reason_code=RegressionReasonCode.TOOL_CALL_COUNT_EXCEEDED,
         unit="tool calls",
     )
     if r:
@@ -204,6 +248,9 @@ def run_assertions(
                 passed=passed,
                 message=(
                     "no new tools" if passed else f"unexpected tools used: {new_tools}"
+                ),
+                reason_code=_reason_code_for(
+                    passed, RegressionReasonCode.NEW_TOOL_PATH
                 ),
                 expected="none",
                 actual=str(new_tools) if new_tools else "none",
@@ -223,6 +270,9 @@ def run_assertions(
                     if passed
                     else f"{loop_count} loop warning(s) detected"
                 ),
+                reason_code=_reason_code_for(
+                    passed, RegressionReasonCode.LOOP_DETECTED
+                ),
                 actual=str(loop_count),
             )
         )
@@ -240,6 +290,9 @@ def run_assertions(
                     if passed
                     else f"{gr_count} guardrail event(s) detected"
                 ),
+                reason_code=_reason_code_for(
+                    passed, RegressionReasonCode.GUARDRAIL_EVENT_CHANGED
+                ),
                 actual=str(gr_count),
             )
         )
@@ -251,6 +304,7 @@ def run_assertions(
         tolerance=policy.cost_tolerance,
         standalone_max=policy.max_cost_tokens,
         check_name="cost_tokens",
+        reason_code=RegressionReasonCode.COST_ENVELOPE_EXCEEDED,
         unit="tokens",
     )
     if r:
@@ -263,6 +317,7 @@ def run_assertions(
         tolerance=policy.duration_tolerance,
         standalone_max=policy.max_duration_ms,
         check_name="duration",
+        reason_code=RegressionReasonCode.LATENCY_ENVELOPE_EXCEEDED,
         unit="ms",
     )
     if r:
@@ -280,6 +335,9 @@ def run_assertions(
                     f"status is '{actual_status}'"
                     if passed
                     else f"expected '{policy.expect_status}', got '{actual_status}'"
+                ),
+                reason_code=_reason_code_for(
+                    passed, RegressionReasonCode.TERMINAL_STATE_MISSING
                 ),
                 expected=policy.expect_status,
                 actual=actual_status,
@@ -307,7 +365,9 @@ def format_report_text(report: AssertionReport, diff: "RunDiff | None" = None) -
     lines: list[str] = []
     for r in report.results:
         mark = _PASS if r.passed else _FAIL
-        lines.append(f"  {mark} {r.check_name}: {r.message}")
+        lines.append(
+            f"  {mark} {r.check_name} [{_reason_code_text(r.reason_code)}]: {r.message}"
+        )
     total = len(report.results)
     failed = sum(1 for r in report.results if not r.passed)
     if total == 0:
@@ -330,10 +390,12 @@ def format_report_json(report: AssertionReport) -> str:
         "run_id": report.run_id,
         "baseline_run_id": report.baseline_run_id,
         "passed": report.passed,
+        "reason_codes": [_reason_code_text(code) for code in report.reason_codes],
         "results": [
             {
                 "check_name": r.check_name,
                 "passed": r.passed,
+                "reason_code": _reason_code_text(r.reason_code),
                 "message": r.message,
                 "expected": r.expected,
                 "actual": r.actual,
@@ -378,13 +440,23 @@ def format_report_markdown(
         lines.append(f"**All {len(report.results)} checks passed** \u00b7 {scope}")
 
     if failed:
-        lines += ["", "| Check | Expected | Actual | Details |", "|---|---|---|---|"]
-        for r in failed:
-            expected = r.expected or "\u2014"
-            actual = r.actual or "\u2014"
-            lines.append(
-                f"| \u274c `{r.check_name}` | {expected} | {actual} | {r.message} |"
-            )
+        seen_reason_codes = report.reason_codes
+        lines += ["", "### Failed checks by reason"]
+        for reason_code in seen_reason_codes:
+            reason_failures = [r for r in failed if r.reason_code == reason_code]
+            lines += [
+                "",
+                f"#### `{_reason_code_text(reason_code)}`",
+                "",
+                "| Check | Expected | Actual | Details |",
+                "|---|---|---|---|",
+            ]
+            for r in reason_failures:
+                expected = r.expected or "\u2014"
+                actual = r.actual or "\u2014"
+                lines.append(
+                    f"| \u274c `{r.check_name}` | {expected} | {actual} | {r.message} |"
+                )
 
     if passed:
         lines += [

--- a/tests/test_assertions.py
+++ b/tests/test_assertions.py
@@ -7,6 +7,7 @@ import pytest
 from maida import record_llm_call, record_tool_call, traced_run
 from maida.assertions import (
     AssertionPolicy,
+    RegressionReasonCode,
     _check_threshold,
     format_report_json,
     format_report_markdown,
@@ -17,6 +18,21 @@ from maida.baseline import create_baseline
 from maida.config import load_config
 from maida.events import EventType
 from tests.conftest import get_latest_run_id
+
+
+def test_regression_reason_code_vocabulary_is_stable():
+    assert {code.value for code in RegressionReasonCode} == {
+        "no_regression",
+        "step_count_exceeded",
+        "new_tool_path",
+        "tool_call_count_exceeded",
+        "loop_detected",
+        "cycle_detected",
+        "terminal_state_missing",
+        "guardrail_event_changed",
+        "latency_envelope_exceeded",
+        "cost_envelope_exceeded",
+    }
 
 
 def _make_run(config, *, name="test_run", events=None, status="ok"):
@@ -102,6 +118,8 @@ def test_max_steps_fails_at_n_plus_one(temp_data_dir):
     report = run_assertions(run_id, policy, config=config)
     assert report.passed is False
     assert any(r.check_name == "step_count" and not r.passed for r in report.results)
+    step_result = next(r for r in report.results if r.check_name == "step_count")
+    assert step_result.reason_code == RegressionReasonCode.STEP_COUNT_EXCEEDED.value
 
 
 def test_max_tool_calls_boundary(temp_data_dir):
@@ -175,6 +193,7 @@ def test_zero_baseline_with_standalone_cap_uses_cap_as_limit():
         tolerance=0.5,
         standalone_max=10,
         check_name="step_count",
+        reason_code=RegressionReasonCode.STEP_COUNT_EXCEEDED,
         unit="steps",
     )
 
@@ -190,6 +209,7 @@ def test_zero_baseline_without_standalone_cap_allows_no_growth():
         tolerance=0.5,
         standalone_max=None,
         check_name="step_count",
+        reason_code=RegressionReasonCode.STEP_COUNT_EXCEEDED,
         unit="steps",
     )
 
@@ -251,6 +271,7 @@ def test_no_new_tools_fails_on_new_tool(temp_data_dir):
     assert report.passed is False
     tool_result = next(r for r in report.results if r.check_name == "new_tools")
     assert "salesforce_api" in tool_result.message
+    assert tool_result.reason_code == RegressionReasonCode.NEW_TOOL_PATH.value
 
 
 # ---------------------------------------------------------------------------
@@ -282,6 +303,7 @@ def test_no_loops_fails_when_present(temp_data_dir):
     assert report.passed is False
     loop_result = next(r for r in report.results if r.check_name == "no_loops")
     assert loop_result.actual == "1"
+    assert loop_result.reason_code == RegressionReasonCode.LOOP_DETECTED.value
 
 
 # ---------------------------------------------------------------------------
@@ -342,6 +364,8 @@ def test_max_cost_tokens_fails(temp_data_dir):
     policy = AssertionPolicy(max_cost_tokens=100)
     report = run_assertions(run_id, policy, config=config)
     assert report.passed is False
+    cost_result = next(r for r in report.results if r.check_name == "cost_tokens")
+    assert cost_result.reason_code == RegressionReasonCode.COST_ENVELOPE_EXCEEDED.value
 
 
 # ---------------------------------------------------------------------------
@@ -377,6 +401,10 @@ def test_expect_status_mismatch(temp_data_dir):
     policy = AssertionPolicy(expect_status="ok")
     report = run_assertions(run_id, policy, config=config)
     assert report.passed is False
+    status_result = next(r for r in report.results if r.check_name == "expect_status")
+    assert (
+        status_result.reason_code == RegressionReasonCode.TERMINAL_STATE_MISSING.value
+    )
 
 
 # ---------------------------------------------------------------------------
@@ -424,6 +452,19 @@ def test_format_report_text_contains_verdict(temp_data_dir):
     assert "PASSED" in text
 
 
+def test_format_report_text_includes_reason_code(temp_data_dir):
+    config = load_config()
+    events = [(EventType.TOOL_CALL, f"t{i}", {}) for i in range(5)]
+    run_id = _make_run(config, events=events)
+    policy = AssertionPolicy(max_steps=2, no_loops=True)
+    report = run_assertions(run_id, policy, config=config)
+
+    text = format_report_text(report)
+
+    assert "[step_count_exceeded]" in text
+    assert "[no_regression]" in text
+
+
 def test_format_report_json_valid(temp_data_dir):
     config = load_config()
     run_id = _make_run(config, events=[])
@@ -432,6 +473,22 @@ def test_format_report_json_valid(temp_data_dir):
     data = json.loads(format_report_json(report))
     assert data["passed"] is True
     assert "results" in data
+    assert data["results"][0]["reason_code"] == RegressionReasonCode.NO_REGRESSION.value
+
+
+def test_format_report_json_emits_stable_reason_codes(temp_data_dir):
+    config = load_config()
+    events = [(EventType.TOOL_CALL, f"t{i}", {}) for i in range(3)]
+    run_id = _make_run(config, events=events)
+    policy = AssertionPolicy(max_steps=1)
+    report = run_assertions(run_id, policy, config=config)
+
+    data = json.loads(format_report_json(report))
+
+    assert data["reason_codes"] == [RegressionReasonCode.STEP_COUNT_EXCEEDED.value]
+    assert data["results"][0]["reason_code"] == (
+        RegressionReasonCode.STEP_COUNT_EXCEEDED.value
+    )
 
 
 def test_format_report_markdown_pass_layout(temp_data_dir):
@@ -444,6 +501,7 @@ def test_format_report_markdown_pass_layout(temp_data_dir):
     assert "## ✅ Maida gate: no behavioral regression" in md
     assert "<details>" in md  # passing checks are collapsed
     assert "passing checks" in md
+    assert "`no_regression`:" not in md
     assert "Reproduce locally" in md
     assert "maida.ai" in md
 
@@ -458,9 +516,26 @@ def test_format_report_markdown_failed_checks_first(temp_data_dir):
     assert "## ❌ Maida gate: agent behavior regressed" in md
     assert "1 of 2 checks failed" in md
     # failed table with expected/actual comes before the collapsed passing block
-    assert md.index("| Check | Expected | Actual |") < md.index("<details>")
-    assert "❌ `step_count`" in md
+    assert md.index("#### `step_count_exceeded`") < md.index("<details>")
+    assert "| Check | Expected | Actual | Details |" in md
+    assert "| ❌ `step_count` |" in md
     assert "✅ `no_loops`" in md
+
+
+def test_format_report_markdown_groups_failures_by_reason_code(temp_data_dir):
+    config = load_config()
+    events = [(EventType.TOOL_CALL, f"t{i}", {}) for i in range(5)]
+    run_id = _make_run(config, events=events)
+    policy = AssertionPolicy(max_steps=2, max_tool_calls=2)
+    report = run_assertions(run_id, policy, config=config)
+
+    md = format_report_markdown(report)
+
+    assert "#### `step_count_exceeded`" in md
+    assert "#### `tool_call_count_exceeded`" in md
+    assert md.index("#### `step_count_exceeded`") < md.index(
+        "#### `tool_call_count_exceeded`"
+    )
 
 
 def test_format_report_markdown_includes_diff_section(temp_data_dir):


### PR DESCRIPTION
Added stable regression reason codes for assertion decisions so text output, JSON output, Markdown PR comments, and docs share one explanation model. The implementation keeps existing assertion checks intact while adding product-facing reason codes and grouped Markdown failure sections.

- Added `RegressionReasonCode` to `maida.assertions` with the issue-required vocabulary, including reserved `cycle_detected`.
- Added `reason_code` to each `AssertionResult` and a de-duplicated `AssertionReport.reason_codes` view for failed checks.
- Threaded reason codes through numeric thresholds, new-tool checks, loop checks, guardrail checks, cost/latency envelopes, and terminal-status checks.
- Updated text output to include each result's reason code.
- Updated JSON output to include top-level failed `reason_codes` and per-result `reason_code`.
- Updated Markdown output to group failed checks by reason code for PR comments while preserving passing-check collapse and diff sections.
- Added unit coverage for the stable vocabulary, per-check mappings, JSON output, and Markdown grouping.
- Updated CLI, regression-testing, and policy docs for the new output contract.

Fixes #57