### PR TITLE
Emit cycle reason codes for loop assertions

### DIFF
--- a/docs/reference/policy.md
+++ b/docs/reference/policy.md
@@ -100,8 +100,8 @@ for that metric.
 | `step_count_exceeded` | Step/event count exceeded the baseline envelope or hard cap |
 | `new_tool_path` | A tool appeared that was not present in the baseline |
 | `tool_call_count_exceeded` | Tool call count exceeded the baseline envelope or hard cap |
-| `loop_detected` | One or more `LOOP_WARNING` events were detected |
-| `cycle_detected` | Reserved (not yet emitted) for graph/cycle checks that detect cyclic behavior |
+| `loop_detected` | One or more repeated-call `LOOP_WARNING` events were detected |
+| `cycle_detected` | One or more multi-event cycle `LOOP_WARNING` events were detected |
 | `terminal_state_missing` | The run did not end in the expected terminal status |
 | `guardrail_event_changed` | Guardrail-triggered events were detected |
 | `latency_envelope_exceeded` | Run duration exceeded the baseline envelope or hard cap |

--- a/docs/regression-testing.md
+++ b/docs/regression-testing.md
@@ -206,6 +206,8 @@ maida assert --baseline baseline.json --format markdown
 ```
 
 The report leads with the verdict, groups failed checks by stable reason code, collapses passing checks, and — when a baseline is provided — embeds the structural diff and a copy-pasteable local-repro snippet.
+For `--no-loops`, repeated single-call warnings use `loop_detected`; multi-event
+cycle warnings, such as A-B-A-B patterns, use `cycle_detected`.
 
 ---
 

--- a/maida/assertions.py
+++ b/maida/assertions.py
@@ -30,7 +30,7 @@ class RegressionReasonCode(str, Enum):
     NEW_TOOL_PATH = "new_tool_path"
     TOOL_CALL_COUNT_EXCEEDED = "tool_call_count_exceeded"
     LOOP_DETECTED = "loop_detected"
-    CYCLE_DETECTED = "cycle_detected"  # reserved - not yet emitted
+    CYCLE_DETECTED = "cycle_detected"
     TERMINAL_STATE_MISSING = "terminal_state_missing"
     GUARDRAIL_EVENT_CHANGED = "guardrail_event_changed"
     LATENCY_ENVELOPE_EXCEEDED = "latency_envelope_exceeded"
@@ -129,6 +129,17 @@ def _loop_signature_summary(events: list[dict], limit: int = 3) -> str:
     if len(loop_events) > limit:
         summaries.append(f"+{len(loop_events) - limit} more")
     return "; ".join(summaries)
+
+
+def _loop_reason_code(events: list[dict]) -> RegressionReasonCode:
+    """Return the most specific reason code for recorded loop warnings."""
+    for event in events:
+        if event.get("event_type") != "LOOP_WARNING":
+            continue
+        payload = event.get("payload") or {}
+        if payload.get("pattern_type") == "cycle":
+            return RegressionReasonCode.CYCLE_DETECTED
+    return RegressionReasonCode.LOOP_DETECTED
 
 
 def _check_threshold(
@@ -289,9 +300,7 @@ def run_assertions(
                 check_name="no_loops",
                 passed=passed,
                 message=message,
-                reason_code=_reason_code_for(
-                    passed, RegressionReasonCode.LOOP_DETECTED
-                ),
+                reason_code=_reason_code_for(passed, _loop_reason_code(events)),
                 actual=str(loop_count),
             )
         )

--- a/tests/test_assertions.py
+++ b/tests/test_assertions.py
@@ -305,6 +305,28 @@ def test_no_loops_fails_when_present(temp_data_dir):
     assert loop_result.actual == "1"
     assert "cycle x3" in loop_result.message
     assert "TOOL_CALL:t args:{} -> LLM_CALL:m" in loop_result.message
+    assert loop_result.reason_code == RegressionReasonCode.CYCLE_DETECTED.value
+
+
+def test_no_loops_repeated_call_keeps_loop_reason_code(temp_data_dir):
+    config = load_config()
+    events = [
+        (
+            EventType.TOOL_CALL,
+            "poll_status",
+            {"args": {"request_id": f"req-{i}"}, "result": {"ok": True}},
+        )
+        for i in range(3)
+    ]
+    run_id = _make_run(config, events=events)
+    policy = AssertionPolicy(no_loops=True)
+    report = run_assertions(run_id, policy, config=config)
+
+    assert report.passed is False
+    loop_result = next(r for r in report.results if r.check_name == "no_loops")
+    assert loop_result.actual == "1"
+    assert "repeated_call x3" in loop_result.message
+    assert "TOOL_CALL:poll_status args:{request_id:str}" in loop_result.message
     assert loop_result.reason_code == RegressionReasonCode.LOOP_DETECTED.value
 
 


### PR DESCRIPTION
Use loop warning pattern metadata to report cycle_detected for multi-event cycles while keeping loop_detected for repeated calls. Update policy and regression docs.

Issue 56 is the parent hardening issue for regression-engine diffs, reason codes, loop/cycle detection, harmless nondeterminism, noisy traces, simple policy defaults, and stable CLI exits. I checked the in-flight sub-issue work that this branch sits on top of:

- #59 tests in `tests/test_loopdetect.py`.
- #60 tests in `tests/test_policy_tolerance_nondeterminism.py`.
- #61 the policy scaffold/docs tests.

Those areas were already covered by the branch. The remaining parent-issue gap was that `cycle_detected` existed in the reason-code vocabulary but was still documented as reserved and was not emitted by `maida assert --no-loops`.

Fixes #56