### PR TITLE
Fix /api/runs/{id}/meta is not validated

### DIFF
--- a/maida/server.py
+++ b/maida/server.py
@@ -51,10 +51,13 @@ def create_app() -> FastAPI:
     def get_run_meta(trace_id: str, config: MaidaConfig = Depends(_get_config)) -> dict:
         trace_id = _validated_trace_id(trace_id)
         try:
+            # TODO: cache or incrementally project events for large live traces.
             meta, _ = storage.load_validated_run(trace_id, config)
             return meta
         except FileNotFoundError:
             raise HTTPException(status_code=404, detail="run not found")
+        except ValueError:
+            raise HTTPException(status_code=400, detail="invalid trace_id")
         except storage.RunValidationError as e:
             raise HTTPException(status_code=422, detail=str(e))
 
@@ -98,10 +101,13 @@ def create_app() -> FastAPI:
     ) -> dict:
         trace_id = _validated_trace_id(trace_id)
         try:
+            # TODO: cache or incrementally project events for large live traces.
             meta, _ = storage.load_validated_run(trace_id, config)
             return meta
         except FileNotFoundError:
             raise HTTPException(status_code=404, detail="run not found")
+        except ValueError:
+            raise HTTPException(status_code=400, detail="invalid trace_id")
         except storage.RunValidationError as e:
             raise HTTPException(status_code=422, detail=str(e))
 

--- a/maida/server.py
+++ b/maida/server.py
@@ -51,9 +51,12 @@ def create_app() -> FastAPI:
     def get_run_meta(trace_id: str, config: MaidaConfig = Depends(_get_config)) -> dict:
         trace_id = _validated_trace_id(trace_id)
         try:
-            return storage.load_run_meta(trace_id, config)
+            meta, _ = storage.load_validated_run(trace_id, config)
+            return meta
         except FileNotFoundError:
             raise HTTPException(status_code=404, detail="run not found")
+        except storage.RunValidationError as e:
+            raise HTTPException(status_code=422, detail=str(e))
 
     @app.get("/api/runs/{trace_id}/spans")
     def get_run_spans(
@@ -95,9 +98,12 @@ def create_app() -> FastAPI:
     ) -> dict:
         trace_id = _validated_trace_id(trace_id)
         try:
-            return storage.load_run_meta(trace_id, config)
+            meta, _ = storage.load_validated_run(trace_id, config)
+            return meta
         except FileNotFoundError:
             raise HTTPException(status_code=404, detail="run not found")
+        except storage.RunValidationError as e:
+            raise HTTPException(status_code=422, detail=str(e))
 
     @app.post("/api/runs/{trace_id}/rename")
     def rename_run(

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -128,6 +128,22 @@ def test_server_returns_404_for_valid_but_missing_run_id(temp_data_dir):
     assert "not found" in (r.json().get("detail") or "").lower()
 
 
+def test_server_meta_returns_422_for_invalid_run_format(temp_data_dir):
+    """GET /api/runs/{run_id} with malformed spans returns 422, not 200."""
+    config = load_config()
+    trace_id = "cc" + "b" * 30
+    _write_run_with_malformed_span(config, trace_id)
+    client = TestClient(create_app())
+
+    r = client.get(f"/api/runs/{trace_id}")
+
+    assert r.status_code == 422
+    detail = r.json().get("detail") or ""
+    assert "spans.jsonl line 1" in detail
+    assert "Next step:" in detail
+    assert "sk-test-DO-NOT-LEAK" not in detail
+
+
 def test_server_returns_200_for_valid_run_id(temp_data_dir):
     """Valid trace_id with existing run returns 200 and metadata."""
     config = load_config()


### PR DESCRIPTION
Validate run meta in GET /api/runs/{id} and /rename endpoints

move calls from storage.load_run_meta to storage.load_validated_run

fixes #95