### PR TITLE
Add baseline acceptance command

### DIFF
--- a/maida/acceptance.py
+++ b/maida/acceptance.py
@@ -1,0 +1,109 @@
+"""Baseline acceptance helpers for intentional behavior changes."""
+
+from dataclasses import dataclass
+from hashlib import sha256
+from pathlib import Path
+
+from maida.baseline import create_baseline, save_baseline
+from maida.config import MaidaConfig
+from maida.diff import RunDiff, compute_diff
+from maida.events import utc_now_iso_ms_z
+
+_STRUCTURAL_BASELINE_KEYS = (
+    "schema_version",
+    "summary",
+    "tool_path",
+    "tool_call_sequence",
+    "_tool_call_sequence_exact",
+    "tool_call_counts",
+    "llm_models_used",
+    "event_type_sequence",
+    "guardrail_events",
+    "final_status",
+)
+
+
+@dataclass(frozen=True)
+class BaselineAcceptResult:
+    """Result of accepting a run into an existing baseline."""
+
+    updated: bool
+    baseline_path: Path
+    source_run_id: str
+    previous_source_run_id: str | None
+    previous_baseline_sha256: str
+    diff: RunDiff
+
+
+def _baseline_sha256(path: Path) -> str:
+    return sha256(path.read_bytes()).hexdigest()
+
+
+def _structural_snapshot(baseline: dict) -> dict:
+    return {key: baseline.get(key) for key in _STRUCTURAL_BASELINE_KEYS}
+
+
+def baseline_matches_run(existing_baseline: dict, new_baseline: dict) -> bool:
+    """Return true when two baselines describe the same structural behavior.
+
+    TODO: This assumes that all the values are strictly ordered and comparable.
+          Tracked in #130
+    """
+
+    return _structural_snapshot(existing_baseline) == _structural_snapshot(new_baseline)
+
+
+def accept_baseline_update(
+    *,
+    run_id: str,
+    baseline_path: Path,
+    existing_baseline: dict,
+    reason: str,
+    maida_version: str,
+    config: MaidaConfig,
+) -> BaselineAcceptResult:
+    """Update *baseline_path* from *run_id* and attach acceptance metadata.
+
+    The existing baseline is compared against the freshly created run baseline.
+    If there is no structural change, the file is left untouched so review diffs
+    stay meaningful.
+    """
+
+    previous_hash = _baseline_sha256(baseline_path)
+    new_baseline = create_baseline(run_id, config)
+    diff = compute_diff(run_id, baseline=existing_baseline, config=config)
+    previous_source_run_id = existing_baseline.get("source_run_id")
+
+    if baseline_matches_run(existing_baseline, new_baseline):
+        return BaselineAcceptResult(
+            updated=False,
+            baseline_path=baseline_path,
+            source_run_id=new_baseline["source_run_id"],
+            previous_source_run_id=previous_source_run_id,
+            previous_baseline_sha256=previous_hash,
+            diff=diff,
+        )
+
+    new_baseline["acceptance"] = {
+        "accepted_at": utc_now_iso_ms_z(),
+        "reason": reason,
+        "maida_version": maida_version,
+        "source_run_id": new_baseline["source_run_id"],
+        "previous_baseline": {
+            "path": str(baseline_path),
+            "source_run_id": previous_source_run_id,
+            "created_at": existing_baseline.get("created_at"),
+            "schema_version": existing_baseline.get("schema_version"),
+            "sha256": previous_hash,
+        },
+    }
+    save_baseline(new_baseline, baseline_path)
+
+    return BaselineAcceptResult(
+        updated=True,
+        baseline_path=baseline_path,
+        source_run_id=new_baseline["source_run_id"],
+        previous_source_run_id=previous_source_run_id,
+        previous_baseline_sha256=previous_hash,
+        diff=diff,
+    )

--- a/maida/cli.py
+++ b/maida/cli.py
@@ -26,6 +26,7 @@ from maida.assertions import (
     format_report_text,
     run_assertions,
 )
+from maida.acceptance import accept_baseline_update
 from maida.baseline import create_baseline, load_baseline, save_baseline
 from maida.config import load_config
 from maida.constants import LOCAL_DIR_NAME, SPEC_VERSION
@@ -335,6 +336,85 @@ def baseline_cmd(
 
         save_baseline(bl, out)
         typer.echo(f"Baseline saved to {out}")
+    except Exit:
+        raise
+    except storage.UnsupportedTraceFormatError as e:
+        _exit_unsupported_trace_format(e)
+    except storage.RunValidationError as e:
+        _exit_run_validation_error(e)
+    except Exception as e:
+        typer.echo(f"error: {e}", err=True)
+        raise Exit(EXIT_INTERNAL)
+
+
+@app.command("accept")
+def accept_cmd(
+    run_id: str | None = typer.Argument(
+        None, help="Run ID or prefix to accept (default: latest run)"
+    ),
+    baseline_path: Path = typer.Option(
+        ..., "--baseline", "-b", help="Baseline JSON file to update"
+    ),
+    reason: str | None = typer.Option(
+        None,
+        "--reason",
+        "--message",
+        "-m",
+        help="Required acceptance reason for the baseline update",
+    ),
+) -> None:
+    """Accept an intentional behavior change by updating a baseline."""
+    try:
+        if reason is None or not reason.strip():
+            typer.echo(
+                "Acceptance reason required: pass --reason TEXT or -m TEXT.",
+                err=True,
+            )
+            raise Exit(EXIT_NOT_FOUND)
+        reason = reason.strip()
+
+        config = load_config()
+        try:
+            run_id = _resolve_run_or_latest(run_id, config)
+        except FileNotFoundError as e:
+            typer.echo(f"Run not found: {run_id or e}", err=True)
+            raise Exit(EXIT_NOT_FOUND)
+
+        try:
+            existing_baseline = load_baseline(baseline_path)
+        except FileNotFoundError:
+            typer.echo(f"Baseline not found: {baseline_path}", err=True)
+            raise Exit(EXIT_NOT_FOUND)
+        except json.JSONDecodeError:
+            typer.echo(f"Invalid baseline file: {baseline_path}", err=True)
+            raise Exit(EXIT_NOT_FOUND)
+
+        if not isinstance(existing_baseline, dict):
+            typer.echo(f"Invalid baseline file: {baseline_path}", err=True)
+            raise Exit(EXIT_NOT_FOUND)
+
+        result = accept_baseline_update(
+            run_id=run_id,
+            baseline_path=baseline_path,
+            existing_baseline=existing_baseline,
+            reason=reason,
+            maida_version=__version__,
+            config=config,
+        )
+
+        if result.updated:
+            typer.echo(f"Baseline updated: {baseline_path}")
+            typer.echo(f"Accepted run: {result.source_run_id[:8]}")
+            typer.echo(
+                f"Previous baseline: {str(result.previous_source_run_id or 'unknown')[:8]}"
+            )
+            typer.echo("")
+            typer.echo(format_diff_text(result.diff))
+        else:
+            typer.echo(
+                f"Baseline already matches run; no update written: {baseline_path}"
+            )
+            typer.echo(f"Matched run: {result.source_run_id[:8]}")
     except Exit:
         raise
     except storage.UnsupportedTraceFormatError as e:


### PR DESCRIPTION
Implemented `maida accept` for intentional baseline updates. The command updates an existing baseline from a selected or latest run, requires an explicit reason, writes acceptance metadata, summarizes the structural diff, and preserves existing baseline behavior.

- Added `maida/acceptance.py` with baseline structural comparison, previous baseline SHA-256 capture, acceptance metadata construction, and no-op detection.
- Added `maida accept [RUN_ID] --baseline/-b PATH --reason/--message/-m TEXT`.
- Preserved CLI conventions: latest-run fallback, selected-run notice on stderr, exit `2` for missing/invalid run or baseline, exit `10` for internal errors.
- No-op accept leaves the baseline file untouched and exits successfully.

Fixes #70