### PR TITLE
Harden loop cycle detection

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -33,7 +33,7 @@ Maida also projects spans into a flat event view for baselines, diffs, assertion
 | `TOOL_CALL` | `record_tool_call()` | `tool_name`, `args`, `result`, `status`, `error` |
 | `STATE_UPDATE` | `record_state()` | `state`, `diff` |
 | `ERROR` | `@trace` (on exception) | `error_type`, `message`, `stack` |
-| `LOOP_WARNING` | Automatic detection | `pattern`, `repetitions`, `window_size`, `evidence_event_ids` |
+| `LOOP_WARNING` | Automatic detection | `pattern`, `pattern_type`, `pattern_length`, `repetitions`, `window_size`, `evidence_event_ids` |
 
 The span records are written as one JSON object per line and flushed after each write.
 
@@ -129,8 +129,8 @@ All integrations are optional dependencies; the core package does not depend on 
 ## Loop detection
 
 - **Input:** A sliding window of the last N events (default N=12; `MAIDA_LOOP_WINDOW`).
-- **Signature:** Each event is reduced to a string: for `LLM_CALL` -> `"LLM_CALL:"+model`, for `TOOL_CALL` -> `"TOOL_CALL:"+tool_name`, else `event_type`.
-- **Rule:** Look for a contiguous block of signatures that repeats K times (default K=3; `MAIDA_LOOP_REPETITIONS`) at the end of the window. If found, emit one `LOOP_WARNING` per distinct pattern per run (deduplicated by pattern + repetitions).
-- **Payload:** `pattern` (e.g. "LLM_CALL:gpt-4 -> TOOL_CALL:search"), `repetitions`, `window_size`, `evidence_event_ids`.
+- **Signature:** Each event is reduced to a string: for `LLM_CALL` -> `"LLM_CALL:"+model`, for `TOOL_CALL` -> `"TOOL_CALL:"+tool_name` plus a compact structural args shape when args are present, else `event_type`. Tool argument values are not compared, so noisy IDs or timestamps do not hide repeated structural calls.
+- **Rule:** Look for a contiguous block of signatures that repeats K times (default K=3; `MAIDA_LOOP_REPETITIONS`) at the end of the window. A block of one signature is reported as `pattern_type: "repeated_call"`; a longer block is reported as `pattern_type: "cycle"`. If found, emit one `LOOP_WARNING` per distinct pattern per run (deduplicated by pattern + repetitions).
+- **Payload:** `pattern` (e.g. "LLM_CALL:gpt-4 -> TOOL_CALL:search"), `pattern_type`, `pattern_length`, `repetitions`, `window_size`, `evidence_event_ids`.
 
-No ML; purely pattern-based on event type and name to give quick feedback on repetitive agent behavior.
+No ML; purely pattern-based on event type, name, and compact tool-argument structure to give quick feedback on repetitive agent behavior.

--- a/docs/reference/trace-format.md
+++ b/docs/reference/trace-format.md
@@ -177,12 +177,16 @@ Error payloads use a consistent shape (same for standalone ERROR events and nest
 ```json
 {
   "pattern": "string",
+  "pattern_type": "repeated_call | cycle",
+  "pattern_length": 1,
   "repetitions": 3,
   "window_size": 6,
   "evidence_event_ids": ["event_uuid_1", "event_uuid_2"]
 }
 ```
 
+- `pattern` is a compact loop signature. Tool calls include structural argument shape when args are present, but do not include raw argument values.
+- `pattern_type` is `repeated_call` for a one-event repeated signature and `cycle` for a multi-event repeating block such as A-B-A-B.
 - Emitted at most once per run per distinct pattern (deduplicated).
 - If `stop_on_loop` guardrails are enabled, `LOOP_WARNING` is still written first and is then followed by `ERROR` and `RUN_END(status="error")`.
 

--- a/maida/_tracing/_recorders.py
+++ b/maida/_tracing/_recorders.py
@@ -308,7 +308,10 @@ def record_tool_call(
     counts["tool_calls"] = counts.get("tool_calls", 0) + 1
     ev = new_event(EventType.TOOL_CALL, run_id, name, {"tool_name": name})
     _append_event_and_check_guardrails(run_id, ev, config, counts)
-    window.append({"event_type": "TOOL_CALL", "payload": {"tool_name": name}})
+    payload = {"tool_name": name}
+    if args is not None:
+        payload["args"] = _redact_and_truncate(args, config)
+    window.append({"event_type": "TOOL_CALL", "payload": payload})
     if len(window) > config.loop_window:
         window[:] = window[-config.loop_window :]
     _maybe_emit_loop_warning(run_id, counts, config, window, emitted)

--- a/maida/assertions.py
+++ b/maida/assertions.py
@@ -114,6 +114,23 @@ def _reason_code_text(reason_code: RegressionReasonCode | str) -> str:
     return str(reason_code)
 
 
+def _loop_signature_summary(events: list[dict], limit: int = 3) -> str:
+    loop_events = [e for e in events if e.get("event_type") == "LOOP_WARNING"]
+    summaries = []
+    for event in loop_events[:limit]:
+        payload = event.get("payload") or {}
+        pattern = payload.get("pattern") or "unknown"
+        pattern_type = payload.get("pattern_type") or "loop"
+        repetitions = payload.get("repetitions")
+        if repetitions is None:
+            summaries.append(f"{pattern_type}: {pattern}")
+        else:
+            summaries.append(f"{pattern_type} x{repetitions}: {pattern}")
+    if len(loop_events) > limit:
+        summaries.append(f"+{len(loop_events) - limit} more")
+    return "; ".join(summaries)
+
+
 def _check_threshold(
     actual: int | float,
     baseline_value: int | float | None,
@@ -261,15 +278,17 @@ def run_assertions(
     if policy.no_loops:
         loop_count = summary["loop_warnings"]
         passed = loop_count == 0
+        signature_summary = _loop_signature_summary(events) if not passed else ""
+        message = "no loop warnings detected"
+        if not passed:
+            message = f"{loop_count} loop warning(s) detected"
+            if signature_summary:
+                message += f": {signature_summary}"
         report.add(
             AssertionResult(
                 check_name="no_loops",
                 passed=passed,
-                message=(
-                    "no loop warnings detected"
-                    if passed
-                    else f"{loop_count} loop warning(s) detected"
-                ),
+                message=message,
                 reason_code=_reason_code_for(
                     passed, RegressionReasonCode.LOOP_DETECTED
                 ),

--- a/maida/loopdetect.py
+++ b/maida/loopdetect.py
@@ -5,8 +5,49 @@ Stdlib only. Pure functions, no I/O. Used to emit LOOP_WARNING when the last N
 events contain a consecutively repeating signature subsequence.
 """
 
+from typing import Any
+
 # Sentinel for evidence_event_ids when an event has no event_id (better UX than "")
 MISSING_EVENT_ID = "__MISSING__"
+_MAX_SIGNATURE_DEPTH = 4
+_MAX_SEQUENCE_ITEMS = 3
+
+
+def _type_name(value: Any) -> str:
+    if value is None:
+        return "null"
+    if isinstance(value, int) and not isinstance(value, bool):
+        return "int"
+    if isinstance(value, float):
+        return "float"
+    if isinstance(value, str):
+        return "str"
+    return type(value).__name__
+
+
+def _structural_signature(value: Any, depth: int = 0) -> str:
+    """Return a compact shape-only signature without raw scalar values."""
+    if depth >= _MAX_SIGNATURE_DEPTH:
+        # TODO: If value has infinite depth, this will silently accept it.
+        return "..."
+    if isinstance(value, dict):
+        if not value:
+            return "{}"
+        parts = []
+        for key in sorted(value, key=lambda item: str(item)):
+            parts.append(f"{key}:{_structural_signature(value[key], depth + 1)}")
+        return "{" + ",".join(parts) + "}"
+    if isinstance(value, (list, tuple)):
+        if not value:
+            return "[]"
+        item_shapes = []
+        for item in value[:_MAX_SEQUENCE_ITEMS]:
+            shape = _structural_signature(item, depth + 1)
+            if shape not in item_shapes:
+                item_shapes.append(shape)
+        suffix = ",..." if len(value) > _MAX_SEQUENCE_ITEMS else ""
+        return "[" + "|".join(item_shapes) + suffix + "]"
+    return _type_name(value)
 
 
 def compute_signature(event: dict) -> str:
@@ -14,7 +55,7 @@ def compute_signature(event: dict) -> str:
     Produce a stable string signature for an event for loop detection.
 
     - LLM_CALL: "LLM_CALL:" + model (or "UNKNOWN" if missing)
-    - TOOL_CALL: "TOOL_CALL:" + tool_name (or "UNKNOWN" if missing)
+    - TOOL_CALL: "TOOL_CALL:" + tool_name, plus structural args when present
     - Else: event_type (or empty string)
     """
     t = event.get("event_type")
@@ -22,8 +63,13 @@ def compute_signature(event: dict) -> str:
         model = event.get("payload", {}).get("model", "") or "UNKNOWN"
         return "LLM_CALL:" + str(model)
     if t == "TOOL_CALL":
-        tool_name = event.get("payload", {}).get("tool_name", "") or "UNKNOWN"
-        return "TOOL_CALL:" + str(tool_name)
+        payload = event.get("payload", {})
+        tool_name = payload.get("tool_name", "") or "UNKNOWN"
+        signature = "TOOL_CALL:" + str(tool_name)
+        args = payload.get("args", None)
+        if args is not None:
+            signature += " args:" + _structural_signature(args)
+        return signature
     return str(t or "")
 
 
@@ -66,6 +112,8 @@ def detect_loop(
             pattern = " -> ".join(block)
             return {
                 "pattern": pattern,
+                "pattern_type": "repeated_call" if m == 1 else "cycle",
+                "pattern_length": m,
                 "repetitions": repetitions,
                 "window_size": len(events_window),
                 "evidence_event_ids": evidence_event_ids,

--- a/tests/test_assertions.py
+++ b/tests/test_assertions.py
@@ -303,6 +303,8 @@ def test_no_loops_fails_when_present(temp_data_dir):
     assert report.passed is False
     loop_result = next(r for r in report.results if r.check_name == "no_loops")
     assert loop_result.actual == "1"
+    assert "cycle x3" in loop_result.message
+    assert "TOOL_CALL:t args:{} -> LLM_CALL:m" in loop_result.message
     assert loop_result.reason_code == RegressionReasonCode.LOOP_DETECTED.value
 
 

--- a/tests/test_loopdetect.py
+++ b/tests/test_loopdetect.py
@@ -120,3 +120,183 @@ def test_loop_warning_does_not_trigger_when_below_repetitions():
         _make_event("e-1", "TOOL_CALL", {"tool_name": "search_db"}),
     ]
     assert detect_loop(events, window=12, repetitions=3) is None
+
+
+def test_detect_loop_repeated_tool_calls_with_similar_structural_args():
+    """Same tool with the same argument shape is detected without comparing raw values."""
+    events = [
+        _make_event(
+            f"e-{i}",
+            "TOOL_CALL",
+            {
+                "tool_name": "search_db",
+                "args": {
+                    "query": query,
+                    "filters": {"limit": 5 + i, "include_archived": False},
+                },
+            },
+        )
+        for i, query in enumerate(("alpha", "beta", "gamma"))
+    ]
+
+    payload = detect_loop(events, window=12, repetitions=3)
+
+    assert payload is not None
+    assert payload["pattern_type"] == "repeated_call"
+    assert payload["pattern_length"] == 1
+    assert (
+        payload["pattern"]
+        == "TOOL_CALL:search_db args:{filters:{include_archived:bool,limit:int},query:str}"
+    )
+
+
+def test_detect_loop_alternating_tool_cycle():
+    """Alternating A-B-A-B tool calls are reported as a compact cycle signature."""
+    events = [
+        _make_event("e-0", "TOOL_CALL", {"tool_name": "search"}),
+        _make_event("e-1", "TOOL_CALL", {"tool_name": "summarize"}),
+        _make_event("e-2", "TOOL_CALL", {"tool_name": "search"}),
+        _make_event("e-3", "TOOL_CALL", {"tool_name": "summarize"}),
+    ]
+
+    payload = detect_loop(events, window=12, repetitions=2)
+
+    assert payload is not None
+    assert payload["pattern_type"] == "cycle"
+    assert payload["pattern_length"] == 2
+    assert payload["pattern"] == "TOOL_CALL:search -> TOOL_CALL:summarize"
+
+
+def test_detect_loop_alternating_tool_cycle_at_default_repetitions():
+    """Alternating A-B cycles are detected at the default repetition threshold."""
+    events = [
+        _make_event(f"e-{i}", "TOOL_CALL", {"tool_name": name})
+        for i, name in enumerate(
+            ("search", "summarize", "search", "summarize", "search", "summarize")
+        )
+    ]
+
+    payload = detect_loop(events, window=12, repetitions=3)
+
+    assert payload is not None
+    assert payload["pattern_type"] == "cycle"
+    assert payload["pattern_length"] == 2
+    assert payload["repetitions"] == 3
+    assert payload["pattern"] == "TOOL_CALL:search -> TOOL_CALL:summarize"
+    assert payload["evidence_event_ids"] == [f"e-{i}" for i in range(6)]
+
+
+def test_detect_loop_noisy_argument_values_do_not_break_structural_match():
+    """Changing timestamps and request IDs should not hide a repeated structural loop."""
+    events = [
+        _make_event(
+            f"e-{i}",
+            "TOOL_CALL",
+            {
+                "tool_name": "fetch_status",
+                "args": {
+                    "request_id": f"req-{i}",
+                    "timestamp": f"2026-06-27T00:00:0{i}Z",
+                    "payload": {"retry": i, "source": "agent"},
+                },
+            },
+        )
+        for i in range(3)
+    ]
+
+    payload = detect_loop(events, window=12, repetitions=3)
+
+    assert payload is not None
+    assert (
+        payload["pattern"]
+        == "TOOL_CALL:fetch_status args:{payload:{retry:int,source:str},request_id:str,timestamp:str}"
+    )
+
+
+def test_detect_loop_truncates_deep_structural_arg_signatures():
+    """Deep argument structures are compacted before they can dominate signatures."""
+    events = [
+        _make_event(
+            f"e-{i}",
+            "TOOL_CALL",
+            {
+                "tool_name": "inspect_tree",
+                "args": {
+                    "root": {
+                        "branch": {
+                            "leaf": {
+                                "hidden": {
+                                    "value": f"payload-{i}",
+                                }
+                            }
+                        }
+                    }
+                },
+            },
+        )
+        for i in range(3)
+    ]
+
+    payload = detect_loop(events, window=12, repetitions=3)
+
+    assert payload is not None
+    assert payload["pattern_type"] == "repeated_call"
+    assert (
+        payload["pattern"]
+        == "TOOL_CALL:inspect_tree args:{root:{branch:{leaf:{hidden:...}}}}"
+    )
+    assert "value" not in payload["pattern"]
+    assert "payload-" not in payload["pattern"]
+
+
+def test_detect_loop_different_argument_shapes_are_not_same_loop():
+    """Same tool can repeat harmlessly when calls use different structural args."""
+    events = [
+        _make_event(
+            "e-0", "TOOL_CALL", {"tool_name": "search", "args": {"query": "a"}}
+        ),
+        _make_event(
+            "e-1",
+            "TOOL_CALL",
+            {"tool_name": "search", "args": {"query": "b", "page": 2}},
+        ),
+        _make_event(
+            "e-2",
+            "TOOL_CALL",
+            {"tool_name": "search", "args": {"query": "c", "sort": "date"}},
+        ),
+    ]
+
+    assert detect_loop(events, window=12, repetitions=3) is None
+
+
+def test_detect_loop_legitimate_repetition_can_pass_under_policy():
+    """Policy can allow limited repetition by requiring more repeats before warning."""
+    events = [
+        _make_event(f"e-{i}", "TOOL_CALL", {"tool_name": "poll_status"})
+        for i in range(3)
+    ]
+
+    assert detect_loop(events, window=12, repetitions=4) is None
+
+
+def test_detect_loop_uses_tail_window_for_long_traces():
+    """Long traces are evaluated against the configured tail window only."""
+    prefix = [
+        _make_event(f"prefix-{i}", "TOOL_CALL", {"tool_name": f"step_{i}"})
+        for i in range(30)
+    ]
+    loop = [
+        _make_event(
+            f"loop-{i}",
+            "TOOL_CALL",
+            {"tool_name": "retry_lookup", "args": {"query": f"q-{i}"}},
+        )
+        for i in range(3)
+    ]
+
+    payload = detect_loop(prefix + loop, window=6, repetitions=3)
+
+    assert payload is not None
+    assert payload["window_size"] == 6
+    assert payload["evidence_event_ids"] == ["loop-0", "loop-1", "loop-2"]

--- a/tests/tracing/test_tracing.py
+++ b/tests/tracing/test_tracing.py
@@ -108,6 +108,39 @@ def test_loop_warning_emitted_once_for_repeated_pattern(temp_data_dir):
     assert payload.get("repetitions") == 3
 
 
+def test_loop_warning_runtime_pattern_includes_structural_tool_args(temp_data_dir):
+    """Runtime loop warnings include compact structural args for repeated tool calls."""
+
+    @trace(name="structural-tool-loop")
+    def _run():
+        for i in range(3):
+            record_tool_call(
+                "search_db",
+                args={
+                    "query": f"case-{i}",
+                    "filters": {"limit": i + 1, "include_archived": False},
+                },
+                result={"ok": True},
+            )
+
+    _run()
+    config = load_config()
+    run_id = get_latest_run_id(config)
+    events = spans_to_events(load_spans(run_id, config))
+    loop_warnings = [
+        e for e in events if e.get("event_type") == EventType.LOOP_WARNING.value
+    ]
+
+    assert len(loop_warnings) == 1
+    payload = loop_warnings[0].get("payload", {})
+    assert payload.get("pattern_type") == "repeated_call"
+    assert payload.get("pattern_length") == 1
+    assert (
+        payload.get("pattern")
+        == "TOOL_CALL:search_db args:{filters:{include_archived:bool,limit:int},query:str}"
+    )
+
+
 def test_tool_call_records_error_status_and_error_object_on_exception(temp_data_dir):
     """Tool that raises records TOOL_CALL with status=error and error object (type, message)."""
 


### PR DESCRIPTION
Add compact structural tool-argument signatures to loop detection, classify repeated calls versus cycles in LOOP_WARNING payloads, and surface those signatures in assertion failures.

- Added structural tool-argument signatures in `maida.loopdetect`, with bounded depth/list sampling and no raw scalar values in signatures.
- Added `pattern_type` (`repeated_call` or `cycle`) and `pattern_length` to LOOP_WARNING payloads.
- Passed redacted/truncated tool args into the runtime loop detection window from `record_tool_call`.
- Enhanced `no_loops` assertion failure messages to include compact loop/cycle signature details.
- Updated trace-format and architecture docs for the additive LOOP_WARNING payload fields.
- Added regression coverage for repeated same-tool structural args, alternating cycles, noisy argument values, harmless differing shapes, policy-threshold allowed repetition, long traces, runtime loop warnings, and assertion messages.

Fixes #59