### PR TITLE
Complete OpenAI Agents adapter conformance

### DIFF
--- a/docs/integrations.md
+++ b/docs/integrations.md
@@ -82,10 +82,10 @@ All guardrails work with the callback handler. When a guardrail fires, the handl
 
 **Status: available.** An optional adapter lives at `maida.integrations.openai_agents`. Importing it registers an OpenAI Agents tracing processor that forwards SDK generation, function, and handoff spans into the active Maida run.
 
-**Requirements:** `openai-agents` must be installed. Install the optional OpenAI dependency group (the `openai` group contains `openai-agents`):
+**Requirements:** `openai-agents` must be installed. Install Maida with the optional OpenAI dependency group:
 
 ```bash
-pip install -e ".[openai]"
+pip install "maida-ai[openai]"
 ```
 
 If `openai-agents` is not installed, importing the integration raises a clear `ImportError` with install instructions. The integration is optional; the core package does not depend on it.
@@ -109,12 +109,26 @@ The adapter captures:
 - **Tool calls** (`FunctionSpanData`): records tool name, args, result, and error status via `record_tool_call`.
 - **Handoffs** (`HandoffSpanData`): records a `TOOL_CALL` named `handoff`, with framework-specific details stored in `meta`.
 
-See `examples/openai_agents/minimal.py` for a runnable fake-data example:
+The runnable [`examples/openai_agents/minimal.py`](../examples/openai_agents/minimal.py) example uses only local SDK tracing spans with fixed payloads. It requires no API key, provider call, or network access:
 
 ```bash
 uv run --extra openai python examples/openai_agents/minimal.py
-maida view
+maida baseline --out openai-agents-baseline.json
+maida assert --baseline openai-agents-baseline.json
 ```
+
+The known-good structural signature is `RUN_START -> LLM_CALL -> TOOL_CALL(lookup_docs) -> TOOL_CALL(handoff) -> RUN_END`, with one `gpt-4o-mini` call, the tool sequence `lookup_docs -> handoff`, 22 total tokens, and terminal status `ok`.
+
+Run the same offline example in regression mode to repeat the documentation lookup:
+
+```bash
+uv run --extra openai python examples/openai_agents/minimal.py --regression
+maida assert --baseline openai-agents-baseline.json
+```
+
+The regression records three consecutive `lookup_docs` calls. Its structural signature is `RUN_START -> LLM_CALL -> TOOL_CALL(lookup_docs) -> TOOL_CALL(lookup_docs) -> TOOL_CALL(lookup_docs) -> LOOP_WARNING -> TOOL_CALL(handoff) -> RUN_END`. The run itself still ends with status `ok`, but the final gate reports the increased step and tool-call counts and exits with code `1`.
+
+Maida's surrounding `@trace` boundary owns `RUN_START` and `RUN_END`. The adapter maps completed generation, function, and handoff spans exposed by the SDK; it does not synthesize successful calls or framework-specific event types for SDK signals it cannot observe.
 
 **Guardrails with OpenAI Agents SDK:**
 All guardrails work with the tracing processor. When a guardrail fires, the processor raises `_MaidaAbortSignal` (a `BaseException`) which bypasses the SDK's `except Exception` error handling — stopping the run immediately:

--- a/examples/openai_agents/minimal.py
+++ b/examples/openai_agents/minimal.py
@@ -4,9 +4,14 @@ Minimal OpenAI Agents tracing example with fake spans only using Maida.
 Run from the repo root:
   uv run --extra openai python examples/openai_agents/minimal.py
 
+To record a deterministic behavioral regression:
+  uv run --extra openai python examples/openai_agents/minimal.py --regression
+
 Then:
   maida view
 """
+
+import argparse
 
 from maida import trace
 from maida.integrations import openai_agents
@@ -20,7 +25,7 @@ from agents.tracing import (
 
 
 @trace(name="OpenAI Agents minimal example")
-def run_agent():
+def run_agent(*, regression: bool = False):
     """Emit deterministic SDK spans without making any model or network calls."""
     # Keep the SDK tracing local-only for this example: no backend exporter, no API key.
     set_trace_processors([openai_agents.PROCESSOR])
@@ -40,17 +45,31 @@ def run_agent():
         ):
             pass
 
-        with function_span(
-            name="lookup_docs",
-            input={"query": "Maida integrations"},
-            output={"hits": 2},
-        ):
-            pass
+        lookup_count = 3 if regression else 1
+        for _ in range(lookup_count):
+            with function_span(
+                name="lookup_docs",
+                input={"query": "Maida integrations"},
+                output={"hits": 2},
+            ):
+                pass
 
         with handoff_span(from_agent="router_agent", to_agent="docs_agent"):
             pass
 
 
-if __name__ == "__main__":
-    run_agent()
+def main() -> None:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--regression",
+        action="store_true",
+        help="repeat lookup_docs enough to trigger a deterministic regression",
+    )
+    args = parser.parse_args()
+
+    run_agent(regression=args.regression)
     print("Run complete. View with: maida view")
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/integrations/test_openai_integration.py
+++ b/tests/integrations/test_openai_integration.py
@@ -13,7 +13,13 @@ from unittest.mock import MagicMock, patch
 
 import pytest
 
+from maida import trace
+from maida.baseline import extract_run_metrics
+from maida.config import load_config
+from maida.events import EventType
 from maida.integrations._error import MissingOptionalDependencyError
+from maida.storage import list_runs, load_run_for_analysis
+from tests.conftest import get_latest_run_id
 
 
 def _drop_openai_agents_integration_modules() -> None:
@@ -234,6 +240,94 @@ def test_generation_span_records_llm_call_event(openai_agents_module):
     assert meta["openai_agents"]["model_config"] == {"temperature": 0.2}
 
 
+def test_openai_agents_success_path_persists_structural_signature(
+    openai_agents_module, temp_data_dir
+):
+    """The offline success path persists the exact normalized signature."""
+    _, tracing_module, span_data = openai_agents_module
+
+    @trace(name="openai-agents-conformance-success")
+    def run_success_path():
+        tracing_module.emit_span(
+            _fake_span(
+                span_data.GenerationSpanData(
+                    input=[{"role": "user", "content": "Summarize this"}],
+                    output=[{"role": "assistant", "content": "Summary"}],
+                    model="gpt-4o-mini",
+                    model_config={"temperature": 0.0},
+                    usage={
+                        "prompt_tokens": 11,
+                        "completion_tokens": 7,
+                        "total_tokens": 18,
+                    },
+                )
+            )
+        )
+        tracing_module.emit_span(
+            _fake_span(
+                span_data.FunctionSpanData(
+                    name="search_docs",
+                    input={"query": "maida"},
+                    output={"hits": 2},
+                )
+            )
+        )
+        tracing_module.emit_span(
+            _fake_span(
+                span_data.HandoffSpanData(
+                    from_agent="router_agent", to_agent="search_agent"
+                )
+            )
+        )
+
+    run_success_path()
+
+    config = load_config()
+    run_id = get_latest_run_id(config)
+    resolved_id, meta, events = load_run_for_analysis(run_id, config)
+    metrics = extract_run_metrics(meta, events)
+
+    assert resolved_id == run_id
+    assert [event["event_type"] for event in events] == [
+        EventType.RUN_START.value,
+        EventType.LLM_CALL.value,
+        EventType.TOOL_CALL.value,
+        EventType.TOOL_CALL.value,
+        EventType.RUN_END.value,
+    ]
+    duration_ms = metrics["summary"]["duration_ms"]
+    assert isinstance(duration_ms, int)
+    assert duration_ms >= 0
+    assert {**metrics["summary"], "duration_ms": 0} == {
+        "status": "ok",
+        "total_events": 3,
+        "llm_calls": 1,
+        "tool_calls": 2,
+        "errors": 0,
+        "loop_warnings": 0,
+        "duration_ms": 0,
+        "total_tokens": 18,
+    }
+    assert metrics["tool_path"] == ["handoff", "search_docs"]
+    assert metrics["tool_call_sequence"] == ["search_docs", "handoff"]
+    assert metrics["tool_call_counts"] == {"search_docs": 1, "handoff": 1}
+    assert metrics["llm_models_used"] == ["gpt-4o-mini"]
+    assert metrics["event_type_sequence"] == [
+        EventType.RUN_START.value,
+        EventType.LLM_CALL.value,
+        EventType.TOOL_CALL.value,
+        EventType.TOOL_CALL.value,
+        EventType.RUN_END.value,
+    ]
+    assert metrics["final_status"] == "ok"
+    assert events[1]["payload"]["status"] == "ok"
+    assert events[2]["payload"]["tool_name"] == "search_docs"
+    assert events[2]["payload"]["status"] == "ok"
+    assert events[3]["payload"]["tool_name"] == "handoff"
+    assert events[3]["payload"]["status"] == "ok"
+    assert events[-1]["payload"] == {"status": "ok"}
+
+
 def test_function_and_handoff_spans_record_tool_call_events(openai_agents_module):
     openai_agents, tracing_module, span_data = openai_agents_module
 
@@ -308,24 +402,117 @@ def test_generation_error_records_error_status(openai_agents_module):
     assert kw["error"]["details"] == {"code": "boom"}
 
 
-def test_no_run_created_when_only_sdk_span_is_emitted(openai_agents_module):
-    openai_agents, tracing_module, span_data = openai_agents_module
-
-    function_span = _fake_span(
-        span_data.FunctionSpanData(
+@pytest.mark.parametrize(
+    ("span_kind", "event_type", "message"),
+    [
+        ("generation", EventType.LLM_CALL.value, "model failed"),
+        ("function", EventType.TOOL_CALL.value, "tool failed"),
+    ],
+)
+def test_openai_agents_errors_persist_on_normalized_calls(
+    openai_agents_module,
+    temp_data_dir,
+    span_kind,
+    event_type,
+    message,
+):
+    """Contained SDK failures stay on normalized calls without duplicate ERROR."""
+    _, tracing_module, span_data = openai_agents_module
+    if span_kind == "generation":
+        data = span_data.GenerationSpanData(
+            input=[{"role": "user", "content": "fail"}],
+            output=None,
+            model="gpt-4o-mini",
+        )
+    else:
+        data = span_data.FunctionSpanData(
             name="search_docs",
+            input={"query": "maida"},
+            output=None,
+        )
+    span = _fake_span(
+        data,
+        error={
+            "error_type": "OpenAIAgentsSpanError",
+            "message": message,
+            "data": {"code": "boom"},
+        },
+    )
+
+    @trace(name=f"openai-agents-{span_kind}-error")
+    def run_failed_call():
+        tracing_module.emit_span(span)
+
+    run_failed_call()
+
+    config = load_config()
+    run_id = get_latest_run_id(config)
+    _, meta, events = load_run_for_analysis(run_id, config)
+
+    assert [event["event_type"] for event in events] == [
+        EventType.RUN_START.value,
+        event_type,
+        EventType.RUN_END.value,
+    ]
+    payload = events[1]["payload"]
+    assert payload["status"] == "error"
+    assert payload["error"] == {
+        "error_type": "OpenAIAgentsSpanError",
+        "message": message,
+        "stack": None,
+    }
+    assert meta["status"] == "ok"
+    assert meta["counts"]["errors"] == 0
+    assert events[-1]["payload"] == {"status": "ok"}
+
+
+def test_calls_outside_run_do_not_create_or_contaminate_run(
+    openai_agents_module, temp_data_dir, monkeypatch
+):
+    _, tracing_module, span_data = openai_agents_module
+    monkeypatch.delenv("MAIDA_IMPLICIT_RUN", raising=False)
+
+    outside_span = _fake_span(
+        span_data.FunctionSpanData(
+            name="outside_tool",
             input={"query": "maida"},
             output={"hits": 2},
         )
     )
+    tracing_module.emit_span(outside_span)
 
-    with patch.object(openai_agents, "has_active_run", return_value=False):
-        with patch.object(
-            openai_agents, "record_tool_call", MagicMock()
-        ) as record_tool:
-            tracing_module.emit_span(function_span)
+    config = load_config()
+    assert list_runs(limit=10, config=config) == []
 
-    record_tool.assert_not_called()
+    @trace(name="openai-agents-inside-run")
+    def run_inside_call():
+        tracing_module.emit_span(
+            _fake_span(
+                span_data.FunctionSpanData(
+                    name="inside_tool",
+                    input={"query": "maida"},
+                    output={"hits": 1},
+                )
+            )
+        )
+
+    run_inside_call()
+
+    runs = list_runs(limit=10, config=config)
+    assert len(runs) == 1
+    _, meta, events = load_run_for_analysis(runs[0]["trace_id"], config)
+    assert [event["event_type"] for event in events] == [
+        EventType.RUN_START.value,
+        EventType.TOOL_CALL.value,
+        EventType.RUN_END.value,
+    ]
+    assert events[1]["payload"]["tool_name"] == "inside_tool"
+    assert meta["counts"] == {
+        "llm_calls": 0,
+        "tool_calls": 1,
+        "errors": 0,
+        "loop_warnings": 0,
+    }
 
 
 def test_guardrail_exception_captured_on_abort_exception(openai_agents_module):
@@ -384,13 +571,7 @@ def test_loop_warning_dedup_with_openai_agents_adapter(
     and propagates to _run_context, which records ERROR + RUN_END and
     re-raises LoopAbort.  The loop stops immediately."""
     openai_agents, tracing_module, span_data = openai_agents_module
-    from maida import trace
-    from maida.config import load_config
-    from maida.events import EventType
     from maida.exceptions import LoopAbort
-    from maida.storage import load_spans, load_run_meta
-    from maida.events import spans_to_events
-    from tests.conftest import get_latest_run_id
 
     processor = openai_agents.PROCESSOR
 
@@ -440,9 +621,7 @@ def test_loop_warning_dedup_with_openai_agents_adapter(
 
     config = load_config()
     run_id = get_latest_run_id(config)
-    spans = load_spans(run_id, config)
-    events = spans_to_events(spans)
-    run_meta = load_run_meta(run_id, config)
+    _, run_meta, events = load_run_for_analysis(run_id, config)
 
     loop_warnings = [
         e for e in events if e.get("event_type") == EventType.LOOP_WARNING.value
@@ -458,3 +637,10 @@ def test_loop_warning_dedup_with_openai_agents_adapter(
     errors = [e for e in events if e.get("event_type") == EventType.ERROR.value]
     assert len(errors) == 1
     assert errors[0]["payload"]["error_type"] == "LoopAbort"
+    assert [event["event_type"] for event in events[-3:]] == [
+        EventType.LOOP_WARNING.value,
+        EventType.ERROR.value,
+        EventType.RUN_END.value,
+    ]
+    assert run_meta["status"] == "error"
+    assert events[-1]["payload"] == {"status": "error"}

--- a/tests/test_docs.py
+++ b/tests/test_docs.py
@@ -118,3 +118,22 @@ def test_adapter_conformance_contract_covers_required_behavior():
     missing = [snippet for snippet in required_snippets if snippet not in text]
 
     assert missing == []
+
+
+def test_openai_agents_docs_include_offline_success_and_regression_workflow():
+    docs = (ROOT / "docs/integrations.md").read_text(encoding="utf-8")
+    example = (ROOT / "examples/openai_agents/minimal.py").read_text(encoding="utf-8")
+
+    required_docs = [
+        'pip install "maida-ai[openai]"',
+        "openai-agents-baseline.json",
+        "examples/openai_agents/minimal.py --regression",
+        "RUN_START -> LLM_CALL -> TOOL_CALL(lookup_docs) -> TOOL_CALL(handoff) -> RUN_END",
+        "LOOP_WARNING",
+        "exits with code `1`",
+    ]
+    missing_docs = [snippet for snippet in required_docs if snippet not in docs]
+
+    assert missing_docs == []
+    assert '"--regression"' in example
+    assert "regression=args.regression" in example


### PR DESCRIPTION
Pin persisted success, failure, isolation, and guardrail behavior for the OpenAI Agents adapter. Add a deterministic offline regression mode and document the baseline-to-failing-gate workflow.

Completed the OpenAI Agents SDK adapter conformance work after the two cross-repository child issues were committed and reported. The existing adapter implementation already mapped SDK spans correctly, so the core change focuses on persisted-trace proof, a deterministic offline regression mode, and documentation that takes a developer from a known-good baseline to a failing behavioral gate without an API key or network call. Raw adapter-path redaction and truncation coverage remains intentionally scoped to downstream issue #80.

- Added a persisted success-path conformance test that pins the exact lifecycle, one LLM call, two tool calls, model, token total, tool sequence and counts, and terminal `ok` status.
- Added persisted generation- and function-failure coverage proving SDK failures remain normalized on `LLM_CALL(status="error")` or `TOOL_CALL(status="error")` without a duplicate top-level `ERROR` event.
- Added `--regression` to the offline OpenAI Agents example. Regression mode emits three identical `lookup_docs` spans, producing a deterministic loop warning and increased step/tool counts while the agent run itself remains terminal `ok`.
- Corrected public install guidance to `pip install "maida-ai[openai]"` and documented the exact success and regression signatures, baseline workflow, failing gate, lifecycle ownership, and unsupported-signal behavior.
- Left `maida/integrations/openai_agents.py`, `pyproject.toml`, and `uv.lock` unchanged.


Fixes #78