### PR TITLE
Polish generated GitHub workflow

### DIFF
--- a/maida/scaffold.py
+++ b/maida/scaffold.py
@@ -44,21 +44,24 @@ name: Agent Regression Check
 on: [pull_request]
 
 permissions:
-  contents: read
-  pull-requests: write  # lets the action post the regression report
+  contents: read          # checkout only needs read access
+  pull-requests: write    # maida-assert posts a sticky PR comment
 
 jobs:
   agent-check:
     runs-on: ubuntu-latest
     steps:
-      - uses: {CHECKOUT_ACTION_REF}
-      - uses: {MAIDA_ASSERT_ACTION_REF}
+      - name: Check out repository
+        uses: {CHECKOUT_ACTION_REF}
+
+      - name: Run Maida regression gate
+        uses: {MAIDA_ASSERT_ACTION_REF}
         with:
-          # TODO: point at the script that runs your traced agent
-          # (it must use @trace or traced_run so a run is recorded).
+          # Replace this with the script that runs your traced agent.
+          # It must use @trace or traced_run so Maida records a run.
           agent-script: my_agent.py
           policy: .maida/policy.yaml
-          # Once you commit a baseline (maida baseline --out ...), enable:
+          # After committing a baseline, uncomment and point this at it:
           # baseline: .maida/baselines/my_agent.json
 """
 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -819,17 +819,41 @@ def test_init_github_writes_valid_workflow(empty_data_dir, tmp_path, monkeypatch
     monkeypatch.chdir(tmp_path)
     result = runner.invoke(app, ["init", "--github"])
     assert result.exit_code == 0
+    policy_path = tmp_path / ".maida" / "policy.yaml"
     wf_path = tmp_path / ".github" / "workflows" / "maida.yml"
+    assert policy_path.is_file()
     assert wf_path.is_file()
 
-    wf = yaml.safe_load(wf_path.read_text())
+    workflow_text = wf_path.read_text(encoding="utf-8")
+    policy = load_policy(policy_path)
+    assert policy.step_tolerance == 0.5
+    assert policy.no_new_tools is False
+
+    wf = yaml.safe_load(workflow_text)
+    assert set(wf["permissions"]) == {"contents", "pull-requests"}
+    assert wf["permissions"]["contents"] == "read"
+    assert wf["permissions"]["pull-requests"] == "write"
+
     job = wf["jobs"]["agent-check"]
+    assert set(wf["jobs"]) == {"agent-check"}
+    assert job["runs-on"] == "ubuntu-latest"
+    assert len(job["steps"]) == 2
+    assert job["steps"][0]["name"] == "Check out repository"
+    assert job["steps"][1]["name"] == "Run Maida regression gate"
+
     uses = [step.get("uses", "") for step in job["steps"]]
     assert CHECKOUT_ACTION_REF in uses
     assert MAIDA_ASSERT_ACTION_REF in uses
     assert "actions/checkout@v4" not in uses
     assert "maida-ai/maida-assert@v2" not in uses
-    assert wf["permissions"]["pull-requests"] == "write"
+
+    action_inputs = job["steps"][1]["with"]
+    assert action_inputs["agent-script"] == "my_agent.py"
+    assert action_inputs["policy"] == ".maida/policy.yaml"
+    assert "baseline" not in action_inputs
+    assert "Replace this with the script that runs your traced agent." in workflow_text
+    assert "After committing a baseline" in workflow_text
+    assert "secrets." not in workflow_text.lower()
 
 
 def test_init_skips_existing_without_force(empty_data_dir, tmp_path, monkeypatch):


### PR DESCRIPTION
Improved the generated `maida init --github` workflow so it is clearer and more copy-pasteable while preserving minimal permissions. The stale action version references were already addressed by the prior action-ref commit on this branch; this commit focuses on the remaining issue 64 acceptance criteria.

- Added explicit step names to the generated workflow: `Check out repository` and `Run Maida regression gate`.
- Clarified the generated workflow permission comments while keeping the permission set limited to `contents: read` and `pull-requests: write`.
- Reworded action input comments so users know to replace `agent-script`, keep the generated `.maida/policy.yaml`, and only enable `baseline` after committing one.
- Strengthened CLI coverage to validate the generated policy and workflow together in a fresh temp directory, including exact permissions, steps, action inputs, action refs, and comments.

Fixes #64