### PR TITLE
move default ~/.maida to ~/config/.maida

### DIFF
--- a/README.md
+++ b/README.md
@@ -152,7 +152,7 @@ Available guardrails:
 - `max_events`
 - `max_duration_s`
 
-You can set them in `@trace(...)`, `traced_run(...)`, `.maida/config.yaml`, `~/.maida/config.yaml`, or env vars like `MAIDA_MAX_LLM_CALLS=50`.
+You can set them in `@trace(...)`, `traced_run(...)`, `.maida/config.yaml`, `~/.config/maida/config.yaml` (default; falls back to `~/.maida/config.yaml`), or env vars like `MAIDA_MAX_LLM_CALLS=50`.
 
 See [docs/guardrails.md](docs/guardrails.md) for full examples, precedence, and trace behavior.
 
@@ -167,7 +167,7 @@ In the UI, you see:
 - **Live-refresh**: leave `maida view` running — new runs appear in the sidebar, events stream in real-time for running agents
 - **Filter chips**: All, LLM, Tools, Errors, State, Loops
 
-Each run produces `meta.json` (metadata, status, counts) and `spans.jsonl` (OpenTelemetry span records) under `~/.maida/`. Nothing leaves your machine.
+Each run produces `meta.json` (metadata, status, counts) and `spans.jsonl` (OpenTelemetry span records) under `~/.config/maida/`. Nothing leaves your machine.
 
 
 ## What Maida is
@@ -279,7 +279,7 @@ export MAIDA_REDACT_KEYS="api_key,token,authorization,cookie,secret,password"
 export MAIDA_MAX_FIELD_BYTES=20000       # truncation limit
 ```
 
-You can also configure redaction in `.maida/config.yaml` (project root) or `~/.maida/config.yaml`.
+You can also configure redaction in `.maida/config.yaml` (project root) or `~/.config/maida/config.yaml` (default; falls back to `~/.maida/config.yaml`).
 
 ## Guardrails
 
@@ -311,7 +311,7 @@ Precedence:
 1. Function arguments passed to `@trace(...)` or `traced_run(...)`
 2. Environment variables
 3. Project YAML: `.maida/config.yaml`
-4. User YAML: `~/.maida/config.yaml`
+4. User YAML: `~/.config/maida/config.yaml` (falls back to `~/.maida/config.yaml`)
 5. Defaults
 
 See [docs/guardrails.md](docs/guardrails.md) and [docs/reference/config.md](docs/reference/config.md).
@@ -322,7 +322,7 @@ See [docs/guardrails.md](docs/guardrails.md) and [docs/reference/config.md](docs
 All data is local. Plain files, easy to inspect or delete.
 
 ```
-~/.maida/
+~/.config/maida/
 └── runs/
     └── <trace_id>/
         ├── meta.json       # run metadata (status, counts, timing)

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -41,7 +41,7 @@ The span records are written as one JSON object per line and flushed after each 
 
 ## Storage layout
 
-- **Base directory:** `~/.maida/` (or `MAIDA_DATA_DIR`).
+- **Base directory:** `~/.config/maida/` (or `MAIDA_DATA_DIR`).
 - **Per run:** `runs/<trace_id>/`
   - **meta.json** - Run metadata: `trace_id`, `run_name`, `started_at`, `ended_at`, `duration_ms`, `status`, and `counts` (llm_calls, tool_calls, errors, loop_warnings).
   - **spans.jsonl** - Append-only; one OTel span JSON object per line.

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -1,6 +1,6 @@
 # CLI
 
-The `maida` CLI runs the bundled demo, scaffolds a project, lists runs, starts the local viewer, exports runs to JSON, and gates runs against baselines. Storage is under `~/.maida/` by default (overridable with `MAIDA_DATA_DIR`). For all configuration options and precedence, see the [configuration reference](reference/config.md).
+The `maida` CLI runs the bundled demo, scaffolds a project, lists runs, starts the local viewer, exports runs to JSON, and gates runs against baselines. Storage is under `~/.config/maida/` by default (overridable with `MAIDA_DATA_DIR`). For all configuration options and precedence, see the [configuration reference](reference/config.md).
 
 Commands that take a run ID (`assert`, `baseline`, `export`, `diff`) default to the **latest run** when the ID is omitted. The selected run is announced on stderr so stdout stays machine-readable.
 

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -124,7 +124,7 @@ See [Guardrails](guardrails.md) for examples and [Configuration reference](refer
 
 ## Where data is stored
 
-- **Default:** `~/.maida/runs/<trace_id>/`
+- **Default:** `~/.config/maida/runs/<trace_id>/`
   - `meta.json` - run metadata (status, counts, started_at, ended_at)
   - `spans.jsonl` - one OpenTelemetry span JSON object per line (append-only)
 
@@ -138,7 +138,7 @@ Set the data directory so runs are stored somewhere else (e.g. project-local):
 export MAIDA_DATA_DIR=/path/to/my/data
 ```
 
-Config can also be set in `~/.maida/config.yaml` or `.maida/config.yaml` in the project root; environment variables take precedence. See the [configuration reference](reference/config.md) for the full list of options and precedence.
+Config can also be set in `~/.config/maida/config.yaml` (default; falls back to `~/.maida/config.yaml`) or `.maida/config.yaml` in the project root; environment variables take precedence. See the [configuration reference](reference/config.md) for the full list of options and precedence.
 
 ---
 

--- a/docs/guardrails.md
+++ b/docs/guardrails.md
@@ -161,7 +161,7 @@ Highest wins:
 1. Function arguments passed to `@trace(...)` or `traced_run(...)`
 2. Environment variables
 3. Project YAML: `.maida/config.yaml`
-4. User YAML: `~/.maida/config.yaml`
+4. User YAML: `~/.config/maida/config.yaml` (falls back to `~/.maida/config.yaml`)
 5. Defaults
 
 ### Decorator and context manager
@@ -193,7 +193,7 @@ export MAIDA_MAX_DURATION_S=60
 ### YAML config
 
 ```yaml
-# .maida/config.yaml or ~/.maida/config.yaml
+# .maida/config.yaml or ~/.config/maida/config.yaml
 guardrails:
   stop_on_loop: true
   stop_on_loop_min_repetitions: 3

--- a/docs/index.md
+++ b/docs/index.md
@@ -28,7 +28,7 @@ maida demo
 maida view
 ```
 
-A browser tab opens showing every event in the run - tool calls, LLM calls, timing. Data is stored locally under `~/.maida/runs/<trace_id>/`.
+A browser tab opens showing every event in the run - tool calls, LLM calls, timing. Data is stored locally under `~/.config/maida/runs/<trace_id>/`.
 
 From there, capture a baseline with `maida baseline`, gate future runs with `maida assert`, and scaffold your own project with `maida init`. To watch the gate catch a regression end-to-end on canned data, run:
 

--- a/docs/reference/config.md
+++ b/docs/reference/config.md
@@ -10,7 +10,7 @@ Configuration is merged in this order (highest wins):
 
 1. **Environment variables**
 2. **Project config:** `.maida/config.yaml` in project root (current working directory when config is loaded)
-3. **User config:** `~/.maida/config.yaml`
+3. **User config:** `~/.config/maida/config.yaml` (falls back to `~/.maida/config.yaml`)
 4. **Defaults** (see below)
 
 ---
@@ -21,7 +21,7 @@ Configuration is merged in this order (highest wins):
 
 | Env | YAML key | Default | Description |
 |-----|----------|---------|-------------|
-| `MAIDA_DATA_DIR` | `data_dir` | `~/.maida` | Base directory for runs. Runs are stored under `<data_dir>/runs/<trace_id>/`. |
+| `MAIDA_DATA_DIR` | `data_dir` | `~/.config/maida` | Base directory for runs. Runs are stored under `<data_dir>/runs/<trace_id>/`. |
 
 **Example (env):**
 
@@ -32,7 +32,7 @@ export MAIDA_DATA_DIR=/path/to/my/maida/data
 **Example (YAML):**
 
 ```yaml
-# ~/.maida/config.yaml or .maida/config.yaml
+# ~/.config/maida/config.yaml or .maida/config.yaml
 data_dir: /path/to/my/maida/data
 ```
 
@@ -183,8 +183,8 @@ export MAIDA_IMPLICIT_RUN=1
 ## Full YAML example
 
 ```yaml
-# ~/.maida/config.yaml or .maida/config.yaml
-data_dir: ~/.maida
+# ~/.config/maida/config.yaml or .maida/config.yaml
+data_dir: ~/.config/maida
 redact: true
 redact_keys:
   - api_key
@@ -210,5 +210,5 @@ guardrails:
 ## Safe-by-default local traces
 
 - **Redaction is on by default** so that common secret keys are not written to disk.
-- **Data directory** defaults to `~/.maida` so traces stay on the machine.
+- **Data directory** defaults to `~/.config/maida` so traces stay on the machine.
 - No cloud or network is used for trace storage. Override only what you need (e.g. `MAIDA_DATA_DIR` for project-local storage, or `MAIDA_REDACT=0` for trusted local inspection with full payloads).

--- a/docs/reference/trace-format.md
+++ b/docs/reference/trace-format.md
@@ -8,7 +8,7 @@ This page describes the **public trace format** for Maida (`spec_version: "0.2"`
 
 ## Run storage layout
 
-Maida stores local runs under the configured data directory. The default is `~/.maida`, and callers can override it with `MAIDA_DATA_DIR` or config. The canonical per-run directory is `<data_dir>/runs/<trace_id>/`, where `<trace_id>` is the lowercase 32-hex-character OpenTelemetry trace ID.
+Maida stores local runs under the configured data directory. The default is `~/.config/maida`, and callers can override it with `MAIDA_DATA_DIR` or config. The canonical per-run directory is `<data_dir>/runs/<trace_id>/`, where `<trace_id>` is the lowercase 32-hex-character OpenTelemetry trace ID.
 
 ```text
 <data_dir>/

--- a/docs/sdk.md
+++ b/docs/sdk.md
@@ -106,7 +106,7 @@ Guardrails are resolved in this order:
 1. Arguments passed to `@trace(...)` or `traced_run(...)`
 2. Environment variables
 3. `.maida/config.yaml` in the current project
-4. `~/.maida/config.yaml`
+4. `~/.config/maida/config.yaml` (falls back to `~/.maida/config.yaml`)
 5. Defaults
 
 See [Guardrails](guardrails.md) and the [configuration reference](reference/config.md) for the full config surface.
@@ -305,6 +305,6 @@ then the first recorder call with no active run creates a single **implicit run*
 
 1. Environment variables (`MAIDA_REDACT`, `MAIDA_REDACT_KEYS`, `MAIDA_MAX_FIELD_BYTES`)
 2. `.maida/config.yaml` in project root
-3. `~/.maida/config.yaml`
+3. `~/.config/maida/config.yaml` (falls back to `~/.maida/config.yaml`)
 
 See the [configuration reference](reference/config.md) for the full list of env vars, YAML keys, and defaults.

--- a/maida/config.py
+++ b/maida/config.py
@@ -222,24 +222,31 @@ def _apply_env_to_guardrails(params: GuardrailParams) -> GuardrailParams:
     return params
 
 
+def _user_config_dir() -> tuple[Path, Path]:
+    """Return (xdg_base, legacy_base) for user config directories."""
+    return Path.home() / ".config" / "maida", Path.home() / ".maida"
+
+
 def load_config(project_root: Path | None = None) -> MaidaConfig:
     """
     Load MaidaConfig with precedence (highest first):
     1. Environment variables
     2. .maida/config.yaml in project root (if present)
-    3. ~/.maida/config.yaml
+    3. ~/.config/maida/config.yaml (falls back to ~/.maida/config.yaml)
     """
-    base = Path.home() / LOCAL_DIR_NAME
+    xdg_base, legacy_base = _user_config_dir()
     redact = _DEFAULT_REDACT
     redact_keys = _DEFAULT_REDACT_KEYS.copy()
     max_field_bytes = _DEFAULT_MAX_FIELD_BYTES
     loop_window = _DEFAULT_LOOP_WINDOW
     loop_repetitions = _DEFAULT_LOOP_REPETITIONS
-    data_dir = base
+    data_dir = xdg_base
 
-    # 3. User config
-    user_config_path = base / "config.yaml"
+    # 3. User config - try XDG first, then legacy ~/.maida
+    user_config_path = xdg_base / "config.yaml"
     user_cfg = _load_yaml(user_config_path)
+    if not user_cfg:
+        user_cfg = _load_yaml(legacy_base / "config.yaml")
     if user_cfg:
         redact = _apply_yaml(user_cfg, "redact", redact)
         redact_keys = _apply_yaml(user_cfg, "redact_keys", redact_keys)


### PR DESCRIPTION
Changes default to ~/.config/maida has fallback to ~/.maida if ~/.config/maida doesn't exist.

Fixes #89