### PR TITLE
Improve tool path diffs

### DIFF
--- a/docs/cli.md
+++ b/docs/cli.md
@@ -181,7 +181,7 @@ maida baseline a1b2c3d4 --out baselines/support_agent_v1.json
 
 **Exit codes:** `0` success; `2` run not found; `10` internal error.
 
-The output file is a JSON object containing `schema_version`, `source_run_id`, summary metrics, `tool_path`, `tool_call_counts`, `llm_models_used`, `event_type_sequence`, and `final_status`. Check it into version control to share the baseline with your team.
+The output file is a JSON object containing `schema_version`, `source_run_id`, summary metrics, `tool_path`, ordered `tool_call_sequence`, `tool_call_counts`, `llm_models_used`, `event_type_sequence`, and `final_status`. Check it into version control to share the baseline with your team.
 
 ---
 
@@ -275,6 +275,7 @@ maida diff --baseline .maida/baselines/my_agent.json
 
 **Text output sections:**
 
-- **Summary** — metric-by-metric comparison with percentage change (e.g. `tool_calls: 10 -> 14 (+40%)`)
-- **Tool path changes** — new (`+`) and removed (`-`) tools
+- **Summary** — metric-by-metric comparison with percentage change (e.g. `step_count: 38 -> 42 (+11%)`)
+- **Tool path** — compact baseline/current tool-call sequences, with long paths truncated in the middle
+- **Tool call changes** — new (`+`), removed (`-`), repeated (`~`), and reordered (`!`) tool calls
 - **Event type distribution** — per-event-type counts with percentage change

--- a/docs/regression-testing.md
+++ b/docs/regression-testing.md
@@ -44,11 +44,12 @@ maida baseline a1b2c3d4 --out baselines/support_agent_v1.json
 
 | Field | Description |
 |---|---|
-| `schema_version` | Baseline format version (`"0.1"`) |
+| `schema_version` | Baseline format version (`"0.2"`) |
 | `source_run_id` | The run this baseline was created from |
 | `source_run_name` | Run name (if set) |
 | `summary` | Aggregate metrics: total events, LLM calls, tool calls, errors, loop warnings, duration, tokens |
 | `tool_path` | Sorted list of unique tool names used |
+| `tool_call_sequence` | Ordered tool-call names, including repeated calls |
 | `tool_call_counts` | Per-tool invocation counts |
 | `llm_models_used` | Models seen in LLM_CALL events |
 | `event_type_sequence` | Ordered list of event types |
@@ -230,12 +231,18 @@ maida diff <RUN_A> <RUN_B>
 Run comparison: a1b2c3d4 vs e5f6a7b8
 
 Summary:
-  total_events: 38 -> 42 (+11%)
+  step_count: 38 -> 42 (+11%)
   tool_calls: 10 -> 14 (+40%)
   loop_warnings: 0 -> 2 (NEW)
 
-Tool path changes:
+Tool path:
+  baseline: search -> parse -> summarize
+  current: search -> parse -> web_search -> web_search -> summarize
+
+Tool call changes:
   + web_search (new)
+  ~ web_search repeated: 0 -> 2 calls
+  ! order changed for shared tool calls
 
 Event type distribution:
   LLM_CALL: 8 -> 8
@@ -243,7 +250,7 @@ Event type distribution:
   LOOP_WARNING: 0 -> 2 (NEW)
 ```
 
-The diff shows summary-level metric changes, new or removed tools, and shifts in the event type distribution.
+The diff shows summary-level metric changes, compact baseline/current tool paths, new or removed tools, repeated calls, reordered shared tools, and shifts in the event type distribution.
 
 ---
 

--- a/maida/assertions.py
+++ b/maida/assertions.py
@@ -440,9 +440,8 @@ def format_report_markdown(
         lines.append(f"**All {len(report.results)} checks passed** \u00b7 {scope}")
 
     if failed:
-        seen_reason_codes = report.reason_codes
         lines += ["", "### Failed checks by reason"]
-        for reason_code in seen_reason_codes:
+        for reason_code in report.reason_codes:
             reason_failures = [r for r in failed if r.reason_code == reason_code]
             lines += [
                 "",

--- a/maida/baseline.py
+++ b/maida/baseline.py
@@ -26,6 +26,7 @@ def extract_run_metrics(meta: dict, events: list[dict]) -> dict:
     """
     counts = meta.get("counts") or {}
     tool_names_ordered: list[str] = []
+    tool_call_sequence: list[str] = []
     tool_counter: Counter[str] = Counter()
     llm_models: set[str] = set()
     event_type_seq: list[str] = []
@@ -44,6 +45,7 @@ def extract_run_metrics(meta: dict, events: list[dict]) -> dict:
 
         if et == EventType.TOOL_CALL.value:
             name = ev.get("name", "")
+            tool_call_sequence.append(name)
             tool_counter[name] += 1
             if name not in tool_names_ordered:
                 tool_names_ordered.append(name)
@@ -77,6 +79,8 @@ def extract_run_metrics(meta: dict, events: list[dict]) -> dict:
             "total_tokens": total_tokens,
         },
         "tool_path": sorted(tool_names_ordered),
+        "tool_call_sequence": tool_call_sequence,
+        "_tool_call_sequence_exact": True,
         "tool_call_counts": dict(tool_counter),
         "llm_models_used": sorted(llm_models),
         "event_type_sequence": event_type_seq,

--- a/maida/diff.py
+++ b/maida/diff.py
@@ -22,19 +22,47 @@ class RunDiff:
     event_count_diff: dict = field(default_factory=dict)
     new_tools: list[str] = field(default_factory=list)
     removed_tools: list[str] = field(default_factory=list)
+    repeated_tools: dict[str, tuple[int, int]] = field(default_factory=dict)
+    reordered_tools: bool = False
+    current_tool_sequence: list[str] = field(default_factory=list)
+    baseline_tool_sequence: list[str] = field(default_factory=list)
     model_changes: dict = field(default_factory=dict)
 
 
+def _as_string_list(value: object) -> list[str]:
+    if not isinstance(value, list):
+        return []
+    return [item for item in value if isinstance(item, str)]
+
+
+def _as_int_counter(value: object) -> Counter[str]:
+    counter: Counter[str] = Counter()
+    if not isinstance(value, dict):
+        return counter
+    for key, count in value.items():
+        if isinstance(key, str) and isinstance(count, int) and count >= 0:
+            counter[key] = count
+    return counter
+
+
 def _metrics_from_baseline(baseline: dict) -> dict:
-    """Normalise a baseline dict into the same shape as ``extract_run_metrics``."""
+    """Normalise a baseline dict into the same shape as `extract_run_metrics`."""
+    tool_path = _as_string_list(baseline.get("tool_path"))
+    tool_call_sequence = _as_string_list(baseline.get("tool_call_sequence"))
+    exact_tool_sequence = isinstance(baseline.get("tool_call_sequence"), list)
+    if not tool_call_sequence:
+        tool_call_sequence = tool_path
     return {
         "summary": baseline.get("summary", {}),
-        "tool_path": baseline.get("tool_path", []),
+        "tool_path": tool_path,
+        "tool_call_sequence": tool_call_sequence,
+        "_tool_call_sequence_exact": exact_tool_sequence,
+        "_tool_call_counts_exact": isinstance(baseline.get("tool_call_counts"), dict),
         "tool_call_counts": baseline.get("tool_call_counts", {}),
         "llm_models_used": baseline.get("llm_models_used", []),
         "event_type_sequence": baseline.get("event_type_sequence", []),
         "guardrail_events": baseline.get("guardrail_events", []),
-        "final_status": baseline.get("final_status", ""),
+        "final_status": baseline.get("final_status", "unknown"),
     }
 
 
@@ -75,14 +103,53 @@ def compute_diff(
             summary_diff[key] = (va, vb)
 
     # --- tool path diff ---
-    tools_a = set(metrics_a["tool_path"])
-    tools_b = set(metrics_b["tool_path"])
-    tool_path_diff = {
-        "added": sorted(tools_a - tools_b),
-        "removed": sorted(tools_b - tools_a),
-        "common": sorted(tools_a & tools_b),
+    tools_a = set(_as_string_list(metrics_a.get("tool_path")))
+    tools_b = set(_as_string_list(metrics_b.get("tool_path")))
+    new_tools = sorted(tools_a - tools_b)
+    removed_tools = sorted(tools_b - tools_a)
+
+    current_tool_sequence = _as_string_list(metrics_a.get("tool_call_sequence"))
+    baseline_tool_sequence = _as_string_list(metrics_b.get("tool_call_sequence"))
+    counts_a = _as_int_counter(metrics_a.get("tool_call_counts")) or Counter(
+        current_tool_sequence
+    )
+    counts_b = _as_int_counter(metrics_b.get("tool_call_counts"))
+    counts_b_exact = bool(metrics_b.get("_tool_call_counts_exact", True))
+    repeated_tools = {
+        tool: (counts_b.get(tool, 0), current_count)
+        for tool, current_count in sorted(counts_a.items())
+        if current_count > 1
+        and (
+            tool not in tools_b
+            or (counts_b_exact and current_count > counts_b.get(tool, 0))
+        )
     }
 
+    common_tools = {
+        tool
+        for tool in counts_a
+        if counts_a[tool] and (counts_b.get(tool) or tool in tools_b)
+    }
+    exact_a = bool(metrics_a.get("_tool_call_sequence_exact"))
+    exact_b = bool(metrics_b.get("_tool_call_sequence_exact"))
+    current_common_sequence = [
+        tool for tool in current_tool_sequence if tool in common_tools
+    ]
+    baseline_common_sequence = [
+        tool for tool in baseline_tool_sequence if tool in common_tools
+    ]
+    reordered_tools = (
+        exact_a and exact_b and current_common_sequence != baseline_common_sequence
+    )
+
+    tool_path_diff = {
+        "new": new_tools,
+        "removed": removed_tools,
+        "repeated": repeated_tools,
+        "reordered": reordered_tools,
+        "current_sequence_exact": exact_a,
+        "baseline_sequence_exact": exact_b,
+    }
     # --- event count diff ---
     seq_a = Counter(metrics_a["event_type_sequence"])
     seq_b = Counter(metrics_b["event_type_sequence"])
@@ -103,8 +170,12 @@ def compute_diff(
         summary_diff=summary_diff,
         tool_path_diff=tool_path_diff,
         event_count_diff=event_count_diff,
-        new_tools=tool_path_diff["added"],
+        new_tools=tool_path_diff["new"],
         removed_tools=tool_path_diff["removed"],
+        repeated_tools=repeated_tools,
+        reordered_tools=reordered_tools,
+        current_tool_sequence=current_tool_sequence,
+        baseline_tool_sequence=baseline_tool_sequence,
         model_changes=model_changes,
     )
 
@@ -124,6 +195,57 @@ def _pct_change(a: int | float, b: int | float) -> str:
     return f"{delta:+.0f}%"
 
 
+_SUMMARY_LABELS = {"total_events": "step_count"}
+_SUMMARY_ORDER = [
+    "total_events",
+    "tool_calls",
+    "total_tokens",
+    "duration_ms",
+    "llm_calls",
+    "errors",
+    "loop_warnings",
+    "status",
+]
+_TOOL_PATH_PREVIEW_SIDE = 6
+
+
+def _summary_keys(summary_diff: dict) -> list[str]:
+    ordered = [key for key in _SUMMARY_ORDER if key in summary_diff]
+    ordered += sorted(key for key in summary_diff if key not in _SUMMARY_ORDER)
+    return ordered
+
+
+def _summary_label(key: str) -> str:
+    return _SUMMARY_LABELS.get(key, key)
+
+
+def _format_tool_sequence(sequence: list[str]) -> str:
+    preview_limit = _TOOL_PATH_PREVIEW_SIDE * 2
+    if len(sequence) <= preview_limit:
+        return " -> ".join(sequence) if sequence else "(none)"
+    head = sequence[:_TOOL_PATH_PREVIEW_SIDE]
+    tail = sequence[-_TOOL_PATH_PREVIEW_SIDE:]
+    hidden = len(sequence) - len(head) - len(tail)
+    return " -> ".join(head + [f"... ({hidden} more) ..."] + tail)
+
+
+def _has_tool_path_changes(diff: RunDiff) -> bool:
+    exact_sequences = bool(
+        diff.tool_path_diff.get("current_sequence_exact")
+        and diff.tool_path_diff.get("baseline_sequence_exact")
+    )
+    return bool(
+        diff.new_tools
+        or diff.removed_tools
+        or diff.repeated_tools
+        or diff.reordered_tools
+        or (
+            exact_sequences
+            and diff.current_tool_sequence != diff.baseline_tool_sequence
+        )
+    )
+
+
 def format_diff_text(diff: RunDiff) -> str:
     """Format a ``RunDiff`` as human-readable text."""
     lines: list[str] = [f"Run comparison: {diff.run_a_id[:8]} vs {diff.run_b_id[:8]}"]
@@ -131,22 +253,36 @@ def format_diff_text(diff: RunDiff) -> str:
     if diff.summary_diff:
         lines.append("")
         lines.append("Summary:")
-        for key, (va, vb) in sorted(diff.summary_diff.items()):
+        for key in _summary_keys(diff.summary_diff):
+            va, vb = diff.summary_diff[key]
+            label = _summary_label(key)
             if isinstance(va, (int, float)) and isinstance(vb, (int, float)):
-                lines.append(f"  {key}: {vb} -> {va} ({_pct_change(va, vb)})")
+                lines.append(f"  {label}: {vb} -> {va} ({_pct_change(va, vb)})")
             else:
-                lines.append(f"  {key}: {vb} -> {va}")
+                lines.append(f"  {label}: {vb} -> {va}")
     else:
         lines.append("")
         lines.append("Summary: identical")
 
-    if diff.new_tools or diff.removed_tools:
+    if _has_tool_path_changes(diff):
         lines.append("")
-        lines.append("Tool path changes:")
+        lines.append("Tool path:")
+        lines.append(
+            f"  baseline: {_format_tool_sequence(diff.baseline_tool_sequence)}"
+        )
+        lines.append(f"  current: {_format_tool_sequence(diff.current_tool_sequence)}")
+        lines.append("")
+        lines.append("Tool call changes:")
         for t in diff.new_tools:
             lines.append(f"  + {t} (new)")
         for t in diff.removed_tools:
             lines.append(f"  - {t} (removed)")
+        for tool, (baseline_count, current_count) in diff.repeated_tools.items():
+            lines.append(
+                f"  ~ {tool} repeated: {baseline_count} -> {current_count} calls"
+            )
+        if diff.reordered_tools:
+            lines.append("  ! order changed for shared tool calls")
 
     if diff.event_count_diff:
         lines.append("")
@@ -170,15 +306,30 @@ def format_diff_markdown(diff: RunDiff) -> str:
 
     if diff.summary_diff:
         rows = ["| Metric | Baseline | Current | Change |", "|---|---|---|---|"]
-        for key, (va, vb) in sorted(diff.summary_diff.items()):
+        for key in _summary_keys(diff.summary_diff):
+            va, vb = diff.summary_diff[key]
+            label = _summary_label(key)
             if isinstance(va, (int, float)) and isinstance(vb, (int, float)):
-                rows.append(f"| {key} | {vb} | {va} | {_pct_change(va, vb)} |")
+                rows.append(f"| {label} | {vb} | {va} | {_pct_change(va, vb)} |")
             else:
-                rows.append(f"| {key} | {vb} | {va} | changed |")
+                rows.append(f"| {label} | {vb} | {va} | changed |")
         sections.append("\n".join(rows))
+
+    if _has_tool_path_changes(diff):
+        sections.append(
+            "**Tool path:**\n"
+            f"- Baseline: `{_format_tool_sequence(diff.baseline_tool_sequence)}`\n"
+            f"- Current: `{_format_tool_sequence(diff.current_tool_sequence)}`"
+        )
 
     tool_lines = [f"- ➕ `{t}` — new tool, not in baseline" for t in diff.new_tools]
     tool_lines += [f"- ➖ `{t}` — no longer called" for t in diff.removed_tools]
+    tool_lines += [
+        f"- 🔁 `{tool}` — repeated {baseline_count} -> {current_count} calls"
+        for tool, (baseline_count, current_count) in diff.repeated_tools.items()
+    ]
+    if diff.reordered_tools:
+        tool_lines.append("- 🔀 Tool order changed for shared calls")
     if tool_lines:
         sections.append("**Tool changes:**\n" + "\n".join(tool_lines))
 

--- a/tests/test_baseline.py
+++ b/tests/test_baseline.py
@@ -87,6 +87,7 @@ def test_create_baseline_schema_keys(temp_data_dir):
         "source_run_name",
         "summary",
         "tool_path",
+        "tool_call_sequence",
         "tool_call_counts",
         "llm_models_used",
         "event_type_sequence",
@@ -180,6 +181,7 @@ def test_tool_path_ordered_unique(temp_data_dir):
     bl = create_baseline(run_id, config)
 
     assert bl["tool_path"] == sorted(["search", "parse", "format"])
+    assert bl["tool_call_sequence"] == ["search", "parse", "search", "format"]
     assert bl["tool_call_counts"] == {"search": 2, "parse": 1, "format": 1}
 
 

--- a/tests/test_diff.py
+++ b/tests/test_diff.py
@@ -175,6 +175,168 @@ def test_diff_against_baseline(temp_data_dir):
     assert d.run_b_id == bl_rid
 
 
+def test_old_baseline_tool_path_order_is_not_treated_as_exact_sequence(temp_data_dir):
+    config = load_config()
+    run_id = _make_run(
+        config,
+        name="current",
+        events=[
+            (EventType.TOOL_CALL, "search", {}),
+            (EventType.TOOL_CALL, "parse", {}),
+        ],
+    )
+    baseline = {
+        "source_run_id": "old-baseline",
+        "summary": {},
+        "tool_path": ["parse", "search"],
+        "tool_call_counts": {"parse": 1, "search": 1},
+        "llm_models_used": [],
+        "event_type_sequence": [],
+        "guardrail_events": [],
+        "final_status": "ok",
+    }
+
+    d = compute_diff(run_id, baseline=baseline, config=config)
+    text = format_diff_text(d)
+
+    assert d.reordered_tools is False
+    assert d.new_tools == []
+    assert d.removed_tools == []
+    assert "Tool path:" not in text
+    assert "Tool call changes:" not in text
+
+
+def test_old_baseline_without_call_counts_does_not_fake_repeated_tool(temp_data_dir):
+    config = load_config()
+    run_id = _make_run(
+        config,
+        name="current",
+        events=[(EventType.TOOL_CALL, "bash", {}) for _ in range(4)],
+    )
+    baseline = {
+        "source_run_id": "old-baseline",
+        "summary": {},
+        "tool_path": ["bash"],
+        "llm_models_used": [],
+        "event_type_sequence": [],
+        "guardrail_events": [],
+        "final_status": "ok",
+    }
+
+    d = compute_diff(run_id, baseline=baseline, config=config)
+    text = format_diff_text(d)
+
+    assert d.repeated_tools == {}
+    assert "~ bash repeated" not in text
+
+
+def test_baseline_with_null_tool_path_is_treated_as_empty(temp_data_dir):
+    config = load_config()
+    run_id = _make_run(config, name="current", events=[])
+    baseline = {
+        "source_run_id": "external-baseline",
+        "summary": {},
+        "tool_path": None,
+        "tool_call_counts": {},
+        "llm_models_used": [],
+        "event_type_sequence": [],
+        "guardrail_events": [],
+        "final_status": "ok",
+    }
+
+    d = compute_diff(run_id, baseline=baseline, config=config)
+
+    assert d.baseline_tool_sequence == []
+    assert d.removed_tools == []
+
+
+def test_diff_tool_path_reports_step_delta_and_tool_changes(temp_data_dir):
+    config = load_config()
+    bl_rid = _make_run(
+        config,
+        name="baseline",
+        events=[
+            (EventType.TOOL_CALL, "search", {}),
+            (EventType.TOOL_CALL, "parse", {}),
+        ],
+    )
+    baseline = create_baseline(bl_rid, config)
+
+    run_id = _make_run(
+        config,
+        name="current",
+        events=[
+            (EventType.TOOL_CALL, "search", {}),
+            (EventType.TOOL_CALL, "parse", {}),
+            (EventType.TOOL_CALL, "enrich", {}),
+            (EventType.TOOL_CALL, "enrich", {}),
+        ],
+    )
+
+    d = compute_diff(run_id, baseline=baseline, config=config)
+    text = format_diff_text(d)
+
+    assert "step_count:" in text
+    assert "baseline: search -> parse" in text
+    assert "current: search -> parse -> enrich -> enrich" in text
+    assert "+ enrich (new)" in text
+    assert "~ enrich repeated: 0 -> 2 calls" in text
+
+
+def test_diff_tool_path_identifies_removed_and_reordered_calls(temp_data_dir):
+    config = load_config()
+    bl_rid = _make_run(
+        config,
+        name="baseline",
+        events=[
+            (EventType.TOOL_CALL, "search", {}),
+            (EventType.TOOL_CALL, "parse", {}),
+            (EventType.TOOL_CALL, "summarize", {}),
+        ],
+    )
+    baseline = create_baseline(bl_rid, config)
+
+    run_id = _make_run(
+        config,
+        name="current",
+        events=[
+            (EventType.TOOL_CALL, "parse", {}),
+            (EventType.TOOL_CALL, "search", {}),
+        ],
+    )
+
+    d = compute_diff(run_id, baseline=baseline, config=config)
+    text = format_diff_text(d)
+
+    assert "- summarize (removed)" in text
+    assert "order changed for shared tool calls" in text
+
+
+def test_diff_tool_path_truncates_long_sequences(temp_data_dir):
+    from maida.diff import format_diff_markdown
+
+    config = load_config()
+    bl_rid = _make_run(
+        config,
+        name="baseline",
+        events=[(EventType.TOOL_CALL, f"tool_{i}", {}) for i in range(16)],
+    )
+    baseline = create_baseline(bl_rid, config)
+
+    run_id = _make_run(
+        config,
+        name="current",
+        events=[(EventType.TOOL_CALL, f"tool_{i}", {}) for i in range(20)],
+    )
+
+    d = compute_diff(run_id, baseline=baseline, config=config)
+    md = format_diff_markdown(d)
+
+    assert "... (8 more) ..." in md
+    assert "tool_19" in md
+    assert "tool_8 -> tool_9 -> tool_10" not in md
+
+
 def test_diff_returns_resolved_left_trace_id(temp_data_dir):
     config = load_config()
     run_a = "a0eebc99" + "a" * 24


### PR DESCRIPTION
Implemented richer structural diffs for step count and tool-call path changes. Baselines now capture an ordered `tool_call_sequence`, and diffs use that sequence to show compact baseline/current paths and classify new, removed, repeated, and reordered tool calls.

- Added `tool_call_sequence` to baseline metric extraction and baseline output while preserving the existing sorted unique `tool_path`.
- Extended `RunDiff` with baseline/current tool sequences, repeated tool counts, and reorder detection.
- Updated text diffs to display `step_count`, compact baseline/current tool paths, and `+`, `-`, `~`, and `!` tool-call change markers.
- Updated Markdown diffs embedded in assertion reports with compact tool-path previews and richer tool change bullets.
- Kept long traces readable by truncating long tool sequences in the middle.
- Added regression tests for baseline sequence capture, step deltas, new/repeated tools, removed/reordered tools, and long path truncation.
- Updated CLI and regression-testing docs for the new baseline field and diff output.

Fixes #58