### PR TITLE
fix thresholds are only violated if violating the upper bound

### DIFF
--- a/docs/cli.md
+++ b/docs/cli.md
@@ -203,15 +203,19 @@ maida assert [TRACE_ID] [options]
 | `--baseline`, `-b` | - | Baseline JSON file to compare against |
 | `--policy` | `.maida/policy.yaml` (auto-detected) | Policy YAML file with assertion thresholds |
 | `--max-steps` | - | Max total events allowed |
+| `--min-steps` | - | Min total events required |
 | `--step-tolerance` | `0.5` | Fractional tolerance for step count |
 | `--max-tool-calls` | - | Max tool calls allowed |
+| `--min-tool-calls` | - | Min tool calls required |
 | `--tool-call-tolerance` | `0.5` | Fractional tolerance for tool calls |
 | `--no-new-tools` | `false` | Fail if run uses tools not in baseline |
 | `--no-loops` | `false` | Fail if any LOOP_WARNING present |
 | `--no-guardrails` | `false` | Fail if any guardrail was triggered |
 | `--max-cost-tokens` | - | Max total tokens allowed |
+| `--min-cost-tokens` | - | Min total tokens required |
 | `--cost-tolerance` | `0.5` | Fractional tolerance for token cost |
 | `--max-duration-ms` | - | Max run duration in ms |
+| `--min-duration-ms` | - | Min run duration in ms |
 | `--duration-tolerance` | `0.5` | Fractional tolerance for duration |
 | `--expect-status` | - | Expected run status (`ok` or `error`) |
 | `--format`, `-f` | `text` | Output format: `text`, `json`, or `markdown` |

--- a/docs/reference/policy.md
+++ b/docs/reference/policy.md
@@ -39,12 +39,16 @@ All fields are optional. A check is **disabled** unless at least one relevant va
 | YAML key | Type | Default | CLI flag | Description |
 |---|---|---|---|---|
 | `max_steps` | `int` or `null` | `null` | `--max-steps` | Hard cap on total event count |
+| `min_steps` | `int` or `null` | `null` | `--min-steps` | Hard floor on total event count |
 | `step_tolerance` | `float` | `0.5` | `--step-tolerance` | Fractional tolerance for step count when comparing against a baseline |
 | `max_tool_calls` | `int` or `null` | `null` | `--max-tool-calls` | Hard cap on tool call count |
+| `min_tool_calls` | `int` or `null` | `null` | `--min-tool-calls` | Hard floor on tool call count |
 | `tool_call_tolerance` | `float` | `0.5` | `--tool-call-tolerance` | Fractional tolerance for tool calls |
 | `max_cost_tokens` | `int` or `null` | `null` | `--max-cost-tokens` | Hard cap on total token count |
+| `min_cost_tokens` | `int` or `null` | `null` | `--min-cost-tokens` | Hard floor on total token count |
 | `cost_tolerance` | `float` | `0.5` | `--cost-tolerance` | Fractional tolerance for token cost |
 | `max_duration_ms` | `int` or `null` | `null` | `--max-duration-ms` | Hard cap on run duration in milliseconds |
+| `min_duration_ms` | `int` or `null` | `null` | `--min-duration-ms` | Hard floor on run duration in milliseconds |
 | `duration_tolerance` | `float` | `0.5` | `--duration-tolerance` | Fractional tolerance for duration |
 
 ### Boolean checks
@@ -67,27 +71,51 @@ All fields are optional. A check is **disabled** unless at least one relevant va
 
 Tolerances are **fractional**, not percentage: `0.5` means 50%, `0.2` means 20%.
 
-For each numeric metric (steps, tool calls, tokens, duration), the check depends on what is available:
+For each numeric metric (steps, tool calls, tokens, duration), the check enforces both an **upper bound** and a **lower bound** when a baseline is available:
 
-| Baseline provided? | `max_*` set? | Effective limit | Meaning |
-|---|---|---|---|
-| Yes | Yes | `min(baseline * (1 + tolerance), max_*)` | Baseline-relative with a hard cap |
-| Yes | No | `baseline * (1 + tolerance)` | Baseline-relative only |
-| No | Yes | `max_*` | Hard cap only |
-| No | No | *(check disabled)* | Nothing to compare against |
+| Baseline provided? | `max_*` set? | `min_*` set? | Effective upper limit | Effective lower limit |
+|---|---|---|---|---|
+| Yes | Yes | — | `min(baseline * (1 + tol), max_*)` | `max(1, baseline * (1 - tol))` |
+| Yes | No | — | `baseline * (1 + tol)` | `max(1, baseline * (1 - tol))` |
+| Yes | Yes | Yes | `min(baseline * (1 + tol), max_*)` | `max(1, baseline * (1 - tol), min_*)` |
+| Yes | — | Yes | `baseline * (1 + tol)` | `max(1, baseline * (1 - tol), min_*)` |
+| No | Yes | — | `max_*` | *(none)* |
+| No | — | Yes | *(none)* | `min_*` |
+| No | No | No | *(check disabled)* | *(check disabled)* |
 
-The check **passes** when `actual <= limit`.
+A check **passes** when `lower_limit <= actual <= upper_limit`. If the actual value falls outside either bound, the check fails with an appropriate reason code.
 
-When a baseline value is zero and a matching `max_*` cap is set, Maida uses
-the cap as the effective limit. Without a cap, a zero baseline allows no growth
-for that metric.
+### Upper bound (too high)
 
-**Example:** A baseline recorded 40 tool calls. With `tool_call_tolerance: 0.25` and `max_tool_calls: 60`:
+The upper limit starts from the baseline scaled by `(1 + tolerance)` and is optionally capped by `max_*`:
 
-- Baseline limit: `40 * 1.25 = 50`
-- Hard cap: `60`
-- Effective limit: `min(50, 60) = 50`
-- A run with 48 tool calls passes; a run with 52 fails.
+```
+upper_limit = min(baseline * (1 + tolerance), max_*)    # if both provided
+upper_limit = baseline * (1 + tolerance)                  # baseline only
+upper_limit = max_*                                       # standalone cap
+```
+
+When a baseline value is zero and a matching `max_*` cap is set, Maida uses the cap as the effective limit. Without a cap, a zero baseline allows no growth for that metric.
+
+### Lower bound (too low)
+
+The lower limit starts from the baseline scaled by `(1 - tolerance)` and is never allowed below **1** for a positive baseline, because a metric falling to zero when the baseline had non-zero activity is always a regression:
+
+```
+lower_limit = max(1, baseline * (1 - tolerance))           # positive baseline
+lower_limit = max(1, baseline * (1 - tolerance), min_*)    # with explicit floor
+lower_limit = min_*                                        # standalone floor only
+```
+
+A zero baseline has no meaningful lower bound — the metric can't go below zero — so the lower-bound check is skipped.
+
+### Example
+
+A baseline recorded 40 tool calls with `tool_call_tolerance: 0.25`, `max_tool_calls: 60`, and `min_tool_calls: 10`:
+
+- Upper limit: `min(40 * 1.25, 60) = 50`
+- Lower limit: `max(1, 40 * 0.75, 10) = 30`
+- A run with 48 tool calls passes; 52 fails (too high); 5 fails (too low).
 
 ---
 
@@ -98,14 +126,18 @@ for that metric.
 | Reason code | Check |
 |---|---|
 | `step_count_exceeded` | Step/event count exceeded the baseline envelope or hard cap |
+| `step_count_below_minimum` | Step/event count fell below the baseline envelope or hard floor |
 | `new_tool_path` | A tool appeared that was not present in the baseline |
 | `tool_call_count_exceeded` | Tool call count exceeded the baseline envelope or hard cap |
+| `tool_call_count_below_minimum` | Tool call count fell below the baseline envelope or hard floor |
 | `loop_detected` | One or more repeated-call `LOOP_WARNING` events were detected |
 | `cycle_detected` | One or more multi-event cycle `LOOP_WARNING` events were detected |
 | `terminal_state_missing` | The run did not end in the expected terminal status |
 | `guardrail_event_changed` | Guardrail-triggered events were detected |
 | `latency_envelope_exceeded` | Run duration exceeded the baseline envelope or hard cap |
+| `duration_below_minimum` | Run duration fell below the baseline envelope or hard floor |
 | `cost_envelope_exceeded` | Token usage exceeded the baseline envelope or hard cap |
+| `cost_below_minimum` | Token usage fell below the baseline envelope or hard floor |
 
 Machine-readable JSON includes a top-level `reason_codes` array containing the failed reason codes in result order, plus `reason_code` on every individual result. Markdown starts with a verdict, shows top behavior changes when a baseline diff is available, and groups failed checks by reason code for PR comments.
 
@@ -179,12 +211,16 @@ assert:
 # .maida/policy.yaml - checked into the repo
 assert:
   max_steps: 80
+  min_steps: 10
   step_tolerance: 0.2
   max_tool_calls: 30
+  min_tool_calls: 5
   tool_call_tolerance: 0.2
   max_cost_tokens: 10000
+  min_cost_tokens: 100
   cost_tolerance: 0.1
   max_duration_ms: 30000
+  min_duration_ms: 500
   duration_tolerance: 0.2
   no_new_tools: true
   no_loops: true

--- a/docs/regression-testing.md
+++ b/docs/regression-testing.md
@@ -82,11 +82,15 @@ maida assert <TRACE_ID> --max-steps 80 --max-tool-calls 30 --no-loops
 
 ### Combining baseline and thresholds
 
-When both a baseline and a `max_*` threshold are set, the effective limit is the **lesser** of the two:
+When both a baseline and thresholds are set, the effective limit is the **lesser** of the tolerance-based upper bound and the hard cap. A **lower bound** is also enforced to catch regressions where the metric falls below the baseline:
 
 ```
-limit = min(baseline_value * (1 + tolerance), max_value)
+upper_limit = min(baseline * (1 + tolerance), max_value)
+lower_limit = max(1, baseline * (1 - tolerance))
+passes when lower_limit <= actual <= upper_limit
 ```
+
+When a baseline is available, a minimum of **1** is always required — a metric dropping to zero when the baseline had non-zero activity is always a regression. You can raise this floor further with `min_*` thresholds.
 
 See the [Policy YAML reference](reference/policy.md#how-thresholds-work) for the full decision table.
 

--- a/maida/assertions.py
+++ b/maida/assertions.py
@@ -35,6 +35,10 @@ class RegressionReasonCode(str, Enum):
     GUARDRAIL_EVENT_CHANGED = "guardrail_event_changed"
     LATENCY_ENVELOPE_EXCEEDED = "latency_envelope_exceeded"
     COST_ENVELOPE_EXCEEDED = "cost_envelope_exceeded"
+    STEP_COUNT_BELOW_MINIMUM = "step_count_below_minimum"
+    TOOL_CALL_COUNT_BELOW_MINIMUM = "tool_call_count_below_minimum"
+    COST_BELOW_MINIMUM = "cost_below_minimum"
+    DURATION_BELOW_MINIMUM = "duration_below_minimum"
 
 
 @dataclass
@@ -46,18 +50,26 @@ class AssertionPolicy:
 
     # Maximum allowed step count
     max_steps: int | None = None
+    # Minimum required step count
+    min_steps: int | None = None
     step_tolerance: float = kDefaultTolerance
 
     # Maximum allowed tool call count
     max_tool_calls: int | None = None
+    # Minimum required tool call count
+    min_tool_calls: int | None = None
     tool_call_tolerance: float = kDefaultTolerance
 
     # Maximum allowed cost tokens
     max_cost_tokens: int | None = None
+    # Minimum required cost tokens
+    min_cost_tokens: int | None = None
     cost_tolerance: float = kDefaultTolerance
 
     # Maximum allowed duration in milliseconds
     max_duration_ms: int | None = None
+    # Minimum required duration in milliseconds
+    min_duration_ms: int | None = None
     duration_tolerance: float = kDefaultTolerance
 
     no_new_tools: bool = False  # Fail if run uses tools not in baseline
@@ -146,66 +158,103 @@ def _check_threshold(
     actual: int | float,
     baseline_value: int | float | None,
     tolerance: float,
-    standalone_max: int | float | None,
-    check_name: str,
-    reason_code: RegressionReasonCode,
-    unit: str,
+    standalone_max: int | float | None = None,
+    standalone_min: int | float | None = None,
+    check_name: str = "",
+    reason_code_exceeded: RegressionReasonCode = RegressionReasonCode.NO_REGRESSION,
+    reason_code_below_minimum: RegressionReasonCode = RegressionReasonCode.NO_REGRESSION,
+    unit: str = "",
 ) -> AssertionResult | None:
     """Shared threshold/tolerance comparison for numeric metrics.
 
-    Returns an ``AssertionResult`` if any check was enabled, else ``None``.
+    Computes both upper and lower bounds from the baseline value and
+    tolerance, then applies optional standalone hard caps/floors.  Returns
+    ``None`` when no check is configured (no baseline and no standalone
+    limit).
     """
-    if baseline_value is not None and standalone_max is not None:
+    has_baseline = baseline_value is not None
+    has_upper = has_baseline or standalone_max is not None
+    has_lower = standalone_min is not None or (
+        has_baseline and baseline_value > 0  # noqa: PLR0914
+    )
+
+    if not has_upper and not has_lower:
+        return None
+
+    # --- upper limit ---
+    upper_limit: float | None = None
+    if has_baseline:
         if baseline_value > 0:
-            limit = min(
-                baseline_value * (1 + tolerance),
-                float(standalone_max),
-            )
+            upper_limit = float(baseline_value) * (1 + tolerance)
+            if standalone_max is not None:
+                upper_limit = min(upper_limit, float(standalone_max))
         else:
-            limit = float(standalone_max)
-        passed = actual <= limit
-        return AssertionResult(
-            check_name=check_name,
-            passed=passed,
-            message=(
-                f"{int(actual)} {unit} (baseline: {int(baseline_value)}, "
-                f"tolerance: {tolerance:.0%}, cap: {standalone_max})"
-            ),
-            reason_code=_reason_code_for(passed, reason_code),
-            expected=str(int(limit)),
-            actual=str(int(actual)),
-        )
+            # baseline is 0 — tolerance-based bound is 0;
+            # standalone_max is the effective cap
+            upper_limit = float(standalone_max) if standalone_max is not None else 0.0
+    elif standalone_max is not None:
+        upper_limit = float(standalone_max)
 
-    if baseline_value is not None:
-        if baseline_value > 0:
-            limit = baseline_value * (1 + tolerance)
+    # --- lower limit ---
+    lower_limit: float | None = None
+    if has_baseline and baseline_value > 0:
+        lower_limit = max(1.0, float(baseline_value) * (1 - tolerance))
+        if standalone_min is not None:
+            lower_limit = max(lower_limit, float(standalone_min))
+    elif standalone_min is not None:
+        lower_limit = float(standalone_min)
+
+    # --- check ---
+    exceeded_upper = upper_limit is not None and actual > upper_limit
+    below_lower = lower_limit is not None and actual < lower_limit
+    passed = not exceeded_upper and not below_lower
+
+    if not passed:
+        if exceeded_upper:
+            reason_code = reason_code_exceeded
+            expected = str(int(upper_limit))
         else:
-            limit = float(standalone_max) if standalone_max is not None else 0.0
-        passed = actual <= limit
-        return AssertionResult(
-            check_name=check_name,
-            passed=passed,
-            message=(
-                f"{int(actual)} {unit} (baseline: {int(baseline_value)}, "
-                f"tolerance: {tolerance:.0%})"
-            ),
-            reason_code=_reason_code_for(passed, reason_code),
-            expected=str(int(limit)),
-            actual=str(int(actual)),
-        )
+            reason_code = reason_code_below_minimum
+            expected = str(int(lower_limit))
+    else:
+        reason_code = RegressionReasonCode.NO_REGRESSION
+        expected = str(int(upper_limit if upper_limit is not None else lower_limit))
 
-    if standalone_max is not None:
-        passed = actual <= standalone_max
-        return AssertionResult(
-            check_name=check_name,
-            passed=passed,
-            message=f"{int(actual)} {unit} (max: {standalone_max})",
-            reason_code=_reason_code_for(passed, reason_code),
-            expected=str(standalone_max),
-            actual=str(int(actual)),
-        )
+    # --- message ---
+    details: list[str] = []
+    if has_baseline:
+        details.append(f"baseline: {int(baseline_value)}")
+        details.append(f"tolerance: {tolerance:.0%}")
+        if lower_limit is not None and upper_limit is not None:
+            details.append(f"range: {int(lower_limit)}–{int(upper_limit)}")
+            if standalone_max is not None:
+                details.append(f"cap: {standalone_max}")
+            if standalone_min is not None:
+                details.append(f"floor: {standalone_min}")
+        elif upper_limit is not None:
+            details.append(f"max: {int(upper_limit)}")
+            if standalone_max is not None:
+                details.append(f"cap: {standalone_max}")
+        elif lower_limit is not None:
+            details.append(f"min: {int(lower_limit)}")
+            if standalone_min is not None:
+                details.append(f"floor: {standalone_min}")
+    else:
+        if upper_limit is not None:
+            details.append(f"max: {int(upper_limit)}")
+        if lower_limit is not None:
+            details.append(f"min: {int(lower_limit)}")
 
-    return None
+    message = f"{int(actual)} {unit} ({', '.join(details)})"
+
+    return AssertionResult(
+        check_name=check_name,
+        passed=passed,
+        message=message,
+        reason_code=reason_code,
+        expected=expected,
+        actual=str(int(actual)),
+    )
 
 
 def run_assertions(
@@ -244,8 +293,10 @@ def run_assertions(
         baseline_value=b_summary["total_events"] if b_summary else None,
         tolerance=policy.step_tolerance,
         standalone_max=policy.max_steps,
+        standalone_min=policy.min_steps,
         check_name="step_count",
-        reason_code=RegressionReasonCode.STEP_COUNT_EXCEEDED,
+        reason_code_exceeded=RegressionReasonCode.STEP_COUNT_EXCEEDED,
+        reason_code_below_minimum=RegressionReasonCode.STEP_COUNT_BELOW_MINIMUM,
         unit="steps",
     )
     if r:
@@ -257,8 +308,10 @@ def run_assertions(
         baseline_value=b_summary["tool_calls"] if b_summary else None,
         tolerance=policy.tool_call_tolerance,
         standalone_max=policy.max_tool_calls,
+        standalone_min=policy.min_tool_calls,
         check_name="tool_calls",
-        reason_code=RegressionReasonCode.TOOL_CALL_COUNT_EXCEEDED,
+        reason_code_exceeded=RegressionReasonCode.TOOL_CALL_COUNT_EXCEEDED,
+        reason_code_below_minimum=RegressionReasonCode.TOOL_CALL_COUNT_BELOW_MINIMUM,
         unit="tool calls",
     )
     if r:
@@ -331,8 +384,10 @@ def run_assertions(
         baseline_value=b_summary["total_tokens"] if b_summary else None,
         tolerance=policy.cost_tolerance,
         standalone_max=policy.max_cost_tokens,
+        standalone_min=policy.min_cost_tokens,
         check_name="cost_tokens",
-        reason_code=RegressionReasonCode.COST_ENVELOPE_EXCEEDED,
+        reason_code_exceeded=RegressionReasonCode.COST_ENVELOPE_EXCEEDED,
+        reason_code_below_minimum=RegressionReasonCode.COST_BELOW_MINIMUM,
         unit="tokens",
     )
     if r:
@@ -344,8 +399,10 @@ def run_assertions(
         baseline_value=b_summary["duration_ms"] if b_summary else None,
         tolerance=policy.duration_tolerance,
         standalone_max=policy.max_duration_ms,
+        standalone_min=policy.min_duration_ms,
         check_name="duration",
-        reason_code=RegressionReasonCode.LATENCY_ENVELOPE_EXCEEDED,
+        reason_code_exceeded=RegressionReasonCode.LATENCY_ENVELOPE_EXCEEDED,
+        reason_code_below_minimum=RegressionReasonCode.DURATION_BELOW_MINIMUM,
         unit="ms",
     )
     if r:

--- a/maida/cli.py
+++ b/maida/cli.py
@@ -358,11 +358,17 @@ def assert_cmd(
     max_steps: int | None = typer.Option(
         None, "--max-steps", help="Max total events allowed"
     ),
+    min_steps: int | None = typer.Option(
+        None, "--min-steps", help="Min total events required"
+    ),
     step_tolerance: float | None = typer.Option(
         None, "--step-tolerance", help="Fractional tolerance for step count"
     ),
     max_tool_calls: int | None = typer.Option(
         None, "--max-tool-calls", help="Max tool calls allowed"
+    ),
+    min_tool_calls: int | None = typer.Option(
+        None, "--min-tool-calls", help="Min tool calls required"
     ),
     tool_call_tolerance: float | None = typer.Option(
         None, "--tool-call-tolerance", help="Fractional tolerance for tool calls"
@@ -379,11 +385,17 @@ def assert_cmd(
     max_cost_tokens: int | None = typer.Option(
         None, "--max-cost-tokens", help="Max total tokens allowed"
     ),
+    min_cost_tokens: int | None = typer.Option(
+        None, "--min-cost-tokens", help="Min total tokens required"
+    ),
     cost_tolerance: float | None = typer.Option(
         None, "--cost-tolerance", help="Fractional tolerance for token cost"
     ),
     max_duration_ms: int | None = typer.Option(
         None, "--max-duration-ms", help="Max run duration in ms"
+    ),
+    min_duration_ms: int | None = typer.Option(
+        None, "--min-duration-ms", help="Min run duration in ms"
     ),
     duration_tolerance: float | None = typer.Option(
         None, "--duration-tolerance", help="Fractional tolerance for duration"
@@ -415,15 +427,19 @@ def assert_cmd(
 
         cli_overrides = {
             "max_steps": max_steps,
+            "min_steps": min_steps,
             "step_tolerance": step_tolerance,
             "max_tool_calls": max_tool_calls,
+            "min_tool_calls": min_tool_calls,
             "tool_call_tolerance": tool_call_tolerance,
             "no_new_tools": no_new_tools,
             "no_loops": no_loops,
             "no_guardrails": no_guardrails,
             "max_cost_tokens": max_cost_tokens,
+            "min_cost_tokens": min_cost_tokens,
             "cost_tolerance": cost_tolerance,
             "max_duration_ms": max_duration_ms,
+            "min_duration_ms": min_duration_ms,
             "duration_tolerance": duration_tolerance,
             "expect_status": expect_status,
         }

--- a/maida/policy.py
+++ b/maida/policy.py
@@ -65,15 +65,19 @@ def merge_policy(
     """
     merged = AssertionPolicy(
         max_steps=file_policy.max_steps,
+        min_steps=file_policy.min_steps,
         step_tolerance=file_policy.step_tolerance,
         max_tool_calls=file_policy.max_tool_calls,
+        min_tool_calls=file_policy.min_tool_calls,
         tool_call_tolerance=file_policy.tool_call_tolerance,
         no_new_tools=file_policy.no_new_tools,
         no_loops=file_policy.no_loops,
         no_guardrails=file_policy.no_guardrails,
         max_cost_tokens=file_policy.max_cost_tokens,
+        min_cost_tokens=file_policy.min_cost_tokens,
         cost_tolerance=file_policy.cost_tolerance,
         max_duration_ms=file_policy.max_duration_ms,
+        min_duration_ms=file_policy.min_duration_ms,
         duration_tolerance=file_policy.duration_tolerance,
         expect_status=file_policy.expect_status,
     )

--- a/maida/scaffold.py
+++ b/maida/scaffold.py
@@ -34,9 +34,13 @@ assert:
 
   # Hard caps, independent of any baseline (uncomment to enable):
   # max_steps: 80
+  # min_steps: 10
   # max_tool_calls: 40
+  # min_tool_calls: 5
   # max_cost_tokens: 20000
+  # min_cost_tokens: 100
   # max_duration_ms: 60000
+  # min_duration_ms: 1000
 """
 
 WORKFLOW_TEMPLATE = f"""\

--- a/tests/test_assertions.py
+++ b/tests/test_assertions.py
@@ -1,6 +1,7 @@
 """Tests for maida.assertions: policy checks, exit codes, report formatting."""
 
 import json
+import time
 from textwrap import dedent
 
 import pytest
@@ -35,6 +36,10 @@ def test_regression_reason_code_vocabulary_is_stable():
         "guardrail_event_changed",
         "latency_envelope_exceeded",
         "cost_envelope_exceeded",
+        "step_count_below_minimum",
+        "tool_call_count_below_minimum",
+        "cost_below_minimum",
+        "duration_below_minimum",
     }
 
 
@@ -196,7 +201,8 @@ def test_zero_baseline_with_standalone_cap_uses_cap_as_limit():
         tolerance=0.5,
         standalone_max=10,
         check_name="step_count",
-        reason_code=RegressionReasonCode.STEP_COUNT_EXCEEDED,
+        reason_code_exceeded=RegressionReasonCode.STEP_COUNT_EXCEEDED,
+        reason_code_below_minimum=RegressionReasonCode.STEP_COUNT_BELOW_MINIMUM,
         unit="steps",
     )
 
@@ -212,13 +218,144 @@ def test_zero_baseline_without_standalone_cap_allows_no_growth():
         tolerance=0.5,
         standalone_max=None,
         check_name="step_count",
-        reason_code=RegressionReasonCode.STEP_COUNT_EXCEEDED,
+        reason_code_exceeded=RegressionReasonCode.STEP_COUNT_EXCEEDED,
+        reason_code_below_minimum=RegressionReasonCode.STEP_COUNT_BELOW_MINIMUM,
         unit="steps",
     )
 
     assert result is not None
     assert result.passed is False
     assert result.expected == "0"
+
+
+# ---------------------------------------------------------------------------
+# _check_threshold — lower bound
+# ---------------------------------------------------------------------------
+
+
+def test_lower_bound_passes_when_above_minimum():
+    result = _check_threshold(
+        actual=8,
+        baseline_value=10,
+        tolerance=0.5,
+        standalone_max=None,
+        check_name="step_count",
+        reason_code_exceeded=RegressionReasonCode.STEP_COUNT_EXCEEDED,
+        reason_code_below_minimum=RegressionReasonCode.STEP_COUNT_BELOW_MINIMUM,
+        unit="steps",
+    )
+
+    assert result is not None
+    assert result.passed is True
+    assert result.reason_code == RegressionReasonCode.NO_REGRESSION
+
+
+def test_lower_bound_fails_when_below_minimum():
+    result = _check_threshold(
+        actual=3,
+        baseline_value=10,
+        tolerance=0.5,
+        standalone_max=None,
+        check_name="step_count",
+        reason_code_exceeded=RegressionReasonCode.STEP_COUNT_EXCEEDED,
+        reason_code_below_minimum=RegressionReasonCode.STEP_COUNT_BELOW_MINIMUM,
+        unit="steps",
+    )
+
+    assert result is not None
+    assert result.passed is False
+    assert result.reason_code == RegressionReasonCode.STEP_COUNT_BELOW_MINIMUM
+
+
+def test_lower_bound_floor_of_one():
+    result = _check_threshold(
+        actual=1,
+        baseline_value=2,
+        tolerance=0.8,
+        standalone_max=None,
+        check_name="step_count",
+        reason_code_exceeded=RegressionReasonCode.STEP_COUNT_EXCEEDED,
+        reason_code_below_minimum=RegressionReasonCode.STEP_COUNT_BELOW_MINIMUM,
+        unit="steps",
+    )
+
+    assert result is not None
+    assert result.passed is True
+
+
+def test_lower_bound_fails_at_zero():
+    result = _check_threshold(
+        actual=0,
+        baseline_value=2,
+        tolerance=0.8,
+        standalone_max=None,
+        check_name="step_count",
+        reason_code_exceeded=RegressionReasonCode.STEP_COUNT_EXCEEDED,
+        reason_code_below_minimum=RegressionReasonCode.STEP_COUNT_BELOW_MINIMUM,
+        unit="steps",
+    )
+
+    assert result is not None
+    assert result.passed is False
+    assert result.reason_code == RegressionReasonCode.STEP_COUNT_BELOW_MINIMUM
+
+
+def test_standalone_min_is_respected():
+    result = _check_threshold(
+        actual=2,
+        baseline_value=10,
+        tolerance=0.5,
+        standalone_max=None,
+        standalone_min=5,
+        check_name="step_count",
+        reason_code_exceeded=RegressionReasonCode.STEP_COUNT_EXCEEDED,
+        reason_code_below_minimum=RegressionReasonCode.STEP_COUNT_BELOW_MINIMUM,
+        unit="steps",
+    )
+
+    # tolerance lower = max(1, 5) = 5, standalone_min = 5 → lower = 5
+    # actual=2 < 5 → fail
+    assert result is not None
+    assert result.passed is False
+    assert result.reason_code == RegressionReasonCode.STEP_COUNT_BELOW_MINIMUM
+    assert "floor: 5" in result.message
+
+
+def test_upper_violation_takes_precedence_over_lower():
+    result = _check_threshold(
+        actual=20,
+        baseline_value=10,
+        tolerance=0.5,
+        standalone_max=12,
+        check_name="step_count",
+        reason_code_exceeded=RegressionReasonCode.STEP_COUNT_EXCEEDED,
+        reason_code_below_minimum=RegressionReasonCode.STEP_COUNT_BELOW_MINIMUM,
+        unit="steps",
+    )
+
+    # Both bounds violated (upper: 12, lower: 5), but upper should win
+    assert result is not None
+    assert result.passed is False
+    assert result.reason_code == RegressionReasonCode.STEP_COUNT_EXCEEDED
+
+
+def test_no_baseline_with_standalone_min():
+    result = _check_threshold(
+        actual=2,
+        baseline_value=None,
+        tolerance=0.5,
+        standalone_max=None,
+        standalone_min=5,
+        check_name="step_count",
+        reason_code_exceeded=RegressionReasonCode.STEP_COUNT_EXCEEDED,
+        reason_code_below_minimum=RegressionReasonCode.STEP_COUNT_BELOW_MINIMUM,
+        unit="steps",
+    )
+
+    assert result is not None
+    assert result.passed is False
+    assert result.reason_code == RegressionReasonCode.STEP_COUNT_BELOW_MINIMUM
+    assert result.expected == "5"
 
 
 # ---------------------------------------------------------------------------
@@ -235,8 +372,11 @@ def test_no_new_tools_passes_when_subset(temp_data_dir):
     bl_rid = _make_run(config, events=bl_events, name="baseline")
     bl = create_baseline(bl_rid, config)
 
-    run_events = [(EventType.TOOL_CALL, "search", {})]
-    run_id = _make_run(config, events=run_events, name="check")
+    # Create a run with a tiny delay so duration > 0 for lower-bound check
+    with traced_run(name="check"):
+        record_tool_call("search", args={}, result=None)
+        time.sleep(0.002)
+    run_id = get_latest_run_id(config)
 
     policy = AssertionPolicy(
         no_new_tools=True,
@@ -256,11 +396,12 @@ def test_no_new_tools_fails_on_new_tool(temp_data_dir):
     bl_rid = _make_run(config, events=bl_events, name="baseline")
     bl = create_baseline(bl_rid, config)
 
-    run_events = [
-        (EventType.TOOL_CALL, "search", {}),
-        (EventType.TOOL_CALL, "salesforce_api", {}),
-    ]
-    run_id = _make_run(config, events=run_events, name="check")
+    # Ensure run has non-zero duration for lower-bound check
+    with traced_run(name="check"):
+        record_tool_call("search", args={}, result=None)
+        record_tool_call("salesforce_api", args={}, result=None)
+        time.sleep(0.002)
+    run_id = get_latest_run_id(config)
 
     policy = AssertionPolicy(
         no_new_tools=True,


### PR DESCRIPTION
_check_threshold now enforces both upper and lower bounds when a baseline is available. The lower bound starts from baseline * (1 - tolerance) and is floored at 1 — a metric falling to zero when the baseline had non-zero activity is always a regression. An explicit min_* field can raise this floor further.

New AssertionPolicy fields: min_steps, min_tool_calls, min_cost_tokens, min_duration_ms (all optional, default None).

New RegressionReasonCode values: step_count_below_minimum, tool_call_count_below_minimum, cost_below_minimum, duration_below_minimum.

Upper-bound violations use the existing EXCEEDED reason codes; lower-bound violations use the new BELOW_MINIMUM codes. Upper takes precedence if both bounds are violated.

CLI flags: --min-steps, --min-tool-calls, --min-cost-tokens, --min-duration-ms.

fixes #12