### PR TITLE
Update action refs in init scaffold

### DIFF
--- a/README.md
+++ b/README.md
@@ -202,7 +202,7 @@ maida demo --regression  # baseline a good run, then watch the gate catch a bad 
 
 ```bash
 maida init           # starter .maida/policy.yaml
-maida init --github  # + .github/workflows/maida.yml (maida-assert action)
+maida init --github  # + .github/workflows/maida.yml (maida-ai/maida-assert@V4)
 ```
 
 ### List recent runs

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -47,13 +47,13 @@ maida init [--github] [--force]
 
 | Option | Description |
 |--------|-------------|
-| `--github` | Also write `.github/workflows/maida.yml` using the [maida-assert action](https://github.com/maida-ai/maida-assert) |
+| `--github` | Also write `.github/workflows/maida.yml` using the pinned [`maida-ai/maida-assert@V4`](https://github.com/maida-ai/maida-assert/releases/tag/V4) action |
 | `--force` | Overwrite existing files |
 
 **Files written:**
 
 - `.maida/policy.yaml` — commented starter policy with 50% baseline tolerances; strict checks such as `no_loops`, `no_guardrails`, `no_new_tools`, and `expect_status: ok` are shown as opt-ins
-- `.github/workflows/maida.yml` (with `--github`) — PR check running your traced agent and posting the regression report as a sticky comment
+- `.github/workflows/maida.yml` (with `--github`) — PR check running your traced agent and posting the regression report as a sticky comment; pins `actions/checkout@v7` and `maida-ai/maida-assert@V4`
 
 **Exit codes:** `0` success; `10` internal error.
 

--- a/docs/regression-testing.md
+++ b/docs/regression-testing.md
@@ -258,7 +258,7 @@ The diff shows summary-level metric changes, compact baseline/current tool paths
 
 ## GitHub Actions example
 
-The easiest path is the [maida-assert action](https://github.com/maida-ai/maida-assert) — scaffold it with `maida init --github`. It runs your traced agent, asserts the run, and posts the regression report as a sticky PR comment.
+The easiest path is the pinned [`maida-ai/maida-assert@V4`](https://github.com/maida-ai/maida-assert/releases/tag/V4) action — scaffold it with `maida init --github`. It runs your traced agent, asserts the run, and posts the regression report as a sticky PR comment.
 
 To wire it up by hand instead, run your agent in CI, then assert against the checked-in baseline (`maida assert` picks up the latest run automatically):
 

--- a/maida/scaffold.py
+++ b/maida/scaffold.py
@@ -4,6 +4,8 @@ from pathlib import Path
 
 POLICY_RELPATH = Path(".maida") / "policy.yaml"
 WORKFLOW_RELPATH = Path(".github") / "workflows" / "maida.yml"
+CHECKOUT_ACTION_REF = "actions/checkout@v7"
+MAIDA_ASSERT_ACTION_REF = "maida-ai/maida-assert@V4"
 
 POLICY_TEMPLATE = """\
 # Maida policy - enforced by `maida assert` locally and in CI.
@@ -37,7 +39,7 @@ assert:
   # max_duration_ms: 60000
 """
 
-WORKFLOW_TEMPLATE = """\
+WORKFLOW_TEMPLATE = f"""\
 name: Agent Regression Check
 on: [pull_request]
 
@@ -49,8 +51,8 @@ jobs:
   agent-check:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: maida-ai/maida-assert@v2
+      - uses: {CHECKOUT_ACTION_REF}
+      - uses: {MAIDA_ASSERT_ACTION_REF}
         with:
           # TODO: point at the script that runs your traced agent
           # (it must use @trace or traced_run so a run is recorded).

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -18,6 +18,7 @@ from maida.cli import _wait_for_port, app
 from maida.config import load_config
 from maida.events import EventType
 from maida.policy import load_policy
+from maida.scaffold import CHECKOUT_ACTION_REF, MAIDA_ASSERT_ACTION_REF
 from maida.storage import list_runs
 from tests.conftest import get_latest_run_id
 
@@ -781,7 +782,10 @@ def test_init_github_writes_valid_workflow(empty_data_dir, tmp_path, monkeypatch
     wf = yaml.safe_load(wf_path.read_text())
     job = wf["jobs"]["agent-check"]
     uses = [step.get("uses", "") for step in job["steps"]]
-    assert any(u.startswith("maida-ai/maida-assert@") for u in uses)
+    assert CHECKOUT_ACTION_REF in uses
+    assert MAIDA_ASSERT_ACTION_REF in uses
+    assert "actions/checkout@v4" not in uses
+    assert "maida-ai/maida-assert@v2" not in uses
     assert wf["permissions"]["pull-requests"] == "write"
 
 

--- a/tests/test_docs.py
+++ b/tests/test_docs.py
@@ -1,5 +1,6 @@
 from pathlib import Path
 
+from maida.scaffold import CHECKOUT_ACTION_REF, MAIDA_ASSERT_ACTION_REF
 
 ROOT = Path(__file__).resolve().parents[1]
 
@@ -62,3 +63,24 @@ def test_trace_format_documents_current_storage_contract():
     missing = [snippet for snippet in required_snippets if snippet not in text]
 
     assert missing == []
+
+
+def test_action_version_references_match_scaffold():
+    docs = [
+        "README.md",
+        "docs/cli.md",
+        "docs/regression-testing.md",
+    ]
+    combined = "\n".join(
+        (ROOT / rel_path).read_text(encoding="utf-8") for rel_path in docs
+    )
+
+    assert MAIDA_ASSERT_ACTION_REF in combined
+    assert "maida-ai/maida-assert@v2" not in combined
+    assert "maida-ai/maida-assert@V2" not in combined
+
+    workflow_text = (ROOT / "maida/scaffold.py").read_text(encoding="utf-8")
+    assert CHECKOUT_ACTION_REF in workflow_text
+    assert MAIDA_ASSERT_ACTION_REF in workflow_text
+    assert "actions/checkout@v4" not in workflow_text
+    assert "maida-ai/maida-assert@v2" not in workflow_text


### PR DESCRIPTION
Updated the current repository's generated GitHub workflow and public docs to use the current action references for the Maida CI scaffold. The linked external repository was not modified.

- Added named scaffold constants for `actions/checkout@v7` and `maida-ai/maida-assert@V4`.
- Updated the `maida init --github` workflow template to use those current refs instead of stale `actions/checkout@v4` and `maida-ai/maida-assert@v2`.
- Updated README, CLI docs, and regression-testing docs so documented action references match the generated workflow.
- Tightened CLI/docs tests so stale workflow refs fail explicitly.

Fixes #67