### PR TITLE
Define adapter conformance contract

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -65,6 +65,7 @@ If you want to add or extend an integration (e.g. another framework):
 3. **Deterministic tests, no network.** Tests for the integration should be deterministic and not perform real LLM or network calls. Use mocks or in-memory stubs.
 4. **Map callbacks to record_*.** Implement the framework's callback/hook interface and call the appropriate `record_*` functions so that events attach to the current run (or an implicit run if `MAIDA_IMPLICIT_RUN=1`).
 5. **Use `_MaidaAbortSignal` for guardrail propagation.** Every framework catches `Exception` in its callback/hook dispatcher. To actually stop execution when a guardrail fires, your adapter must escalate to `_MaidaAbortSignal(BaseException)`. See [maida/integrations/CONTRIBUTING.md](maida/integrations/CONTRIBUTING.md) for the full pattern and pitfalls.
+6. **Meet the conformance contract.** Prove normalized lifecycle, LLM, tool, error, guardrail, terminal-state, payload-safety, and metadata behavior with deterministic offline tests. See the [adapter conformance contract](maida/integrations/CONTRIBUTING.md#adapter-conformance-contract).
 
 New integrations should be documented in [docs/integrations.md](docs/integrations.md) with usage and install instructions. For the guardrail propagation patterns, error handling, and testing checklist, see the [integration adapter guide](maida/integrations/CONTRIBUTING.md).
 

--- a/docs/integrations.md
+++ b/docs/integrations.md
@@ -167,4 +167,4 @@ Planned framework adapters (not yet implemented):
 1. **Agno** - optional adapter for Agno-based agents.
 2. Others as needed (e.g. AutoGen, custom loops).
 
-For guidance on adding new integrations (optional deps, mapping callbacks to `record_*`, tests), see [CONTRIBUTING.md](../CONTRIBUTING.md#adding-integrations--adapters) in the repo root.
+For guidance on adding new integrations, start with [CONTRIBUTING.md](../CONTRIBUTING.md#adding-integrations--adapters) and satisfy the normative [adapter conformance contract](../maida/integrations/CONTRIBUTING.md#adapter-conformance-contract), including normalized signals, deterministic offline tests, payload safety, and namespaced framework metadata.

--- a/maida/integrations/CONTRIBUTING.md
+++ b/maida/integrations/CONTRIBUTING.md
@@ -4,6 +4,111 @@ This guide captures the patterns and pitfalls discovered while building the Lang
 
 ---
 
+## Adapter conformance contract
+
+This section is normative. Every new adapter, and every existing adapter whose
+event mapping changes, MUST satisfy this contract. An adapter translates a
+framework's signals into Maida's public recording API; it does not define a
+second trace schema.
+
+### Required normalized signals
+
+Conformance is judged from the persisted Maida trace, not only from mocked
+`record_*` calls.
+
+| Framework signal | Required Maida representation |
+|---|---|
+| Run start | An active `@trace` or `traced_run(...)` boundary produces one `RUN_START`. Adapters MUST attach to that run and MUST NOT create a second root run. |
+| Run end | The same boundary produces exactly one terminal `RUN_END`, after adapter exit hooks have flushed pending work. Successful runs end with `status="ok"`; an unhandled exception or guardrail abort ends with `status="error"`. |
+| LLM call | Each completed generation exposed by the framework produces one `LLM_CALL` through `record_llm_call`, including model, available input/output and usage, and `status`. Failed generations use `status="error"` and the normalized `error` argument. |
+| Tool call | Each completed tool or equivalent operation exposed by the framework produces one `TOOL_CALL` through `record_tool_call`, including the stable tool name, available arguments/result, and `status`. Failed operations use `status="error"` and the normalized `error` argument. |
+| Error | An LLM/tool failure stays on its normalized call with `status="error"`. An exception escaping the run is also represented by the core lifecycle as `ERROR`; adapters MUST NOT invent a duplicate framework-specific error event. |
+| Guardrail | If adapter callbacks can trigger Maida guardrails, the adapter MUST preserve the core `LOOP_WARNING` or limit signal, stop subsequent framework operations, and let the run reach terminal `RUN_END` with `status="error"`. Use the abort pattern below when the framework swallows `Exception`. |
+| State or other metadata | When a framework exposes a genuine state transition, use `record_state`. Context that does not map to a normalized signal belongs under namespaced `meta`, not in a new event type. |
+
+Frameworks do not all expose every signal. "Where applicable" means the
+adapter MUST map a signal when the framework supplies a reliable callback,
+hook, or span for it. The adapter documentation MUST call out signals the
+framework cannot expose. It MUST NOT synthesize successful calls that were not
+observed.
+
+Some frameworks emit a start hook without a matching completion hook when the
+operation or run fails. An adapter that keeps pending operations MUST flush
+them before run teardown as an `LLM_CALL` or `TOOL_CALL` with
+`status="error"`. The trace must still contain exactly one terminal `RUN_END`.
+
+### Deterministic offline conformance tests
+
+Adapter tests MUST be deterministic and offline. Use fake framework modules,
+in-memory callbacks, fixed payloads, and stub tools. Tests MUST NOT make real
+provider calls, require API keys, or depend on network access, wall-clock
+timing, random IDs, or framework services.
+
+At minimum, the adapter test suite MUST prove:
+
+1. Importing the core `maida` package works without the optional framework,
+   while importing the adapter gives clear installation instructions when its
+   extra is missing.
+2. With an active run, the success path persists one `RUN_START`, the expected
+   `LLM_CALL` and `TOOL_CALL` signals the framework exposes, and one terminal
+   `RUN_END(status="ok")` in lifecycle order.
+3. Failed LLM/tool operations persist `status="error"` with normalized error
+   details, and an escaping run failure persists `ERROR` followed by one
+   terminal `RUN_END(status="error")`.
+4. Missing completion hooks are flushed as failed operations before
+   `RUN_END`, if the framework has split start/end hooks.
+5. Calls outside an active run follow the adapter's documented behavior and do
+   not contaminate another run.
+6. Guardrail propagation, aborting subsequent operations, and terminal error
+   state work when callbacks can invoke guardrails.
+7. Payload safety and metadata namespacing satisfy the two sections below.
+
+Assertions SHOULD inspect the persisted `meta.json` and `spans.jsonl` through
+Maida's storage/event projection APIs. Mock-call assertions are useful for
+mapping details, but are not sufficient evidence of conformance by themselves.
+
+### Redaction and truncation
+
+Every framework-derived prompt, response, tool argument/result, error detail,
+state value, and metadata value MUST flow through `record_llm_call`,
+`record_tool_call`, or `record_state`. Those APIs apply Maida's configured
+redaction and truncation before persistence. Adapters MUST NOT write raw
+framework payloads directly to spans or files, and MUST NOT retain an
+unredacted duplicate under `meta`.
+
+The conformance suite MUST persist a nested secret under a configured sensitive
+key and an oversized string in both a normalized payload and framework
+metadata. It must inspect the raw run artifacts to prove that the secret is
+absent, redacted values use `__REDACTED__`, and bounded values use
+`__TRUNCATED__`. This test must exercise the adapter path rather than only the
+redaction helper.
+
+### Framework-specific metadata
+
+Normalized signal data belongs in the existing arguments to Maida's public
+recorders. Framework-specific extras MUST be stored below
+`meta.<adapter_name>` using a stable, lowercase adapter name, for example:
+
+```python
+meta = {
+    "framework": "openai_agents",
+    "openai_agents": {
+        "span_type": "generation",
+        "trace_metadata": trace_metadata,
+    },
+}
+```
+
+An adapter MAY include the common `meta.framework` discriminator, but its
+framework-only fields still belong in the namespaced object. Adapters MUST NOT
+add framework-specific event types, top-level trace fields, or core schema
+fields. If a framework concept cannot be represented as an existing normalized
+signal plus namespaced metadata, document the gap and discuss a
+framework-agnostic core change separately; do not change the schema for one
+framework.
+
+---
+
 ## The core problem
 
 Every agent framework has its own error handling around callbacks/hooks/processors. When maida detects a loop or a guardrail violation, it raises an exception. The framework almost always catches it:

--- a/tests/test_docs.py
+++ b/tests/test_docs.py
@@ -86,3 +86,35 @@ def test_action_version_references_match_scaffold():
     assert MAIDA_ASSERT_ACTION_REF in workflow_text
     assert "actions/checkout@v4" not in workflow_text
     assert "maida-ai/maida-assert@v2" not in workflow_text
+
+
+def test_adapter_conformance_contract_covers_required_behavior():
+    text = " ".join(
+        (ROOT / "maida/integrations/CONTRIBUTING.md")
+        .read_text(encoding="utf-8")
+        .split()
+    )
+
+    required_snippets = [
+        "## Adapter conformance contract",
+        "### Required normalized signals",
+        "`RUN_START`",
+        "`RUN_END`",
+        "`LLM_CALL`",
+        "`TOOL_CALL`",
+        "`ERROR`",
+        "`LOOP_WARNING`",
+        "terminal `RUN_END`",
+        "### Deterministic offline conformance tests",
+        "real provider calls",
+        "### Redaction and truncation",
+        "`__REDACTED__`",
+        "`__TRUNCATED__`",
+        "### Framework-specific metadata",
+        "`meta.<adapter_name>`",
+        "MUST NOT add framework-specific event types",
+    ]
+
+    missing = [snippet for snippet in required_snippets if snippet not in text]
+
+    assert missing == []


### PR DESCRIPTION
Defined a normative conformance contract for every Maida framework adapter. The contract covers lifecycle ownership and terminal state, normalized LLM/tool/error signals, guardrail behavior where applicable, deterministic offline testing, redaction and truncation proofs at the persistence boundary, and strict namespacing of framework-specific metadata without framework-specific schema changes.

- Added the normative adapter contract to `maida/integrations/CONTRIBUTING.md`, including the required signal mapping and minimum conformance suite.
- Required adapter-path tests to inspect persisted artifacts for redaction and truncation, including nested secrets and oversized normalized and metadata values.
- Required framework-only data to remain under `meta.<adapter_name>` and explicitly prohibited framework-specific event types and core schema fields.
- Linked the contract from the repository contribution guide and public integrations documentation.
- Added a documentation regression test that guards all issue acceptance criteria.

Fixes #76