### PR TITLE
Guide intentional baseline updates

### DIFF
--- a/README.md
+++ b/README.md
@@ -189,7 +189,7 @@ Each run produces `meta.json` (metadata, status, counts) and `spans.jsonl` (Open
 
 ## CLI reference
 
-Commands that take a run ID (`assert`, `baseline`, `export`, `diff`) default to the **latest run** when the ID is omitted; a short prefix also works.
+Commands that take a run ID (`assert`, `baseline`, `accept`, `export`, `diff`) default to the **latest run** when the ID is omitted; a short prefix also works.
 
 ### Run the bundled demo
 
@@ -245,6 +245,17 @@ maida assert --baseline baseline.json --format markdown    # for CI summaries / 
 
 Exit code `0` = pass, `1` = fail. With a baseline, the markdown report starts with the verdict and includes top behavior changes (steps, tool path, loops/cycles, guardrails, terminal state, latency/cost, and models) plus next steps so a failing check explains itself. See [docs/regression-testing.md](docs/regression-testing.md) for the full workflow and [docs/reference/policy.md](docs/reference/policy.md) for policy YAML configuration.
 
+### Accept an intentional baseline change
+
+```bash
+maida diff --baseline .maida/baselines/my_agent.json
+maida view
+maida accept --baseline .maida/baselines/my_agent.json --reason "expected tool flow change"
+git diff .maida/baselines/my_agent.json
+```
+
+Use `maida accept` only after inspecting the diff and trace. It updates the baseline from the selected run, records the acceptance reason and previous baseline hash in the JSON, and leaves the baseline diff reviewable in Git. If the run already matches the baseline, Maida exits successfully without rewriting the file.
+
 ### Diff two runs
 
 ```bash
@@ -260,6 +271,7 @@ Baselines, assertions, and diffs let you catch agent regressions locally or in C
 1. **Baseline** a known-good run (`maida baseline`)
 2. **Assert** future runs against it (`maida assert --baseline ...`)
 3. **Diff** failures to see what changed (`maida diff`)
+4. **Accept** intentional changes only after review (`maida accept --baseline ... --reason ...`)
 
 Control assertion thresholds via a committed `.maida/policy.yaml` file or CLI flags. Supports text, JSON, and markdown output formats.
 

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -1,8 +1,8 @@
 # CLI
 
-The `maida` CLI runs the bundled demo, scaffolds a project, lists runs, starts the local viewer, exports runs to JSON, and gates runs against baselines. Storage is under `~/.maida/` by default (overridable with `MAIDA_DATA_DIR`). For all configuration options and precedence, see the [configuration reference](reference/config.md).
+The `maida` CLI runs the bundled demo, scaffolds a project, lists runs, starts the local viewer, exports runs to JSON, updates baselines intentionally, and gates runs against baselines. Storage is under `~/.maida/` by default (overridable with `MAIDA_DATA_DIR`). For all configuration options and precedence, see the [configuration reference](reference/config.md).
 
-Commands that take a run ID (`assert`, `baseline`, `export`, `diff`) default to the **latest run** when the ID is omitted. The selected run is announced on stderr so stdout stays machine-readable.
+Commands that take a run ID (`assert`, `baseline`, `accept`, `export`, `diff`) default to the **latest run** when the ID is omitted. The selected run is announced on stderr so stdout stays machine-readable.
 
 ---
 
@@ -182,6 +182,39 @@ maida baseline a1b2c3d4 --out baselines/support_agent_v1.json
 **Exit codes:** `0` success; `2` run not found; `10` internal error.
 
 The output file is a JSON object containing `schema_version`, `source_run_id`, summary metrics, `tool_path`, ordered `tool_call_sequence`, `tool_call_counts`, `llm_models_used`, `event_type_sequence`, and `final_status`. Check it into version control to share the baseline with your team.
+
+---
+
+## `maida accept`
+
+Updates an existing baseline from a completed run when a behavior change is intentional. Use it after inspecting `maida diff` and `maida view`; do not accept a regression just to make CI pass.
+
+**Usage:**
+
+```bash
+maida accept [TRACE_ID] --baseline PATH --reason TEXT
+```
+
+**Arguments / options:**
+
+| Argument/Option | Default | Description |
+|---|---|---|
+| `TRACE_ID` | *(latest run)* | OTel trace ID or prefix to accept |
+| `--baseline`, `-b` | *(required)* | Existing baseline JSON file to update |
+| `--reason`, `--message`, `-m` | *(required)* | Human-readable reason for accepting the change |
+
+**Examples:**
+
+```bash
+maida diff --baseline .maida/baselines/my_agent.json
+maida view
+maida accept --baseline .maida/baselines/my_agent.json --reason "expected retrieval tool split"
+git diff .maida/baselines/my_agent.json
+```
+
+**Exit codes:** `0` baseline updated or already matched; `2` run or baseline not found, invalid baseline, invalid run, or missing reason; `10` internal error.
+
+When the accepted run changes baseline behavior, the baseline JSON is rewritten with the same structural fields produced by `maida baseline` plus an `acceptance` object containing the reason, timestamp, Maida version, source run ID, previous baseline source run ID, and previous baseline SHA-256. If the selected run already matches the baseline structurally, Maida prints `no update written` and leaves the file untouched.
 
 ---
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -59,7 +59,7 @@ After any run, inspect evidence with `maida view`, capture baselines with `maida
 | [Getting started](getting-started.md) | Installation (uv/pip), quickstart, data dir, redaction |
 | [Guardrails](guardrails.md) | Stop runaway runs with loop, count, and duration limits |
 | [Regression testing](regression-testing.md) | Baseline, assert, and diff workflow for catching agent regressions |
-| [CLI](cli.md) | `demo`, `init`, `list`, `view`, `export`, `baseline`, `assert`, `diff` with options and exit codes |
+| [CLI](cli.md) | `demo`, `init`, `list`, `view`, `export`, `baseline`, `accept`, `assert`, `diff` with options and exit codes |
 | [Viewer](viewer.md) | Timeline UI usage, URL params, live refresh, and development |
 | [SDK](sdk.md) | `@trace`, `traced_run`, `has_active_run`, `record_llm_call`, `record_tool_call`, `record_state` |
 | [Integrations](integrations.md) | LangChain handler, OpenAI Agents adapter, and planned adapters |

--- a/docs/reference/trace-format.md
+++ b/docs/reference/trace-format.md
@@ -272,6 +272,7 @@ These commands read from or write to the storage contract documented here:
 - [`maida view`](../cli.md#maida-view) serves `meta.json`, `spans.jsonl`, and the projected event timeline through the local viewer API.
 - [`maida export`](../cli.md#maida-export) writes one JSON document containing `spec_version`, run metadata, and projected events.
 - [`maida baseline`](../cli.md#maida-baseline) reads a run and captures stable structural metrics for future comparison.
+- [`maida accept`](../cli.md#maida-accept) reads a run and rewrites an existing baseline after an intentional behavior change.
 - [`maida assert`](../cli.md#maida-assert) reads a run, baseline, and policy to evaluate behavioral regression checks.
 - [`maida diff`](../cli.md#maida-diff) reads two runs or a run plus baseline and reports structural differences.
 

--- a/docs/regression-testing.md
+++ b/docs/regression-testing.md
@@ -1,6 +1,6 @@
 # Regression testing
 
-Maida ships three CLI commands that turn traced runs into behavioral regression gates: **baseline**, **assert**, and **diff**. Together they let you capture a known-good run, check future runs against it, and drill into what changed when something breaks.
+Maida ships four CLI commands that turn traced runs into behavioral regression gates: **baseline**, **assert**, **diff**, and **accept**. Together they let you capture a known-good run, check future runs against it, drill into what changed when something breaks, and intentionally update the baseline after review.
 
 ---
 
@@ -18,9 +18,10 @@ Agent behavior is non-deterministic. A prompt tweak, model upgrade, or tool chan
 3. Run the agent again         python your_agent.py
 4. Assert against baseline     maida assert --baseline .maida/baselines/my_agent.json
 5. If it fails, diff           maida diff --baseline .maida/baselines/my_agent.json
+6. If expected, accept         maida accept --baseline .maida/baselines/my_agent.json --reason "..."
 ```
 
-`baseline`, `assert`, and `diff` default to the latest run when no run ID is given; pass an ID or short prefix to target a specific run.
+`baseline`, `assert`, `diff`, and `accept` default to the latest run when no run ID is given; pass an ID or short prefix to target a specific run.
 
 To see the whole workflow on canned data first, run `maida demo --regression`.
 
@@ -218,7 +219,8 @@ maida assert --baseline baseline.json --format markdown
 
 - Inspect the full diff: `maida diff a1b2c3d4 --baseline baseline.json`
 - Open the trace locally: `maida view a1b2c3d4`
-- If this is expected, update the baseline or policy; otherwise fix the agent behavior and rerun the gate.
+- If this behavior change is intentional, accept it explicitly: `maida accept a1b2c3d4 --baseline baseline.json --reason "..."`
+- Review and commit the baseline diff; otherwise fix the agent behavior and rerun the gate.
 ```
 
 The report leads with the verdict, shows top behavior changes, groups failed checks by stable reason code, collapses passing checks, and includes concise next steps plus a copy-pasteable local-repro snippet.
@@ -269,6 +271,21 @@ Event type distribution:
 ```
 
 The diff shows summary-level metric changes, compact baseline/current tool paths, new or removed tools, repeated calls, reordered shared tools, and shifts in the event type distribution.
+
+---
+
+## Step 5: Accept intentional changes
+
+If the diff and trace show an intentional behavior change, update the checked-in baseline explicitly:
+
+```bash
+maida accept --baseline .maida/baselines/my_agent.json --reason "expected retrieval tool split"
+git diff .maida/baselines/my_agent.json
+```
+
+`maida accept` rewrites the baseline from the selected run and records acceptance metadata in the JSON: reason, timestamp, Maida version, source run ID, previous baseline source run ID, and previous baseline SHA-256. If the selected run already matches the baseline structurally, it exits `0` and leaves the file untouched.
+
+Always inspect the trace and Git diff before committing the updated baseline. Accepting a baseline change means the new behavior is what future PRs will be gated against; if the change is not intentional, fix the agent and rerun `maida assert` instead.
 
 ---
 

--- a/maida/assertions.py
+++ b/maida/assertions.py
@@ -457,8 +457,19 @@ def _markdown_next_steps(
         steps.append("- Review the failed checks and policy thresholds above.")
     steps += [
         f"- Open the trace locally: `maida view {short_run}`",
-        "- If this is expected, update the baseline or policy; otherwise fix the agent behavior and rerun the gate.",
     ]
+    if baseline_path:
+        steps.append(
+            "- If this behavior change is intentional, accept it explicitly: "
+            f'`maida accept {short_run} --baseline {baseline_path} --reason "..."`'
+        )
+        steps.append(
+            "- Review and commit the baseline diff; otherwise fix the agent behavior and rerun the gate."
+        )
+    else:
+        steps.append(
+            "- If this is expected, update the policy; otherwise fix the agent behavior and rerun the gate."
+        )
     return steps
 
 

--- a/maida/cli.py
+++ b/maida/cli.py
@@ -1,7 +1,7 @@
 """
 Typer CLI for Maida.
 
-Commands: list, export, view, baseline, assert, diff.
+Commands: list, export, view, baseline, accept, assert, diff.
 Entrypoint: main() for console script maida.cli:main.
 """
 

--- a/tests/test_assertions.py
+++ b/tests/test_assertions.py
@@ -760,6 +760,9 @@ def test_format_report_markdown_includes_diff_section(temp_data_dir):
     assert "`new_tool`" in md
     assert "maida diff" in md
     assert "--baseline bl.json" in md
+    assert "maida accept" in md
+    assert '--reason "..."' in md
+    assert "Review and commit the baseline diff" in md
 
 
 def test_format_report_markdown_no_diff_section_without_diff(temp_data_dir):
@@ -944,7 +947,8 @@ def test_format_report_markdown_failure_behavior_diff_snapshot():
 
         - Inspect the full diff: `maida diff aaaaaaaa --baseline baseline.json`
         - Open the trace locally: `maida view aaaaaaaa`
-        - If this is expected, update the baseline or policy; otherwise fix the agent behavior and rerun the gate.
+        - If this behavior change is intentional, accept it explicitly: `maida accept aaaaaaaa --baseline baseline.json --reason "..."`
+        - Review and commit the baseline diff; otherwise fix the agent behavior and rerun the gate.
 
         <details>
         <summary>Reproduce locally</summary>

--- a/tests/test_docs.py
+++ b/tests/test_docs.py
@@ -56,6 +56,7 @@ def test_trace_format_documents_current_storage_contract():
         "[`maida view`](../cli.md#maida-view)",
         "[`maida export`](../cli.md#maida-export)",
         "[`maida baseline`](../cli.md#maida-baseline)",
+        "[`maida accept`](../cli.md#maida-accept)",
         "[`maida assert`](../cli.md#maida-assert)",
         "[`maida diff`](../cli.md#maida-diff)",
     ]


### PR DESCRIPTION
Updated core docs and markdown report next steps so intentional behavior changes are handled through inspect -> accept -> review/commit baseline, not vague baseline or policy edits.

- Updated markdown PR-comment next steps to suggest `maida diff`, `maida view`, then `maida accept ... --reason "..."` only for intentional behavior changes.
- Updated report snapshot tests and docs tests for the new command surface.
- Added `maida accept` to README, CLI docs, regression workflow docs, docs index, and trace-format related command references.
- Documented no-op behavior, acceptance metadata, and reviewable Git diffs.

Fixes #72