### PR TITLE
Redesign PR markdown verdict and behavior diff

### DIFF
--- a/README.md
+++ b/README.md
@@ -243,7 +243,7 @@ maida assert <TRACE_ID> --max-steps 80 --no-loops          # standalone threshol
 maida assert --baseline baseline.json --format markdown    # for CI summaries / PR comments
 ```
 
-Exit code `0` = pass, `1` = fail. With a baseline, the markdown report includes a "What changed vs baseline" section (new tools, metric deltas, model changes) so a failing check explains itself. See [docs/regression-testing.md](docs/regression-testing.md) for the full workflow and [docs/reference/policy.md](docs/reference/policy.md) for policy YAML configuration.
+Exit code `0` = pass, `1` = fail. With a baseline, the markdown report starts with the verdict and includes top behavior changes (steps, tool path, loops/cycles, guardrails, terminal state, latency/cost, and models) plus next steps so a failing check explains itself. See [docs/regression-testing.md](docs/regression-testing.md) for the full workflow and [docs/reference/policy.md](docs/reference/policy.md) for policy YAML configuration.
 
 ### Diff two runs
 

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -236,7 +236,7 @@ maida assert --baseline baseline.json --format markdown
 
 **Exit codes:** `0` all checks passed; `1` one or more checks failed; `2` run or baseline not found; `10` internal error.
 
-Each assertion result includes a stable `reason_code`; JSON output also includes a top-level `reason_codes` array for failed checks. Markdown output groups failed checks by reason code so PR comments can cluster related failures. When a baseline is provided, the markdown report embeds a **What changed vs baseline** section (metric deltas, new/removed tools, model changes) plus a local-repro snippet. The text report appends the structural diff on failure.
+Each assertion result includes a stable `reason_code`; JSON output also includes a top-level `reason_codes` array for failed checks. Markdown output starts with a pass/fail verdict, shows **Top behavior changes** when a baseline diff is available, groups failed checks by reason code, and includes concise next steps plus a local-repro snippet. The text report appends the structural diff on failure.
 
 ---
 

--- a/docs/reference/policy.md
+++ b/docs/reference/policy.md
@@ -107,7 +107,7 @@ for that metric.
 | `latency_envelope_exceeded` | Run duration exceeded the baseline envelope or hard cap |
 | `cost_envelope_exceeded` | Token usage exceeded the baseline envelope or hard cap |
 
-Machine-readable JSON includes a top-level `reason_codes` array containing the failed reason codes in result order, plus `reason_code` on every individual result. Markdown groups failed checks by reason code for PR comments.
+Machine-readable JSON includes a top-level `reason_codes` array containing the failed reason codes in result order, plus `reason_code` on every individual result. Markdown starts with a verdict, shows top behavior changes when a baseline diff is available, and groups failed checks by reason code for PR comments.
 
 ---
 

--- a/docs/regression-testing.md
+++ b/docs/regression-testing.md
@@ -177,11 +177,25 @@ maida assert --baseline baseline.json --format markdown
 ```
 
 ```markdown
-## ❌ Maida gate: agent behavior regressed
+## ❌ Maida verdict: fail
 
-**1 of 4 checks failed** · run `a1b2c3d4` vs baseline `e5f6a7b8`
+**2 of 5 checks failed** · run `a1b2c3d4` vs baseline `e5f6a7b8`
 
-### Failed checks by reason
+### Top behavior changes
+
+| Behavior | Baseline | Current | Change |
+|---|---|---|---|
+| Steps | 38 | 42 | +11% |
+| Tool path | search -> parse -> summarize | search -> parse -> web_search -> web_search -> summarize | 1 new; repeated calls |
+| Loops/cycles | 0 | 2 | NEW |
+| Terminal state | ok | error | changed |
+| Cost envelope | 1000 tokens | 1400 tokens | +40% |
+
+**Tool changes:**
+- ➕ `web_search` — new tool, not in baseline
+- 🔁 `web_search` — repeated 0 -> 2 calls
+
+### Failed checks by reason code
 
 #### `loop_detected`
 
@@ -189,23 +203,25 @@ maida assert --baseline baseline.json --format markdown
 |---|---|---|---|
 | ❌ `no_loops` | — | 2 | 2 loop warning(s) detected |
 
+#### `terminal_state_missing`
+
+| Check | Expected | Actual | Details |
+|---|---|---|---|
+| ❌ `expect_status` | ok | error | expected 'ok', got 'error' |
+
 <details>
 <summary>✅ 3 passing checks</summary>
 ...
 </details>
 
-### What changed vs baseline
+### Next steps
 
-| Metric | Baseline | Current | Change |
-|---|---|---|---|
-| tool_calls | 10 | 14 | +40% |
-| loop_warnings | 0 | 2 | NEW |
-
-**Tool changes:**
-- ➕ `web_search` — new tool, not in baseline
+- Inspect the full diff: `maida diff a1b2c3d4 --baseline baseline.json`
+- Open the trace locally: `maida view a1b2c3d4`
+- If this is expected, update the baseline or policy; otherwise fix the agent behavior and rerun the gate.
 ```
 
-The report leads with the verdict, groups failed checks by stable reason code, collapses passing checks, and — when a baseline is provided — embeds the structural diff and a copy-pasteable local-repro snippet.
+The report leads with the verdict, shows top behavior changes, groups failed checks by stable reason code, collapses passing checks, and includes concise next steps plus a copy-pasteable local-repro snippet.
 For `--no-loops`, repeated single-call warnings use `loop_detected`; multi-event
 cycle warnings, such as A-B-A-B patterns, use `cycle_detected`.
 

--- a/maida/assertions.py
+++ b/maida/assertions.py
@@ -383,6 +383,43 @@ _PASS = "\u2713"  # ✓
 _FAIL = "\u2717"  # ✗
 
 
+def _markdown_table_cell(value: object) -> str:
+    return str(value).replace("\n", " ").replace("|", "\\|")
+
+
+def _markdown_scope(report: AssertionReport) -> str:
+    scope = f"run `{report.run_id[:8]}`"
+    if report.baseline_run_id:
+        scope += f" vs baseline `{str(report.baseline_run_id)[:8]}`"
+    return scope
+
+
+def _markdown_next_steps(
+    report: AssertionReport,
+    *,
+    short_run: str,
+    baseline_path: str | None,
+) -> list[str]:
+    if report.passed:
+        return [
+            f"- No gate action needed; inspect the trace with `maida view {short_run}` if desired.",
+        ]
+
+    steps: list[str] = []
+    if baseline_path:
+        steps.append(
+            "- Inspect the full diff: "
+            f"`maida diff {short_run} --baseline {baseline_path}`"
+        )
+    else:
+        steps.append("- Review the failed checks and policy thresholds above.")
+    steps += [
+        f"- Open the trace locally: `maida view {short_run}`",
+        "- If this is expected, update the baseline or policy; otherwise fix the agent behavior and rerun the gate.",
+    ]
+    return steps
+
+
 def format_report_text(report: AssertionReport, diff: "RunDiff | None" = None) -> str:
     """Format report as human-readable text for CLI output.
 
@@ -441,23 +478,21 @@ def format_report_markdown(
 ) -> str:
     """Format report as Markdown for GitHub PR comments.
 
-    Failed checks come first so reviewers see the regression immediately;
-    passing checks are collapsed. When *diff* is provided, a "What changed
-    vs baseline" section explains the structural difference, and
-    *baseline_path* (when known) makes the local-repro snippet copy-pasteable.
+    The comment starts with a verdict, then surfaces top behavior changes,
+    failed checks grouped by reason code, concise next steps, and a collapsed
+    local-repro block. Passing checks are collapsed to keep the default comment
+    readable.
     """
     failed = [r for r in report.results if not r.passed]
     passed = [r for r in report.results if r.passed]
     short_run = report.run_id[:8]
 
     if report.passed:
-        lines = ["## \u2705 Maida gate: no behavioral regression", ""]
+        lines = ["## \u2705 Maida verdict: pass", ""]
     else:
-        lines = ["## \u274c Maida gate: agent behavior regressed", ""]
+        lines = ["## \u274c Maida verdict: fail", ""]
 
-    scope = f"run `{short_run}`"
-    if report.baseline_run_id:
-        scope += f" vs baseline `{str(report.baseline_run_id)[:8]}`"
+    scope = _markdown_scope(report)
     if not report.results:
         lines.append(f"**No checks enabled** \u00b7 {scope}")
     elif failed:
@@ -467,8 +502,23 @@ def format_report_markdown(
     else:
         lines.append(f"**All {len(report.results)} checks passed** \u00b7 {scope}")
 
+    diff_md = format_diff_markdown(diff) if diff is not None else ""
+    if diff_md:
+        if report.passed:
+            lines += [
+                "",
+                "<details>",
+                "<summary>Top behavior changes within tolerance</summary>",
+                "",
+                diff_md,
+                "",
+                "</details>",
+            ]
+        else:
+            lines += ["", diff_md]
+
     if failed:
-        lines += ["", "### Failed checks by reason"]
+        lines += ["", "### Failed checks by reason code"]
         for reason_code in report.reason_codes:
             reason_failures = [r for r in failed if r.reason_code == reason_code]
             lines += [
@@ -482,7 +532,11 @@ def format_report_markdown(
                 expected = r.expected or "\u2014"
                 actual = r.actual or "\u2014"
                 lines.append(
-                    f"| \u274c `{r.check_name}` | {expected} | {actual} | {r.message} |"
+                    "| \u274c "
+                    f"`{_markdown_table_cell(r.check_name)}` | "
+                    f"{_markdown_table_cell(expected)} | "
+                    f"{_markdown_table_cell(actual)} | "
+                    f"{_markdown_table_cell(r.message)} |"
                 )
 
     if passed:
@@ -495,24 +549,19 @@ def format_report_markdown(
             "|---|---|",
         ]
         for r in passed:
-            lines.append(f"| \u2705 `{r.check_name}` | {r.message} |")
+            lines.append(
+                "| \u2705 "
+                f"`{_markdown_table_cell(r.check_name)}` | "
+                f"{_markdown_table_cell(r.message)} |"
+            )
         lines += ["", "</details>"]
 
-    if diff is not None:
-        diff_md = format_diff_markdown(diff)
-        if diff_md:
-            if report.passed:
-                lines += [
-                    "",
-                    "<details>",
-                    "<summary>What changed vs baseline (within tolerance)</summary>",
-                    "",
-                    diff_md,
-                    "",
-                    "</details>",
-                ]
-            else:
-                lines += ["", diff_md]
+    lines += [
+        "",
+        "### Next steps",
+        "",
+        *_markdown_next_steps(report, short_run=short_run, baseline_path=baseline_path),
+    ]
 
     repro = ["pip install maida-ai"]
     if baseline_path:

--- a/maida/diff.py
+++ b/maida/diff.py
@@ -27,6 +27,8 @@ class RunDiff:
     current_tool_sequence: list[str] = field(default_factory=list)
     baseline_tool_sequence: list[str] = field(default_factory=list)
     model_changes: dict = field(default_factory=dict)
+    guardrail_event_diff: tuple[int, int] | None = None
+    terminal_status_diff: tuple[str, str] | None = None
 
 
 def _as_string_list(value: object) -> list[str]:
@@ -164,6 +166,17 @@ def compute_diff(
         "removed": sorted(models_b - models_a),
     }
 
+    # --- guardrail event + terminal status changes ---
+    guardrails_a = metrics_a.get("guardrail_events") or []
+    guardrails_b = metrics_b.get("guardrail_events") or []
+    guardrail_event_diff = None
+    if len(guardrails_a) != len(guardrails_b):
+        guardrail_event_diff = (len(guardrails_a), len(guardrails_b))
+
+    status_a = str(metrics_a.get("final_status") or sum_a.get("status") or "unknown")
+    status_b = str(metrics_b.get("final_status") or sum_b.get("status") or "unknown")
+    terminal_status_diff = (status_a, status_b) if status_a != status_b else None
+
     return RunDiff(
         run_a_id=full_a,
         run_b_id=b_id,
@@ -177,6 +190,8 @@ def compute_diff(
         current_tool_sequence=current_tool_sequence,
         baseline_tool_sequence=baseline_tool_sequence,
         model_changes=model_changes,
+        guardrail_event_diff=guardrail_event_diff,
+        terminal_status_diff=terminal_status_diff,
     )
 
 
@@ -207,6 +222,27 @@ _SUMMARY_ORDER = [
     "status",
 ]
 _TOOL_PATH_PREVIEW_SIDE = 6
+_PRIMARY_BEHAVIOR_ORDER = [
+    "total_events",
+    "tool_path",
+    "loop_warnings",
+    "guardrail_events",
+    "status",
+    "duration_ms",
+    "total_tokens",
+]
+_PRIMARY_BEHAVIOR_LABELS = {
+    "total_events": "Steps",
+    "tool_path": "Tool path",
+    "loop_warnings": "Loops/cycles",
+    "guardrail_events": "Guardrail events",
+    "status": "Terminal state",
+    "duration_ms": "Latency envelope",
+    "total_tokens": "Cost envelope",
+    "tool_calls": "Tool calls",
+    "llm_calls": "LLM calls",
+    "errors": "Errors",
+}
 
 
 def _summary_keys(summary_diff: dict) -> list[str]:
@@ -244,6 +280,117 @@ def _has_tool_path_changes(diff: RunDiff) -> bool:
             and diff.current_tool_sequence != diff.baseline_tool_sequence
         )
     )
+
+
+def _table_cell(value: object) -> str:
+    return str(value).replace("\n", " ").replace("|", "\\|")
+
+
+def _format_behavior_value(key: str, value: object) -> str:
+    if key == "duration_ms" and isinstance(value, (int, float)):
+        return f"{int(value)} ms"
+    if key == "total_tokens" and isinstance(value, (int, float)):
+        return f"{int(value)} tokens"
+    return str(value)
+
+
+def _tool_path_change_summary(diff: RunDiff) -> str:
+    parts: list[str] = []
+    if diff.new_tools:
+        parts.append(f"{len(diff.new_tools)} new")
+    if diff.removed_tools:
+        parts.append(f"{len(diff.removed_tools)} removed")
+    if diff.repeated_tools:
+        parts.append("repeated calls")
+    if diff.reordered_tools:
+        parts.append("order changed")
+    if not parts:
+        parts.append("sequence changed")
+    return "; ".join(parts)
+
+
+def _model_change_summary(diff: RunDiff) -> tuple[str, str, str] | None:
+    added = diff.model_changes.get("added", [])
+    removed = diff.model_changes.get("removed", [])
+    if not added and not removed:
+        return None
+    baseline = ", ".join(removed) if removed else "(unchanged)"
+    current = ", ".join(added) if added else "(unchanged)"
+    parts: list[str] = []
+    if added:
+        parts.append(f"{len(added)} added")
+    if removed:
+        parts.append(f"{len(removed)} removed")
+    return ("Models", baseline, current, "; ".join(parts))
+
+
+def _behavior_change_rows(diff: RunDiff) -> list[tuple[str, str, str, str]]:
+    rows: list[tuple[str, str, str, str]] = []
+    emitted: set[str] = set()
+
+    def add_summary_row(key: str) -> None:
+        if key not in diff.summary_diff:
+            return
+        current, baseline = diff.summary_diff[key]
+        label = _PRIMARY_BEHAVIOR_LABELS.get(key, _summary_label(key))
+        if isinstance(current, (int, float)) and isinstance(baseline, (int, float)):
+            change = _pct_change(current, baseline)
+        else:
+            change = "changed"
+        rows.append(
+            (
+                label,
+                _format_behavior_value(key, baseline),
+                _format_behavior_value(key, current),
+                change,
+            )
+        )
+        emitted.add(key)
+
+    for key in _PRIMARY_BEHAVIOR_ORDER:
+        if key == "tool_path":
+            if _has_tool_path_changes(diff):
+                rows.append(
+                    (
+                        "Tool path",
+                        _format_tool_sequence(diff.baseline_tool_sequence),
+                        _format_tool_sequence(diff.current_tool_sequence),
+                        _tool_path_change_summary(diff),
+                    )
+                )
+                emitted.add(key)
+            continue
+        if key == "guardrail_events":
+            if diff.guardrail_event_diff is not None:
+                current, baseline = diff.guardrail_event_diff
+                rows.append(
+                    (
+                        "Guardrail events",
+                        str(baseline),
+                        str(current),
+                        _pct_change(current, baseline),
+                    )
+                )
+                emitted.add(key)
+            continue
+        if key == "status":
+            if diff.terminal_status_diff is not None:
+                current, baseline = diff.terminal_status_diff
+                rows.append(("Terminal state", baseline, current, "changed"))
+                emitted.add(key)
+            continue
+        add_summary_row(key)
+
+    model_row = _model_change_summary(diff)
+    if model_row is not None:
+        rows.append(model_row)
+
+    for key in _summary_keys(diff.summary_diff):
+        if key in emitted:
+            continue
+        add_summary_row(key)
+
+    return rows
 
 
 def format_diff_text(diff: RunDiff) -> str:
@@ -293,6 +440,19 @@ def format_diff_text(diff: RunDiff) -> str:
             else:
                 lines.append(f"  {et}: {cb} -> {ca} ({_pct_change(ca, cb)})")
 
+    if diff.guardrail_event_diff is not None:
+        current, baseline = diff.guardrail_event_diff
+        lines.append("")
+        lines.append(
+            f"Guardrail events: {baseline} -> {current} "
+            f"({_pct_change(current, baseline)})"
+        )
+
+    if diff.terminal_status_diff is not None and "status" not in diff.summary_diff:
+        current, baseline = diff.terminal_status_diff
+        lines.append("")
+        lines.append(f"Terminal state: {baseline} -> {current}")
+
     return "\n".join(lines)
 
 
@@ -304,15 +464,17 @@ def format_diff_markdown(diff: RunDiff) -> str:
     """
     sections: list[str] = []
 
-    if diff.summary_diff:
-        rows = ["| Metric | Baseline | Current | Change |", "|---|---|---|---|"]
-        for key in _summary_keys(diff.summary_diff):
-            va, vb = diff.summary_diff[key]
-            label = _summary_label(key)
-            if isinstance(va, (int, float)) and isinstance(vb, (int, float)):
-                rows.append(f"| {label} | {vb} | {va} | {_pct_change(va, vb)} |")
-            else:
-                rows.append(f"| {label} | {vb} | {va} | changed |")
+    behavior_rows = _behavior_change_rows(diff)
+    if behavior_rows:
+        rows = ["| Behavior | Baseline | Current | Change |", "|---|---|---|---|"]
+        for behavior, baseline, current, change in behavior_rows:
+            rows.append(
+                "| "
+                f"{_table_cell(behavior)} | "
+                f"{_table_cell(baseline)} | "
+                f"{_table_cell(current)} | "
+                f"{_table_cell(change)} |"
+            )
         sections.append("\n".join(rows))
 
     if _has_tool_path_changes(diff):
@@ -342,4 +504,4 @@ def format_diff_markdown(diff: RunDiff) -> str:
 
     if not sections:
         return ""
-    return "### What changed vs baseline\n\n" + "\n\n".join(sections)
+    return "### Top behavior changes\n\n" + "\n\n".join(sections)

--- a/maida/diff.py
+++ b/maida/diff.py
@@ -54,8 +54,11 @@ def _metrics_from_baseline(baseline: dict) -> dict:
     exact_tool_sequence = isinstance(baseline.get("tool_call_sequence"), list)
     if not tool_call_sequence:
         tool_call_sequence = tool_path
+    summary = dict(baseline.get("summary") or {})
+    final_status = baseline.get("final_status") or summary.get("status") or "unknown"
+    summary["status"] = final_status
     return {
-        "summary": baseline.get("summary", {}),
+        "summary": summary,
         "tool_path": tool_path,
         "tool_call_sequence": tool_call_sequence,
         "_tool_call_sequence_exact": exact_tool_sequence,
@@ -64,7 +67,7 @@ def _metrics_from_baseline(baseline: dict) -> dict:
         "llm_models_used": baseline.get("llm_models_used", []),
         "event_type_sequence": baseline.get("event_type_sequence", []),
         "guardrail_events": baseline.get("guardrail_events", []),
-        "final_status": baseline.get("final_status", "unknown"),
+        "final_status": final_status,
     }
 
 

--- a/tests/test_assertions.py
+++ b/tests/test_assertions.py
@@ -1,12 +1,15 @@
 """Tests for maida.assertions: policy checks, exit codes, report formatting."""
 
 import json
+from textwrap import dedent
 
 import pytest
 
 from maida import record_llm_call, record_tool_call, traced_run
 from maida.assertions import (
     AssertionPolicy,
+    AssertionReport,
+    AssertionResult,
     RegressionReasonCode,
     _check_threshold,
     format_report_json,
@@ -522,10 +525,11 @@ def test_format_report_markdown_pass_layout(temp_data_dir):
     policy = AssertionPolicy(max_steps=100)
     report = run_assertions(run_id, policy, config=config)
     md = format_report_markdown(report)
-    assert "## ✅ Maida gate: no behavioral regression" in md
+    assert "## ✅ Maida verdict: pass" in md
     assert "<details>" in md  # passing checks are collapsed
     assert "passing checks" in md
     assert "`no_regression`:" not in md
+    assert "### Next steps" in md
     assert "Reproduce locally" in md
     assert "maida.ai" in md
 
@@ -537,13 +541,15 @@ def test_format_report_markdown_failed_checks_first(temp_data_dir):
     policy = AssertionPolicy(max_steps=2, no_loops=True)
     report = run_assertions(run_id, policy, config=config)
     md = format_report_markdown(report)
-    assert "## ❌ Maida gate: agent behavior regressed" in md
+    assert "## ❌ Maida verdict: fail" in md
     assert "1 of 2 checks failed" in md
     # failed table with expected/actual comes before the collapsed passing block
     assert md.index("#### `step_count_exceeded`") < md.index("<details>")
+    assert "### Failed checks by reason code" in md
     assert "| Check | Expected | Actual | Details |" in md
     assert "| ❌ `step_count` |" in md
     assert "✅ `no_loops`" in md
+    assert "### Next steps" in md
 
 
 def test_format_report_markdown_groups_failures_by_reason_code(temp_data_dir):
@@ -591,7 +597,7 @@ def test_format_report_markdown_includes_diff_section(temp_data_dir):
 
     diff = compute_diff(run_id, baseline=baseline, config=config)
     md = format_report_markdown(report, diff=diff, baseline_path="bl.json")
-    assert "### What changed vs baseline" in md
+    assert "### Top behavior changes" in md
     assert "`new_tool`" in md
     assert "maida diff" in md
     assert "--baseline bl.json" in md
@@ -603,7 +609,200 @@ def test_format_report_markdown_no_diff_section_without_diff(temp_data_dir):
     policy = AssertionPolicy(max_steps=100)
     report = run_assertions(run_id, policy, config=config)
     md = format_report_markdown(report)
-    assert "What changed vs baseline" not in md
+    assert "Top behavior changes" not in md
+
+
+def test_format_report_markdown_pass_snapshot():
+    report = AssertionReport(run_id="a" * 32, baseline_run_id=None)
+    report.add(
+        AssertionResult(
+            check_name="step_count",
+            passed=True,
+            message="8 steps (max: 12)",
+            expected="12",
+            actual="8",
+        )
+    )
+
+    md = format_report_markdown(report)
+
+    assert (
+        md
+        == dedent(
+            """\
+        ## ✅ Maida verdict: pass
+
+        **All 1 checks passed** · run `aaaaaaaa`
+
+        <details>
+        <summary>✅ 1 passing checks</summary>
+
+        | Check | Details |
+        |---|---|
+        | ✅ `step_count` | 8 steps (max: 12) |
+
+        </details>
+
+        ### Next steps
+
+        - No gate action needed; inspect the trace with `maida view aaaaaaaa` if desired.
+
+        <details>
+        <summary>Reproduce locally</summary>
+
+        ```bash
+        pip install maida-ai
+        maida view aaaaaaaa
+        ```
+
+        </details>
+
+        ---
+        *Gated by [Maida](https://maida.ai) — the local-first behavioral regression gate for AI agents.*
+        """
+        ).strip()
+    )
+
+
+def test_format_report_markdown_failure_behavior_diff_snapshot():
+    from maida.diff import RunDiff
+
+    report = AssertionReport(run_id="a" * 32, baseline_run_id="b" * 32)
+    report.add(
+        AssertionResult(
+            check_name="step_count",
+            passed=False,
+            message="18 steps (baseline: 8, tolerance: 50%)",
+            reason_code=RegressionReasonCode.STEP_COUNT_EXCEEDED,
+            expected="12",
+            actual="18",
+        )
+    )
+    report.add(
+        AssertionResult(
+            check_name="no_loops",
+            passed=False,
+            message="2 loop warning(s) detected: cycle x2 search -> summarize",
+            reason_code=RegressionReasonCode.CYCLE_DETECTED,
+            actual="2",
+        )
+    )
+    report.add(
+        AssertionResult(
+            check_name="cost_tokens",
+            passed=True,
+            message="450 tokens (baseline: 100, tolerance: 400%)",
+        )
+    )
+    diff = RunDiff(
+        run_a_id="a" * 32,
+        run_b_id="b" * 32,
+        summary_diff={
+            "total_events": (18, 8),
+            "loop_warnings": (2, 0),
+            "status": ("error", "ok"),
+            "duration_ms": (2500, 1000),
+            "total_tokens": (450, 100),
+        },
+        tool_path_diff={
+            "new": ["web_search"],
+            "removed": [],
+            "repeated": {"web_search": (0, 2)},
+            "reordered": True,
+            "current_sequence_exact": True,
+            "baseline_sequence_exact": True,
+        },
+        new_tools=["web_search"],
+        repeated_tools={"web_search": (0, 2)},
+        reordered_tools=True,
+        current_tool_sequence=["search", "web_search", "web_search", "summarize"],
+        baseline_tool_sequence=["search", "summarize"],
+        model_changes={"added": ["gpt-4.1-mini"], "removed": ["gpt-4.1"]},
+        guardrail_event_diff=(1, 0),
+        terminal_status_diff=("error", "ok"),
+    )
+
+    md = format_report_markdown(report, diff=diff, baseline_path="baseline.json")
+
+    assert (
+        md
+        == dedent(
+            """\
+        ## ❌ Maida verdict: fail
+
+        **2 of 3 checks failed** · run `aaaaaaaa` vs baseline `bbbbbbbb`
+
+        ### Top behavior changes
+
+        | Behavior | Baseline | Current | Change |
+        |---|---|---|---|
+        | Steps | 8 | 18 | +125% |
+        | Tool path | search -> summarize | search -> web_search -> web_search -> summarize | 1 new; repeated calls; order changed |
+        | Loops/cycles | 0 | 2 | NEW |
+        | Guardrail events | 0 | 1 | NEW |
+        | Terminal state | ok | error | changed |
+        | Latency envelope | 1000 ms | 2500 ms | +150% |
+        | Cost envelope | 100 tokens | 450 tokens | +350% |
+        | Models | gpt-4.1 | gpt-4.1-mini | 1 added; 1 removed |
+
+        **Tool path:**
+        - Baseline: `search -> summarize`
+        - Current: `search -> web_search -> web_search -> summarize`
+
+        **Tool changes:**
+        - ➕ `web_search` — new tool, not in baseline
+        - 🔁 `web_search` — repeated 0 -> 2 calls
+        - 🔀 Tool order changed for shared calls
+
+        **Model changes:**
+        - ➕ `gpt-4.1-mini`
+        - ➖ `gpt-4.1`
+
+        ### Failed checks by reason code
+
+        #### `step_count_exceeded`
+
+        | Check | Expected | Actual | Details |
+        |---|---|---|---|
+        | ❌ `step_count` | 12 | 18 | 18 steps (baseline: 8, tolerance: 50%) |
+
+        #### `cycle_detected`
+
+        | Check | Expected | Actual | Details |
+        |---|---|---|---|
+        | ❌ `no_loops` | — | 2 | 2 loop warning(s) detected: cycle x2 search -> summarize |
+
+        <details>
+        <summary>✅ 1 passing checks</summary>
+
+        | Check | Details |
+        |---|---|
+        | ✅ `cost_tokens` | 450 tokens (baseline: 100, tolerance: 400%) |
+
+        </details>
+
+        ### Next steps
+
+        - Inspect the full diff: `maida diff aaaaaaaa --baseline baseline.json`
+        - Open the trace locally: `maida view aaaaaaaa`
+        - If this is expected, update the baseline or policy; otherwise fix the agent behavior and rerun the gate.
+
+        <details>
+        <summary>Reproduce locally</summary>
+
+        ```bash
+        pip install maida-ai
+        maida diff aaaaaaaa --baseline baseline.json
+        maida view aaaaaaaa
+        ```
+
+        </details>
+
+        ---
+        *Gated by [Maida](https://maida.ai) — the local-first behavioral regression gate for AI agents.*
+        """
+        ).strip()
+    )
 
 
 def test_format_report_text_appends_diff_on_failure(temp_data_dir):

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -486,7 +486,7 @@ def test_assert_markdown_format(empty_data_dir):
         app, ["assert", run_id, "--max-steps", "10", "--format", "markdown"]
     )
     assert result.exit_code == 0
-    assert "Maida gate" in result.output
+    assert "Maida verdict" in result.output
 
 
 def test_assert_with_baseline(empty_data_dir):
@@ -744,8 +744,8 @@ def test_demo_regression_story(empty_data_dir, tmp_path, monkeypatch):
     assert "duration_ms:" not in result.output
     # and preview the PR comment
     assert "PR comment preview" in result.output
-    assert "Maida gate: agent behavior regressed" in result.output
-    assert "What changed vs baseline" in result.output
+    assert "Maida verdict: fail" in result.output
+    assert "Top behavior changes" in result.output
 
 
 def test_demo_regression_is_local_only_and_forces_demo_loop_settings(

--- a/tests/test_diff.py
+++ b/tests/test_diff.py
@@ -250,6 +250,26 @@ def test_baseline_with_null_tool_path_is_treated_as_empty(temp_data_dir):
     assert d.removed_tools == []
 
 
+def test_baseline_status_is_canonicalized_for_diff(temp_data_dir):
+    config = load_config()
+    run_id = _make_run(config, name="current-ok", events=[])
+    baseline = {
+        "source_run_id": "inconsistent-baseline",
+        "summary": {"status": "ok"},
+        "tool_path": [],
+        "tool_call_counts": {},
+        "llm_models_used": [],
+        "event_type_sequence": [],
+        "guardrail_events": [],
+        "final_status": "error",
+    }
+
+    d = compute_diff(run_id, baseline=baseline, config=config)
+
+    assert d.summary_diff["status"] == ("ok", "error")
+    assert d.terminal_status_diff == ("ok", "error")
+
+
 def test_diff_tracks_guardrail_and_terminal_status_changes(temp_data_dir):
     config = load_config()
     run_id = _make_run(config, name="current-ok", events=[])

--- a/tests/test_diff.py
+++ b/tests/test_diff.py
@@ -250,6 +250,26 @@ def test_baseline_with_null_tool_path_is_treated_as_empty(temp_data_dir):
     assert d.removed_tools == []
 
 
+def test_diff_tracks_guardrail_and_terminal_status_changes(temp_data_dir):
+    config = load_config()
+    run_id = _make_run(config, name="current-ok", events=[])
+    baseline = {
+        "source_run_id": "old-error-baseline",
+        "summary": {"status": "error"},
+        "tool_path": [],
+        "tool_call_counts": {},
+        "llm_models_used": [],
+        "event_type_sequence": [],
+        "guardrail_events": [{"event_type": "ERROR"}],
+        "final_status": "error",
+    }
+
+    d = compute_diff(run_id, baseline=baseline, config=config)
+
+    assert d.guardrail_event_diff == (0, 1)
+    assert d.terminal_status_diff == ("ok", "error")
+
+
 def test_diff_tool_path_reports_step_delta_and_tool_changes(temp_data_dir):
     config = load_config()
     bl_rid = _make_run(
@@ -427,8 +447,8 @@ def test_format_diff_markdown_includes_changes(temp_data_dir):
     )
     diff = compute_diff(run_id, baseline=baseline, config=config)
     md = format_diff_markdown(diff)
-    assert "### What changed vs baseline" in md
-    assert "| Metric | Baseline | Current | Change |" in md
+    assert "### Top behavior changes" in md
+    assert "| Behavior | Baseline | Current | Change |" in md
     assert "➕ `escalate`" in md
     assert "**Model changes:**" in md
     assert "➕ `model-b`" in md


### PR DESCRIPTION
Surface a verdict-first markdown report with top behavior changes, reason-code grouping, and concise next steps. Extend diff output with guardrail event and terminal status comparisons, and add deterministic markdown snapshot coverage.

- Redesigned Markdown assertion reports to lead with `Maida verdict: pass/fail`, include top behavior changes before failed-check detail, group failures by reason code, collapse passing checks, and show concise next steps.
- Extended `RunDiff` with explicit guardrail event and terminal status comparisons, then used those fields in the Markdown behavior summary.
- Reworked `format_diff_markdown()` around a bounded `Top behavior changes` table while preserving compact tool-path truncation and detailed tool/model change sections.
- Added deterministic Markdown snapshot tests for pass and failure output, plus coverage for guardrail and terminal status diff fields.
- Updated README and docs to describe the new PR comment shape.

Fixes #65
