### PR TITLE
Align changelog action ref

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@
 
 - **`maida demo`** - bundled simulated agent: `pip install maida-ai && maida demo` produces a traced run with no repo clone, no network, and no API keys.
 - **`maida demo --regression`** - the full gate story in one command: baseline a known-good run, run a "refactored" agent that loops, calls a new tool, and burns more tokens, then show the failing report with a PR-comment preview.
-- **`maida init`** - scaffolds a commented starter `.maida/policy.yaml`, and with `--github` a ready-to-edit workflow using `maida-ai/maida-assert@v2`.
+- **`maida init`** - scaffolds a commented starter `.maida/policy.yaml`, and with `--github` a ready-to-edit workflow using `maida-ai/maida-assert@V4`.
 - **Latest-run defaults** - `maida assert`, `maida baseline`, `maida export`, and `maida diff` no longer require a run ID; they default to the most recent run (announced on stderr so stdout stays machine-readable).
 - **Richer gate reports** - the markdown report (the PR comment) now leads with a verdict, lists failed checks first with expected vs actual values, collapses passing checks, embeds a "What changed vs baseline" structural diff, and ends with a local-repro snippet. The text report appends the same diff on failure.
 

--- a/tests/test_docs.py
+++ b/tests/test_docs.py
@@ -67,6 +67,7 @@ def test_trace_format_documents_current_storage_contract():
 
 def test_action_version_references_match_scaffold():
     docs = [
+        "CHANGELOG.md",
         "README.md",
         "docs/cli.md",
         "docs/regression-testing.md",


### PR DESCRIPTION
The branch already contained the main implementation for the first failing PR workflow: the regression demo, generated GitHub workflow, verdict-first PR markdown, CLI/action exit-code contract, and current action references were present and covered by tests. During cross-repo verification, one remaining stale public reference was found in the unreleased changelog: it still described `maida init --github` as using `maida-ai/maida-assert@v2`.

The stale changelog reference was updated to the current `maida-ai/maida-assert@V4` ref, and the docs-version regression test now includes `CHANGELOG.md` so the changelog stays aligned with the scaffold constants. The separate Windows console Unicode behavior was not changed for this issue, per user direction.

- Updated `CHANGELOG.md` so the unreleased `maida init --github` highlight points at `maida-ai/maida-assert@V4`.
- Extended `tests/test_docs.py::test_action_version_references_match_scaffold` to include `CHANGELOG.md` in the public-doc action-version consistency check.

Fixes #62