### PR TITLE
Add ability to disable some assertions completely

### DIFF
--- a/docs/reference/policy.md
+++ b/docs/reference/policy.md
@@ -32,7 +32,7 @@ Requires **PyYAML** (`pip install pyyaml` or included in `maida[yaml]`). If PyYA
 
 ## Assertion fields
 
-All fields are optional. A check is **disabled** unless at least one relevant value is set (via baseline, policy file, or CLI flag).
+All fields are optional. A check is **disabled** unless at least one relevant value is set (via baseline, policy file, or CLI flag).  A check can also be **explicitly ignored** via `ignored_checks` — this skips the check even when thresholds or a baseline are present.
 
 ### Numeric thresholds
 
@@ -60,6 +60,32 @@ All fields are optional. A check is **disabled** unless at least one relevant va
 | YAML key | Type | Default | CLI flag | Description |
 |---|---|---|---|---|
 | `expect_status` | `string` or `null` | `null` | `--expect-status` | Expected run status: `"ok"` or `"error"` |
+
+### Ignored checks
+
+| YAML key | Type | Default | CLI flag | Description |
+|---|---|---|---|---|
+| `ignored_checks` | `list[string]` | `[]` | `--ignore-check` (repeatable) | Explicitly skip these checks regardless of thresholds or baseline |
+
+A check listed in `ignored_checks` is skipped entirely — it does not run any comparison and does not count as a failure. This is useful for temporarily disabling noisy checks without removing policy configuration.
+
+**Available check names:** `step_count`, `tool_calls`, `cost_tokens`, `duration`, `new_tools`, `no_loops`, `no_guardrails`, `expect_status`
+
+**CLI merge:** When `--ignore-check` is provided on the CLI, its values are **unioned** with the file's `ignored_checks` list (both sets apply).
+
+```yaml
+assert:
+  max_steps: 80
+  no_loops: true
+  ignored_checks:
+    - step_count
+    - cost_tokens
+```
+
+The equivalent CLI invocation would be:
+```bash
+maida assert <run> --ignore-check step_count --ignore-check cost_tokens
+```
 
 ---
 

--- a/maida/assertions.py
+++ b/maida/assertions.py
@@ -267,7 +267,16 @@ def run_assertions(
         )
 
     # --- step count ---
-    if "step_count" in _ignored:
+    r = _check_threshold(
+        actual=summary["total_events"],
+        baseline_value=b_summary["total_events"] if b_summary else None,
+        tolerance=policy.step_tolerance,
+        standalone_max=policy.max_steps,
+        check_name="step_count",
+        reason_code=RegressionReasonCode.STEP_COUNT_EXCEEDED,
+        unit="steps",
+    )
+    if r and "step_count" in _ignored:
         report.add(
             AssertionResult(
                 check_name="step_count",
@@ -276,21 +285,20 @@ def run_assertions(
                 ignored=True,
             )
         )
-    else:
-        r = _check_threshold(
-            actual=summary["total_events"],
-            baseline_value=b_summary["total_events"] if b_summary else None,
-            tolerance=policy.step_tolerance,
-            standalone_max=policy.max_steps,
-            check_name="step_count",
-            reason_code=RegressionReasonCode.STEP_COUNT_EXCEEDED,
-            unit="steps",
-        )
-        if r:
-            report.add(r)
+    elif r:
+        report.add(r)
 
     # --- tool calls ---
-    if "tool_calls" in _ignored:
+    r = _check_threshold(
+        actual=summary["tool_calls"],
+        baseline_value=b_summary["tool_calls"] if b_summary else None,
+        tolerance=policy.tool_call_tolerance,
+        standalone_max=policy.max_tool_calls,
+        check_name="tool_calls",
+        reason_code=RegressionReasonCode.TOOL_CALL_COUNT_EXCEEDED,
+        unit="tool calls",
+    )
+    if r and "tool_calls" in _ignored:
         report.add(
             AssertionResult(
                 check_name="tool_calls",
@@ -299,109 +307,113 @@ def run_assertions(
                 ignored=True,
             )
         )
-    else:
-        r = _check_threshold(
-            actual=summary["tool_calls"],
-            baseline_value=b_summary["tool_calls"] if b_summary else None,
-            tolerance=policy.tool_call_tolerance,
-            standalone_max=policy.max_tool_calls,
-            check_name="tool_calls",
-            reason_code=RegressionReasonCode.TOOL_CALL_COUNT_EXCEEDED,
-            unit="tool calls",
-        )
-        if r:
-            report.add(r)
+    elif r:
+        report.add(r)
 
     # --- no new tools ---
-    if "new_tools" in _ignored:
-        report.add(
-            AssertionResult(
-                check_name="new_tools",
-                passed=True,
-                message="check ignored",
-                ignored=True,
+    if policy.no_new_tools and baseline is not None:
+        if "new_tools" in _ignored:
+            report.add(
+                AssertionResult(
+                    check_name="new_tools",
+                    passed=True,
+                    message="check ignored",
+                    ignored=True,
+                )
             )
-        )
-    elif policy.no_new_tools and baseline is not None:
-        baseline_tools = set(baseline.get("tool_path") or [])
-        run_tools = set(metrics["tool_path"])
-        new_tools = sorted(run_tools - baseline_tools)
-        passed = len(new_tools) == 0
-        report.add(
-            AssertionResult(
-                check_name="new_tools",
-                passed=passed,
-                message=(
-                    "no new tools" if passed else f"unexpected tools used: {new_tools}"
-                ),
-                reason_code=_reason_code_for(
-                    passed, RegressionReasonCode.NEW_TOOL_PATH
-                ),
-                expected="none",
-                actual=str(new_tools) if new_tools else "none",
+        else:
+            baseline_tools = set(baseline.get("tool_path") or [])
+            run_tools = set(metrics["tool_path"])
+            new_tools = sorted(run_tools - baseline_tools)
+            passed = len(new_tools) == 0
+            report.add(
+                AssertionResult(
+                    check_name="new_tools",
+                    passed=passed,
+                    message=(
+                        "no new tools"
+                        if passed
+                        else f"unexpected tools used: {new_tools}"
+                    ),
+                    reason_code=_reason_code_for(
+                        passed, RegressionReasonCode.NEW_TOOL_PATH
+                    ),
+                    expected="none",
+                    actual=str(new_tools) if new_tools else "none",
+                )
             )
-        )
 
     # --- no loops ---
-    if "no_loops" in _ignored:
-        report.add(
-            AssertionResult(
-                check_name="no_loops",
-                passed=True,
-                message="check ignored",
-                ignored=True,
+    if policy.no_loops:
+        if "no_loops" in _ignored:
+            report.add(
+                AssertionResult(
+                    check_name="no_loops",
+                    passed=True,
+                    message="check ignored",
+                    ignored=True,
+                )
             )
-        )
-    elif policy.no_loops:
-        loop_count = summary["loop_warnings"]
-        passed = loop_count == 0
-        signature_summary = _loop_signature_summary(events) if not passed else ""
-        message = "no loop warnings detected"
-        if not passed:
-            message = f"{loop_count} loop warning(s) detected"
-            if signature_summary:
-                message += f": {signature_summary}"
-        report.add(
-            AssertionResult(
-                check_name="no_loops",
-                passed=passed,
-                message=message,
-                reason_code=_reason_code_for(passed, _loop_reason_code(events)),
-                actual=str(loop_count),
+        else:
+            loop_count = summary["loop_warnings"]
+            passed = loop_count == 0
+            signature_summary = _loop_signature_summary(events) if not passed else ""
+            message = "no loop warnings detected"
+            if not passed:
+                message = f"{loop_count} loop warning(s) detected"
+                if signature_summary:
+                    message += f": {signature_summary}"
+            report.add(
+                AssertionResult(
+                    check_name="no_loops",
+                    passed=passed,
+                    message=message,
+                    reason_code=_reason_code_for(passed, _loop_reason_code(events)),
+                    actual=str(loop_count),
+                )
             )
-        )
 
     # --- no guardrails ---
-    if "no_guardrails" in _ignored:
-        report.add(
-            AssertionResult(
-                check_name="no_guardrails",
-                passed=True,
-                message="check ignored",
-                ignored=True,
+    if policy.no_guardrails:
+        if "no_guardrails" in _ignored:
+            report.add(
+                AssertionResult(
+                    check_name="no_guardrails",
+                    passed=True,
+                    message="check ignored",
+                    ignored=True,
+                )
             )
-        )
-    elif policy.no_guardrails:
-        gr_count = len(metrics["guardrail_events"])
-        passed = gr_count == 0
-        report.add(
-            AssertionResult(
-                check_name="no_guardrails",
-                passed=passed,
-                message=(
-                    "no guardrail events"
-                    if passed
-                    else f"{gr_count} guardrail event(s) detected"
-                ),
-                reason_code=_reason_code_for(
-                    passed, RegressionReasonCode.GUARDRAIL_EVENT_CHANGED
-                ),
-                actual=str(gr_count),
+        else:
+            gr_count = len(metrics["guardrail_events"])
+            passed = gr_count == 0
+            report.add(
+                AssertionResult(
+                    check_name="no_guardrails",
+                    passed=passed,
+                    message=(
+                        "no guardrail events"
+                        if passed
+                        else f"{gr_count} guardrail event(s) detected"
+                    ),
+                    reason_code=_reason_code_for(
+                        passed, RegressionReasonCode.GUARDRAIL_EVENT_CHANGED
+                    ),
+                    actual=str(gr_count),
+                )
             )
-        )
 
     # --- cost tokens ---
-    if "cost_tokens" in _ignored:
+    r = _check_threshold(
+        actual=summary["total_tokens"],
+        baseline_value=b_summary["total_tokens"] if b_summary else None,
+        tolerance=policy.cost_tolerance,
+        standalone_max=policy.max_cost_tokens,
+        check_name="cost_tokens",
+        reason_code=RegressionReasonCode.COST_ENVELOPE_EXCEEDED,
+        unit="tokens",
+    )
+    if r and "cost_tokens" in _ignored:
         report.add(
             AssertionResult(
                 check_name="cost_tokens",
@@ -410,21 +422,20 @@ def run_assertions(
                 ignored=True,
             )
         )
-    else:
-        r = _check_threshold(
-            actual=summary["total_tokens"],
-            baseline_value=b_summary["total_tokens"] if b_summary else None,
-            tolerance=policy.cost_tolerance,
-            standalone_max=policy.max_cost_tokens,
-            check_name="cost_tokens",
-            reason_code=RegressionReasonCode.COST_ENVELOPE_EXCEEDED,
-            unit="tokens",
-        )
-        if r:
-            report.add(r)
+    elif r:
+        report.add(r)
 
     # --- duration ---
-    if "duration" in _ignored:
+    r = _check_threshold(
+        actual=summary["duration_ms"],
+        baseline_value=b_summary["duration_ms"] if b_summary else None,
+        tolerance=policy.duration_tolerance,
+        standalone_max=policy.max_duration_ms,
+        check_name="duration",
+        reason_code=RegressionReasonCode.LATENCY_ENVELOPE_EXCEEDED,
+        unit="ms",
+    )
+    if r and "duration" in _ignored:
         report.add(
             AssertionResult(
                 check_name="duration",
@@ -433,48 +444,39 @@ def run_assertions(
                 ignored=True,
             )
         )
-    else:
-        r = _check_threshold(
-            actual=summary["duration_ms"],
-            baseline_value=b_summary["duration_ms"] if b_summary else None,
-            tolerance=policy.duration_tolerance,
-            standalone_max=policy.max_duration_ms,
-            check_name="duration",
-            reason_code=RegressionReasonCode.LATENCY_ENVELOPE_EXCEEDED,
-            unit="ms",
-        )
-        if r:
-            report.add(r)
+    elif r:
+        report.add(r)
 
     # --- expect status ---
-    if "expect_status" in _ignored:
-        report.add(
-            AssertionResult(
-                check_name="expect_status",
-                passed=True,
-                message="check ignored",
-                ignored=True,
+    if policy.expect_status is not None:
+        if "expect_status" in _ignored:
+            report.add(
+                AssertionResult(
+                    check_name="expect_status",
+                    passed=True,
+                    message="check ignored",
+                    ignored=True,
+                )
             )
-        )
-    elif policy.expect_status is not None:
-        actual_status = meta.get("status", "")
-        passed = actual_status == policy.expect_status
-        report.add(
-            AssertionResult(
-                check_name="expect_status",
-                passed=passed,
-                message=(
-                    f"status is '{actual_status}'"
-                    if passed
-                    else f"expected '{policy.expect_status}', got '{actual_status}'"
-                ),
-                reason_code=_reason_code_for(
-                    passed, RegressionReasonCode.TERMINAL_STATE_MISSING
-                ),
-                expected=policy.expect_status,
-                actual=actual_status,
+        else:
+            actual_status = meta.get("status", "")
+            passed = actual_status == policy.expect_status
+            report.add(
+                AssertionResult(
+                    check_name="expect_status",
+                    passed=passed,
+                    message=(
+                        f"status is '{actual_status}'"
+                        if passed
+                        else f"expected '{policy.expect_status}', got '{actual_status}'"
+                    ),
+                    reason_code=_reason_code_for(
+                        passed, RegressionReasonCode.TERMINAL_STATE_MISSING
+                    ),
+                    expected=policy.expect_status,
+                    actual=actual_status,
+                )
             )
-        )
 
     return report
 

--- a/maida/assertions.py
+++ b/maida/assertions.py
@@ -594,9 +594,13 @@ def format_report_markdown(
         lines.append(
             f"**{len(failed)} of {len(report.results)} checks failed** \u00b7 {scope}"
         )
-    else:
-        active = len(report.results) - len(ignored)
+    elif active := len(report.results) - len(ignored):
         parts = [f"**All {active} checks passed** \u00b7 {scope}"]
+        if ignored:
+            parts.append(f"({len(ignored)} ignored)")
+        lines.append(" ".join(parts))
+    else:
+        parts = [f"**All checks ignored** \u00b7 {scope}"]
         if ignored:
             parts.append(f"({len(ignored)} ignored)")
         lines.append(" ".join(parts))

--- a/maida/assertions.py
+++ b/maida/assertions.py
@@ -65,6 +65,9 @@ class AssertionPolicy:
     no_guardrails: bool = False  # Fail if any guardrail was triggered
     expect_status: str | None = None  # Expected run status (ok or error)
 
+    # Explicitly ignored checks (skipped even when thresholds/baseline are set)
+    ignored_checks: list[str] = field(default_factory=list)
+
 
 @dataclass
 class AssertionResult:
@@ -76,6 +79,7 @@ class AssertionResult:
     reason_code: RegressionReasonCode = RegressionReasonCode.NO_REGRESSION
     expected: str | None = None
     actual: str | None = None
+    ignored: bool = False
 
 
 @dataclass
@@ -238,34 +242,65 @@ def run_assertions(
         baseline_run_id=(baseline or {}).get("source_run_id"),
     )
 
+    _ignored = set(policy.ignored_checks)
+
     # --- step count ---
-    r = _check_threshold(
-        actual=summary["total_events"],
-        baseline_value=b_summary["total_events"] if b_summary else None,
-        tolerance=policy.step_tolerance,
-        standalone_max=policy.max_steps,
-        check_name="step_count",
-        reason_code=RegressionReasonCode.STEP_COUNT_EXCEEDED,
-        unit="steps",
-    )
-    if r:
-        report.add(r)
+    if "step_count" in _ignored:
+        report.add(
+            AssertionResult(
+                check_name="step_count",
+                passed=True,
+                message="check ignored",
+                ignored=True,
+            )
+        )
+    else:
+        r = _check_threshold(
+            actual=summary["total_events"],
+            baseline_value=b_summary["total_events"] if b_summary else None,
+            tolerance=policy.step_tolerance,
+            standalone_max=policy.max_steps,
+            check_name="step_count",
+            reason_code=RegressionReasonCode.STEP_COUNT_EXCEEDED,
+            unit="steps",
+        )
+        if r:
+            report.add(r)
 
     # --- tool calls ---
-    r = _check_threshold(
-        actual=summary["tool_calls"],
-        baseline_value=b_summary["tool_calls"] if b_summary else None,
-        tolerance=policy.tool_call_tolerance,
-        standalone_max=policy.max_tool_calls,
-        check_name="tool_calls",
-        reason_code=RegressionReasonCode.TOOL_CALL_COUNT_EXCEEDED,
-        unit="tool calls",
-    )
-    if r:
-        report.add(r)
+    if "tool_calls" in _ignored:
+        report.add(
+            AssertionResult(
+                check_name="tool_calls",
+                passed=True,
+                message="check ignored",
+                ignored=True,
+            )
+        )
+    else:
+        r = _check_threshold(
+            actual=summary["tool_calls"],
+            baseline_value=b_summary["tool_calls"] if b_summary else None,
+            tolerance=policy.tool_call_tolerance,
+            standalone_max=policy.max_tool_calls,
+            check_name="tool_calls",
+            reason_code=RegressionReasonCode.TOOL_CALL_COUNT_EXCEEDED,
+            unit="tool calls",
+        )
+        if r:
+            report.add(r)
 
     # --- no new tools ---
-    if policy.no_new_tools and baseline is not None:
+    if "new_tools" in _ignored:
+        report.add(
+            AssertionResult(
+                check_name="new_tools",
+                passed=True,
+                message="check ignored",
+                ignored=True,
+            )
+        )
+    elif policy.no_new_tools and baseline is not None:
         baseline_tools = set(baseline.get("tool_path") or [])
         run_tools = set(metrics["tool_path"])
         new_tools = sorted(run_tools - baseline_tools)
@@ -286,7 +321,16 @@ def run_assertions(
         )
 
     # --- no loops ---
-    if policy.no_loops:
+    if "no_loops" in _ignored:
+        report.add(
+            AssertionResult(
+                check_name="no_loops",
+                passed=True,
+                message="check ignored",
+                ignored=True,
+            )
+        )
+    elif policy.no_loops:
         loop_count = summary["loop_warnings"]
         passed = loop_count == 0
         signature_summary = _loop_signature_summary(events) if not passed else ""
@@ -306,7 +350,16 @@ def run_assertions(
         )
 
     # --- no guardrails ---
-    if policy.no_guardrails:
+    if "no_guardrails" in _ignored:
+        report.add(
+            AssertionResult(
+                check_name="no_guardrails",
+                passed=True,
+                message="check ignored",
+                ignored=True,
+            )
+        )
+    elif policy.no_guardrails:
         gr_count = len(metrics["guardrail_events"])
         passed = gr_count == 0
         report.add(
@@ -326,33 +379,62 @@ def run_assertions(
         )
 
     # --- cost tokens ---
-    r = _check_threshold(
-        actual=summary["total_tokens"],
-        baseline_value=b_summary["total_tokens"] if b_summary else None,
-        tolerance=policy.cost_tolerance,
-        standalone_max=policy.max_cost_tokens,
-        check_name="cost_tokens",
-        reason_code=RegressionReasonCode.COST_ENVELOPE_EXCEEDED,
-        unit="tokens",
-    )
-    if r:
-        report.add(r)
+    if "cost_tokens" in _ignored:
+        report.add(
+            AssertionResult(
+                check_name="cost_tokens",
+                passed=True,
+                message="check ignored",
+                ignored=True,
+            )
+        )
+    else:
+        r = _check_threshold(
+            actual=summary["total_tokens"],
+            baseline_value=b_summary["total_tokens"] if b_summary else None,
+            tolerance=policy.cost_tolerance,
+            standalone_max=policy.max_cost_tokens,
+            check_name="cost_tokens",
+            reason_code=RegressionReasonCode.COST_ENVELOPE_EXCEEDED,
+            unit="tokens",
+        )
+        if r:
+            report.add(r)
 
     # --- duration ---
-    r = _check_threshold(
-        actual=summary["duration_ms"],
-        baseline_value=b_summary["duration_ms"] if b_summary else None,
-        tolerance=policy.duration_tolerance,
-        standalone_max=policy.max_duration_ms,
-        check_name="duration",
-        reason_code=RegressionReasonCode.LATENCY_ENVELOPE_EXCEEDED,
-        unit="ms",
-    )
-    if r:
-        report.add(r)
+    if "duration" in _ignored:
+        report.add(
+            AssertionResult(
+                check_name="duration",
+                passed=True,
+                message="check ignored",
+                ignored=True,
+            )
+        )
+    else:
+        r = _check_threshold(
+            actual=summary["duration_ms"],
+            baseline_value=b_summary["duration_ms"] if b_summary else None,
+            tolerance=policy.duration_tolerance,
+            standalone_max=policy.max_duration_ms,
+            check_name="duration",
+            reason_code=RegressionReasonCode.LATENCY_ENVELOPE_EXCEEDED,
+            unit="ms",
+        )
+        if r:
+            report.add(r)
 
     # --- expect status ---
-    if policy.expect_status is not None:
+    if "expect_status" in _ignored:
+        report.add(
+            AssertionResult(
+                check_name="expect_status",
+                passed=True,
+                message="check ignored",
+                ignored=True,
+            )
+        )
+    elif policy.expect_status is not None:
         actual_status = meta.get("status", "")
         passed = actual_status == policy.expect_status
         report.add(
@@ -429,20 +511,31 @@ def format_report_text(report: AssertionReport, diff: "RunDiff | None" = None) -
     """
     lines: list[str] = []
     for r in report.results:
-        mark = _PASS if r.passed else _FAIL
-        lines.append(
-            f"  {mark} {r.check_name} [{_reason_code_text(r.reason_code)}]: {r.message}"
-        )
+        if r.ignored:
+            lines.append(f"  - {r.check_name} [ignored]")
+        else:
+            mark = _PASS if r.passed else _FAIL
+            lines.append(
+                f"  {mark} {r.check_name} [{_reason_code_text(r.reason_code)}]: {r.message}"
+            )
     total = len(report.results)
     failed = sum(1 for r in report.results if not r.passed)
+    ignored_count = sum(1 for r in report.results if r.ignored)
+    active = total - ignored_count
     if total == 0:
         lines.append("  (no checks enabled)")
     verdict = "PASSED" if report.passed else "FAILED"
     lines.append("")
-    if failed:
-        lines.append(f"RESULT: {verdict} ({failed} of {total} checks failed)")
+    parts = []
+    if active == 0:
+        parts.append(f"RESULT: {verdict} (all checks ignored)")
+    elif failed:
+        parts.append(f"RESULT: {verdict} ({failed} of {active} active checks failed)")
     else:
-        lines.append(f"RESULT: {verdict} ({total} checks passed)")
+        parts.append(f"RESULT: {verdict} ({active} active checks passed)")
+    if ignored_count:
+        parts.append(f"({ignored_count} ignored)")
+    lines.append(" ".join(parts))
     if diff is not None and not report.passed:
         lines.append("")
         lines.append(format_diff_text(diff))
@@ -464,6 +557,7 @@ def format_report_json(report: AssertionReport) -> str:
                 "message": r.message,
                 "expected": r.expected,
                 "actual": r.actual,
+                "ignored": r.ignored,
             }
             for r in report.results
         ],
@@ -484,7 +578,8 @@ def format_report_markdown(
     readable.
     """
     failed = [r for r in report.results if not r.passed]
-    passed = [r for r in report.results if r.passed]
+    passed = [r for r in report.results if r.passed and not r.ignored]
+    ignored = [r for r in report.results if r.ignored]
     short_run = report.run_id[:8]
 
     if report.passed:
@@ -500,7 +595,11 @@ def format_report_markdown(
             f"**{len(failed)} of {len(report.results)} checks failed** \u00b7 {scope}"
         )
     else:
-        lines.append(f"**All {len(report.results)} checks passed** \u00b7 {scope}")
+        active = len(report.results) - len(ignored)
+        parts = [f"**All {active} checks passed** \u00b7 {scope}"]
+        if ignored:
+            parts.append(f"({len(ignored)} ignored)")
+        lines.append(" ".join(parts))
 
     diff_md = format_diff_markdown(diff) if diff is not None else ""
     if diff_md:
@@ -554,6 +653,19 @@ def format_report_markdown(
                 f"`{_markdown_table_cell(r.check_name)}` | "
                 f"{_markdown_table_cell(r.message)} |"
             )
+        lines += ["", "</details>"]
+
+    if ignored:
+        lines += [
+            "",
+            "<details>",
+            f"<summary>\u2796 {len(ignored)} ignored checks</summary>",
+            "",
+            "| Check |",
+            "|---|",
+        ]
+        for r in ignored:
+            lines.append(f"| \u2796 `{_markdown_table_cell(r.check_name)}` |")
         lines += ["", "</details>"]
 
     lines += [

--- a/maida/assertions.py
+++ b/maida/assertions.py
@@ -21,6 +21,19 @@ from maida.storage import load_run_for_analysis
 
 kDefaultTolerance = 0.5  # 50% global default
 
+KNOWN_CHECK_NAMES = frozenset(
+    {
+        "step_count",
+        "tool_calls",
+        "new_tools",
+        "no_loops",
+        "no_guardrails",
+        "cost_tokens",
+        "duration",
+        "expect_status",
+    }
+)
+
 
 class RegressionReasonCode(str, Enum):
     """Stable reason codes for assertion decisions and PR comment grouping."""
@@ -243,6 +256,11 @@ def run_assertions(
     )
 
     _ignored = set(policy.ignored_checks)
+    if unknown := _ignored - KNOWN_CHECK_NAMES:
+        raise ValueError(
+            f"Unknown check name(s) in ignored_checks: {', '.join(sorted(unknown))}. "
+            f"Known checks: {', '.join(sorted(KNOWN_CHECK_NAMES))}"
+        )
 
     # --- step count ---
     if "step_count" in _ignored:

--- a/maida/assertions.py
+++ b/maida/assertions.py
@@ -8,7 +8,7 @@ results are collected into an ``AssertionReport`` with an overall pass/fail.
 import json
 from dataclasses import dataclass, field
 from enum import Enum
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING, Any, Callable
 
 if TYPE_CHECKING:
     from maida.diff import RunDiff
@@ -266,217 +266,153 @@ def run_assertions(
             f"Known checks: {', '.join(sorted(KNOWN_CHECK_NAMES))}"
         )
 
-    # --- step count ---
-    r = _check_threshold(
-        actual=summary["total_events"],
-        baseline_value=b_summary["total_events"] if b_summary else None,
-        tolerance=policy.step_tolerance,
-        standalone_max=policy.max_steps,
-        check_name="step_count",
-        reason_code=RegressionReasonCode.STEP_COUNT_EXCEEDED,
-        unit="steps",
-    )
-    if r and "step_count" in _ignored:
-        report.add(
-            AssertionResult(
-                check_name="step_count",
-                passed=True,
-                message="check ignored",
-                ignored=True,
-            )
+    # --- per-check runner helpers (return None when check is not enabled) ---
+    def _threshold(
+        name: str,
+        actual: int | float,
+        baseline_val: int | float | None,
+        tolerance: float,
+        max_val: int | float | None,
+        reason: RegressionReasonCode,
+        unit: str,
+    ) -> Callable[[], AssertionResult | None]:
+        return lambda: _check_threshold(
+            actual, baseline_val, tolerance, max_val, name, reason, unit
         )
-    elif r:
-        report.add(r)
 
-    # --- tool calls ---
-    r = _check_threshold(
-        actual=summary["tool_calls"],
-        baseline_value=b_summary["tool_calls"] if b_summary else None,
-        tolerance=policy.tool_call_tolerance,
-        standalone_max=policy.max_tool_calls,
-        check_name="tool_calls",
-        reason_code=RegressionReasonCode.TOOL_CALL_COUNT_EXCEEDED,
-        unit="tool calls",
-    )
-    if r and "tool_calls" in _ignored:
-        report.add(
-            AssertionResult(
-                check_name="tool_calls",
-                passed=True,
-                message="check ignored",
-                ignored=True,
-            )
+    def _check_new_tools() -> AssertionResult | None:
+        if not (policy.no_new_tools and baseline is not None):
+            return None
+        bl_tools = set(baseline.get("tool_path") or [])
+        run_tools = set(metrics["tool_path"])
+        new_tools = sorted(run_tools - bl_tools)
+        passed = len(new_tools) == 0
+        return AssertionResult(
+            check_name="new_tools",
+            passed=passed,
+            message=(
+                "no new tools" if passed else f"unexpected tools used: {new_tools}"
+            ),
+            reason_code=_reason_code_for(passed, RegressionReasonCode.NEW_TOOL_PATH),
+            expected="none",
+            actual=str(new_tools) if new_tools else "none",
         )
-    elif r:
-        report.add(r)
 
-    # --- no new tools ---
-    if policy.no_new_tools and baseline is not None:
-        if "new_tools" in _ignored:
+    def _check_no_loops() -> AssertionResult | None:
+        if not policy.no_loops:
+            return None
+        loop_count = summary["loop_warnings"]
+        passed = loop_count == 0
+        sig = _loop_signature_summary(events) if not passed else ""
+        message = "no loop warnings detected"
+        if not passed:
+            message = f"{loop_count} loop warning(s) detected"
+            if sig:
+                message += f": {sig}"
+        return AssertionResult(
+            check_name="no_loops",
+            passed=passed,
+            message=message,
+            reason_code=_reason_code_for(passed, _loop_reason_code(events)),
+            actual=str(loop_count),
+        )
+
+    def _check_no_guardrails() -> AssertionResult | None:
+        if not policy.no_guardrails:
+            return None
+        gr_count = len(metrics["guardrail_events"])
+        passed = gr_count == 0
+        return AssertionResult(
+            check_name="no_guardrails",
+            passed=passed,
+            message=(
+                "no guardrail events"
+                if passed
+                else f"{gr_count} guardrail event(s) detected"
+            ),
+            reason_code=_reason_code_for(
+                passed, RegressionReasonCode.GUARDRAIL_EVENT_CHANGED
+            ),
+            actual=str(gr_count),
+        )
+
+    def _check_expect_status() -> AssertionResult | None:
+        if policy.expect_status is None:
+            return None
+        actual_status = meta.get("status", "")
+        passed = actual_status == policy.expect_status
+        return AssertionResult(
+            check_name="expect_status",
+            passed=passed,
+            message=(
+                f"status is '{actual_status}'"
+                if passed
+                else f"expected '{policy.expect_status}', got '{actual_status}'"
+            ),
+            reason_code=_reason_code_for(
+                passed, RegressionReasonCode.TERMINAL_STATE_MISSING
+            ),
+            expected=policy.expect_status,
+            actual=actual_status,
+        )
+
+    # --- unified runner dispatch ---
+    runners: dict[str, Callable[[], AssertionResult | None]] = {
+        "step_count": _threshold(
+            "step_count",
+            summary["total_events"],
+            b_summary["total_events"] if b_summary else None,
+            policy.step_tolerance,
+            policy.max_steps,
+            RegressionReasonCode.STEP_COUNT_EXCEEDED,
+            "steps",
+        ),
+        "tool_calls": _threshold(
+            "tool_calls",
+            summary["tool_calls"],
+            b_summary["tool_calls"] if b_summary else None,
+            policy.tool_call_tolerance,
+            policy.max_tool_calls,
+            RegressionReasonCode.TOOL_CALL_COUNT_EXCEEDED,
+            "tool calls",
+        ),
+        "new_tools": _check_new_tools,
+        "no_loops": _check_no_loops,
+        "no_guardrails": _check_no_guardrails,
+        "cost_tokens": _threshold(
+            "cost_tokens",
+            summary["total_tokens"],
+            b_summary["total_tokens"] if b_summary else None,
+            policy.cost_tolerance,
+            policy.max_cost_tokens,
+            RegressionReasonCode.COST_ENVELOPE_EXCEEDED,
+            "tokens",
+        ),
+        "duration": _threshold(
+            "duration",
+            summary["duration_ms"],
+            b_summary["duration_ms"] if b_summary else None,
+            policy.duration_tolerance,
+            policy.max_duration_ms,
+            RegressionReasonCode.LATENCY_ENVELOPE_EXCEEDED,
+            "ms",
+        ),
+        "expect_status": _check_expect_status,
+    }
+
+    for name, runner in runners.items():
+        r = runner()
+        if r and name in _ignored:
             report.add(
                 AssertionResult(
-                    check_name="new_tools",
+                    check_name=name,
                     passed=True,
                     message="check ignored",
                     ignored=True,
                 )
             )
-        else:
-            baseline_tools = set(baseline.get("tool_path") or [])
-            run_tools = set(metrics["tool_path"])
-            new_tools = sorted(run_tools - baseline_tools)
-            passed = len(new_tools) == 0
-            report.add(
-                AssertionResult(
-                    check_name="new_tools",
-                    passed=passed,
-                    message=(
-                        "no new tools"
-                        if passed
-                        else f"unexpected tools used: {new_tools}"
-                    ),
-                    reason_code=_reason_code_for(
-                        passed, RegressionReasonCode.NEW_TOOL_PATH
-                    ),
-                    expected="none",
-                    actual=str(new_tools) if new_tools else "none",
-                )
-            )
-
-    # --- no loops ---
-    if policy.no_loops:
-        if "no_loops" in _ignored:
-            report.add(
-                AssertionResult(
-                    check_name="no_loops",
-                    passed=True,
-                    message="check ignored",
-                    ignored=True,
-                )
-            )
-        else:
-            loop_count = summary["loop_warnings"]
-            passed = loop_count == 0
-            signature_summary = _loop_signature_summary(events) if not passed else ""
-            message = "no loop warnings detected"
-            if not passed:
-                message = f"{loop_count} loop warning(s) detected"
-                if signature_summary:
-                    message += f": {signature_summary}"
-            report.add(
-                AssertionResult(
-                    check_name="no_loops",
-                    passed=passed,
-                    message=message,
-                    reason_code=_reason_code_for(passed, _loop_reason_code(events)),
-                    actual=str(loop_count),
-                )
-            )
-
-    # --- no guardrails ---
-    if policy.no_guardrails:
-        if "no_guardrails" in _ignored:
-            report.add(
-                AssertionResult(
-                    check_name="no_guardrails",
-                    passed=True,
-                    message="check ignored",
-                    ignored=True,
-                )
-            )
-        else:
-            gr_count = len(metrics["guardrail_events"])
-            passed = gr_count == 0
-            report.add(
-                AssertionResult(
-                    check_name="no_guardrails",
-                    passed=passed,
-                    message=(
-                        "no guardrail events"
-                        if passed
-                        else f"{gr_count} guardrail event(s) detected"
-                    ),
-                    reason_code=_reason_code_for(
-                        passed, RegressionReasonCode.GUARDRAIL_EVENT_CHANGED
-                    ),
-                    actual=str(gr_count),
-                )
-            )
-
-    # --- cost tokens ---
-    r = _check_threshold(
-        actual=summary["total_tokens"],
-        baseline_value=b_summary["total_tokens"] if b_summary else None,
-        tolerance=policy.cost_tolerance,
-        standalone_max=policy.max_cost_tokens,
-        check_name="cost_tokens",
-        reason_code=RegressionReasonCode.COST_ENVELOPE_EXCEEDED,
-        unit="tokens",
-    )
-    if r and "cost_tokens" in _ignored:
-        report.add(
-            AssertionResult(
-                check_name="cost_tokens",
-                passed=True,
-                message="check ignored",
-                ignored=True,
-            )
-        )
-    elif r:
-        report.add(r)
-
-    # --- duration ---
-    r = _check_threshold(
-        actual=summary["duration_ms"],
-        baseline_value=b_summary["duration_ms"] if b_summary else None,
-        tolerance=policy.duration_tolerance,
-        standalone_max=policy.max_duration_ms,
-        check_name="duration",
-        reason_code=RegressionReasonCode.LATENCY_ENVELOPE_EXCEEDED,
-        unit="ms",
-    )
-    if r and "duration" in _ignored:
-        report.add(
-            AssertionResult(
-                check_name="duration",
-                passed=True,
-                message="check ignored",
-                ignored=True,
-            )
-        )
-    elif r:
-        report.add(r)
-
-    # --- expect status ---
-    if policy.expect_status is not None:
-        if "expect_status" in _ignored:
-            report.add(
-                AssertionResult(
-                    check_name="expect_status",
-                    passed=True,
-                    message="check ignored",
-                    ignored=True,
-                )
-            )
-        else:
-            actual_status = meta.get("status", "")
-            passed = actual_status == policy.expect_status
-            report.add(
-                AssertionResult(
-                    check_name="expect_status",
-                    passed=passed,
-                    message=(
-                        f"status is '{actual_status}'"
-                        if passed
-                        else f"expected '{policy.expect_status}', got '{actual_status}'"
-                    ),
-                    reason_code=_reason_code_for(
-                        passed, RegressionReasonCode.TERMINAL_STATE_MISSING
-                    ),
-                    expected=policy.expect_status,
-                    actual=actual_status,
-                )
-            )
+        elif r:
+            report.add(r)
 
     return report
 

--- a/maida/assertions.py
+++ b/maida/assertions.py
@@ -81,6 +81,10 @@ class AssertionPolicy:
     # Explicitly ignored checks (skipped even when thresholds/baseline are set)
     ignored_checks: list[str] = field(default_factory=list)
 
+    def __post_init__(self) -> None:
+        if self.ignored_checks is None:
+            self.ignored_checks = []
+
 
 @dataclass
 class AssertionResult:

--- a/maida/cli.py
+++ b/maida/cli.py
@@ -391,6 +391,9 @@ def assert_cmd(
     expect_status: str | None = typer.Option(
         None, "--expect-status", help="Expected run status (ok or error)"
     ),
+    ignore_check: list[str] = typer.Option(
+        [], "--ignore-check", help="Skip a check (repeatable)"
+    ),
     output_format: str = typer.Option(
         "text", "--format", "-f", help="Output format: text, json, markdown"
     ),
@@ -426,6 +429,7 @@ def assert_cmd(
             "max_duration_ms": max_duration_ms,
             "duration_tolerance": duration_tolerance,
             "expect_status": expect_status,
+            "ignored_checks": ignore_check or None,
         }
         policy = merge_policy(policy, cli_overrides)
 

--- a/maida/policy.py
+++ b/maida/policy.py
@@ -76,6 +76,7 @@ def merge_policy(
         max_duration_ms=file_policy.max_duration_ms,
         duration_tolerance=file_policy.duration_tolerance,
         expect_status=file_policy.expect_status,
+        ignored_checks=list(file_policy.ignored_checks),
     )
     for key, value in cli_overrides.items():
         if not hasattr(merged, key):
@@ -84,5 +85,10 @@ def merge_policy(
             continue
         if isinstance(value, bool) and not value:
             continue
-        setattr(merged, key, value)
+        if key == "ignored_checks":
+            existing = set(getattr(merged, key) or [])
+            merged_set = existing | set(value)
+            setattr(merged, key, sorted(merged_set))
+        else:
+            setattr(merged, key, value)
     return merged

--- a/maida/scaffold.py
+++ b/maida/scaffold.py
@@ -37,6 +37,11 @@ assert:
   # max_tool_calls: 40
   # max_cost_tokens: 20000
   # max_duration_ms: 60000
+
+  # Ignored checks (skip these even when thresholds are set):
+  # ignored_checks:
+  #   - step_count
+  #   - cost_tokens
 """
 
 WORKFLOW_TEMPLATE = f"""\

--- a/tests/test_assertions.py
+++ b/tests/test_assertions.py
@@ -466,6 +466,157 @@ def test_all_checks_disabled_passes(temp_data_dir):
 
 
 # ---------------------------------------------------------------------------
+# Ignored checks
+# ---------------------------------------------------------------------------
+
+
+def test_ignored_step_count_produces_ignored_result(temp_data_dir):
+    config = load_config()
+    events = [(EventType.TOOL_CALL, f"t{i}", {}) for i in range(100)]
+    run_id = _make_run(config, events=events)
+    policy = AssertionPolicy(max_steps=1, ignored_checks=["step_count"])
+    report = run_assertions(run_id, policy, config=config)
+    step = next(r for r in report.results if r.check_name == "step_count")
+    assert step.ignored is True
+    assert step.passed is True
+    assert report.passed is True
+
+
+def test_ignored_tool_calls_produces_ignored_result(temp_data_dir):
+    config = load_config()
+    events = [(EventType.TOOL_CALL, f"t{i}", {}) for i in range(100)]
+    run_id = _make_run(config, events=events)
+    policy = AssertionPolicy(max_tool_calls=1, ignored_checks=["tool_calls"])
+    report = run_assertions(run_id, policy, config=config)
+    result = next(r for r in report.results if r.check_name == "tool_calls")
+    assert result.ignored is True
+
+
+def test_ignored_cost_tokens_produces_ignored_result(temp_data_dir):
+    config = load_config()
+    events = [
+        (
+            EventType.LLM_CALL,
+            "gpt-4",
+            {
+                "usage": {
+                    "prompt_tokens": 9999,
+                    "completion_tokens": 9999,
+                    "total_tokens": 19998,
+                }
+            },
+        )
+    ]
+    run_id = _make_run(config, events=events)
+    policy = AssertionPolicy(max_cost_tokens=1, ignored_checks=["cost_tokens"])
+    report = run_assertions(run_id, policy, config=config)
+    result = next(r for r in report.results if r.check_name == "cost_tokens")
+    assert result.ignored is True
+
+
+def test_ignored_duration_produces_ignored_result(temp_data_dir):
+    config = load_config()
+    run_id = _make_run(config, events=[])
+    policy = AssertionPolicy(max_duration_ms=1, ignored_checks=["duration"])
+    report = run_assertions(run_id, policy, config=config)
+    result = next(r for r in report.results if r.check_name == "duration")
+    assert result.ignored is True
+
+
+def test_ignored_new_tools_produces_ignored_result(temp_data_dir):
+    config = load_config()
+    bl_events = [(EventType.TOOL_CALL, "existing_tool", {})]
+    bl_rid = _make_run(config, events=bl_events, name="baseline")
+    bl = create_baseline(bl_rid, config)
+    run_events = [(EventType.TOOL_CALL, "new_tool", {})]
+    run_id = _make_run(config, events=run_events, name="check")
+    policy = AssertionPolicy(no_new_tools=True, ignored_checks=["new_tools"])
+    report = run_assertions(run_id, policy, baseline=bl, config=config)
+    result = next(r for r in report.results if r.check_name == "new_tools")
+    assert result.ignored is True
+
+
+def test_ignored_no_loops_produces_ignored_result(temp_data_dir):
+    config = load_config()
+    events = [
+        (EventType.TOOL_CALL, "t", {}),
+        (EventType.LLM_CALL, "m", {}),
+        (EventType.TOOL_CALL, "t", {}),
+        (EventType.LLM_CALL, "m", {}),
+        (EventType.TOOL_CALL, "t", {}),
+        (EventType.LLM_CALL, "m", {}),
+    ]
+    run_id = _make_run(config, events=events)
+    policy = AssertionPolicy(no_loops=True, ignored_checks=["no_loops"])
+    report = run_assertions(run_id, policy, config=config)
+    result = next(r for r in report.results if r.check_name == "no_loops")
+    assert result.ignored is True
+
+
+def test_ignored_no_guardrails_produces_ignored_result(temp_data_dir):
+    config = load_config()
+    run_id = _make_run(config, events=[])
+    policy = AssertionPolicy(no_guardrails=True, ignored_checks=["no_guardrails"])
+    report = run_assertions(run_id, policy, config=config)
+    result = next(r for r in report.results if r.check_name == "no_guardrails")
+    assert result.ignored is True
+
+
+def test_ignored_expect_status_produces_ignored_result(temp_data_dir):
+    config = load_config()
+    run_id = _make_run(config, events=[], status="error")
+    policy = AssertionPolicy(expect_status="ok", ignored_checks=["expect_status"])
+    report = run_assertions(run_id, policy, config=config)
+    result = next(r for r in report.results if r.check_name == "expect_status")
+    assert result.ignored is True
+
+
+def test_ignored_check_reports_passed(temp_data_dir):
+    config = load_config()
+    events = [(EventType.TOOL_CALL, f"t{i}", {}) for i in range(100)]
+    run_id = _make_run(config, events=events)
+    policy = AssertionPolicy(
+        max_steps=1, max_tool_calls=1, ignored_checks=["step_count", "tool_calls"]
+    )
+    report = run_assertions(run_id, policy, config=config)
+    assert report.passed is True
+    for r in report.results:
+        assert r.ignored is True
+
+
+def test_ignored_checks_in_report_text(temp_data_dir):
+    config = load_config()
+    run_id = _make_run(config, events=[])
+    policy = AssertionPolicy(max_steps=100, ignored_checks=["step_count"])
+    report = run_assertions(run_id, policy, config=config)
+    text = format_report_text(report)
+    assert "[ignored]" in text
+    assert "step_count" in text
+    assert "1 ignored" in text
+
+
+def test_ignored_checks_in_report_json(temp_data_dir):
+    config = load_config()
+    run_id = _make_run(config, events=[])
+    policy = AssertionPolicy(max_steps=100, ignored_checks=["step_count"])
+    report = run_assertions(run_id, policy, config=config)
+    data = json.loads(format_report_json(report))
+    step = next(r for r in data["results"] if r["check_name"] == "step_count")
+    assert step["ignored"] is True
+    assert step["passed"] is True
+
+
+def test_ignored_checks_in_report_markdown(temp_data_dir):
+    config = load_config()
+    run_id = _make_run(config, events=[])
+    policy = AssertionPolicy(max_steps=100, ignored_checks=["step_count"])
+    report = run_assertions(run_id, policy, config=config)
+    md = format_report_markdown(report)
+    assert "ignored checks" in md.lower()
+    assert "step_count" in md
+
+
+# ---------------------------------------------------------------------------
 # Report formatters
 # ---------------------------------------------------------------------------
 

--- a/tests/test_assertions.py
+++ b/tests/test_assertions.py
@@ -571,6 +571,14 @@ def test_ignored_expect_status_produces_ignored_result(temp_data_dir):
     assert result.ignored is True
 
 
+def test_unknown_ignored_check_raises_error(temp_data_dir):
+    config = load_config()
+    run_id = _make_run(config, events=[])
+    policy = AssertionPolicy(ignored_checks=["step_counts"])
+    with pytest.raises(ValueError, match="Unknown check name"):
+        run_assertions(run_id, policy, config=config)
+
+
 def test_ignored_check_reports_passed(temp_data_dir):
     config = load_config()
     events = [(EventType.TOOL_CALL, f"t{i}", {}) for i in range(100)]

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -586,6 +586,34 @@ def test_assert_no_loops_flag(empty_data_dir):
     assert result.exit_code == 0
 
 
+def test_assert_ignore_check_flag(empty_data_dir):
+    config = load_config()
+    events = [(EventType.TOOL_CALL, f"t{i}", {}) for i in range(100)]
+    _make_run(config, name="check", events=events)
+    from tests.conftest import get_latest_run_id
+
+    run_id = get_latest_run_id(config)
+
+    # Run would fail with max_steps=1, but --ignore-check skips step_count
+    result = runner.invoke(
+        app,
+        [
+            "assert",
+            run_id,
+            "--max-steps",
+            "1",
+            "--ignore-check",
+            "step_count",
+            "--format",
+            "json",
+        ],
+    )
+    assert result.exit_code == 0
+    data = json.loads(result.stdout)
+    step = next(r for r in data["results"] if r["check_name"] == "step_count")
+    assert step["ignored"] is True
+
+
 # ---------------------------------------------------------------------------
 # diff command
 # ---------------------------------------------------------------------------

--- a/tests/test_policy.py
+++ b/tests/test_policy.py
@@ -141,6 +141,13 @@ def test_load_policy_with_ignored_checks(tmp_path):
     assert policy.ignored_checks == ["step_count", "cost_tokens"]
 
 
+def test_load_policy_ignored_checks_null(tmp_path):
+    p = tmp_path / "policy.yaml"
+    p.write_text("assert:\n  ignored_checks:\n")
+    policy = load_policy(p)
+    assert policy.ignored_checks == []
+
+
 def test_load_policy_ignored_checks_empty_list(tmp_path):
     p = tmp_path / "policy.yaml"
     p.write_text("assert:\n  ignored_checks: []\n")

--- a/tests/test_policy.py
+++ b/tests/test_policy.py
@@ -127,3 +127,52 @@ def test_merge_ignores_unknown_keys():
     merged = merge_policy(file_policy, cli)
     assert merged.max_steps == 10
     assert not hasattr(merged, "unknown_field")
+
+
+# ---------------------------------------------------------------------------
+# ignored_checks
+# ---------------------------------------------------------------------------
+
+
+def test_load_policy_with_ignored_checks(tmp_path):
+    p = tmp_path / "policy.yaml"
+    p.write_text("assert:\n  ignored_checks:\n    - step_count\n    - cost_tokens\n")
+    policy = load_policy(p)
+    assert policy.ignored_checks == ["step_count", "cost_tokens"]
+
+
+def test_load_policy_ignored_checks_empty_list(tmp_path):
+    p = tmp_path / "policy.yaml"
+    p.write_text("assert:\n  ignored_checks: []\n")
+    policy = load_policy(p)
+    assert policy.ignored_checks == []
+
+
+def test_merge_ignored_checks_union_with_cli():
+    file_policy = AssertionPolicy(ignored_checks=["step_count", "no_loops"])
+    cli = {"ignored_checks": ["cost_tokens"]}
+    merged = merge_policy(file_policy, cli)
+    assert sorted(merged.ignored_checks) == sorted(
+        ["step_count", "no_loops", "cost_tokens"]
+    )
+
+
+def test_merge_ignored_checks_file_only():
+    file_policy = AssertionPolicy(ignored_checks=["step_count"])
+    cli = {"ignored_checks": None}
+    merged = merge_policy(file_policy, cli)
+    assert merged.ignored_checks == ["step_count"]
+
+
+def test_merge_ignored_checks_cli_only():
+    file_policy = AssertionPolicy()
+    cli = {"ignored_checks": ["duration"]}
+    merged = merge_policy(file_policy, cli)
+    assert merged.ignored_checks == ["duration"]
+
+
+def test_merge_ignored_checks_dedup():
+    file_policy = AssertionPolicy(ignored_checks=["step_count"])
+    cli = {"ignored_checks": ["step_count", "no_loops"]}
+    merged = merge_policy(file_policy, cli)
+    assert merged.ignored_checks == ["no_loops", "step_count"]


### PR DESCRIPTION
Add `ignored_checks: list[str]` to `AssertionPolicy` to allow explicitly skipping checks even when thresholds or a baseline is present. This is more intentional than the previous implicit-disable (both baseline and standalone_max being None).

Changes:
- `AssertionResult` gains `ignored: bool` field
- `AssertionPolicy` gains `ignored_checks: list[str]` field
- All 8 checks in `run_assertions()` respect `ignored_checks`
- All 3 report formatters (text/json/markdown) display ignored checks
- `merge_policy()` unions CLI `--ignore-check` values with file values
- CLI gains repeatable `--ignore-check` flag
- Docs and scaffold template updated

fixes #88