### PR TITLE
Complete CrewAI adapter conformance

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,7 +31,6 @@
 
 ### Known issues
 
-- **No CrewAI example or tutorial** - `examples/crewai/` has no runnable `.py` script and there is no CrewAI tutorial notebook. The integration itself works and is tested, but end-user reference material is missing.
 - **Thread-pool context propagation** - `contextvars` are not copied into worker threads. If tools execute concurrently via a thread pool, events may be lost or mis-ordered. Single-threaded agent loops are unaffected. Fix planned for v0.3.
 - **`cwd()` project-root heuristic** - when the CLI is invoked from outside the project directory, the project-level config file may not be found. Workaround: run `agentdbg` from the project root or set config via env vars.
 

--- a/README.md
+++ b/README.md
@@ -412,12 +412,17 @@ def run_crew():
     ...
 ```
 
+See `examples/crewai/minimal.py` for a deterministic fake-hook example that
+uses no API key or network calls. Its `--regression` mode repeats the same
+`search_docs` call three times so a strict baseline assertion catches the
+structural change.
+
 More framework adapters coming soon (Agno, and others).
 
 
 ## Tutorials
 
-Step-by-step Jupyter notebooks live in a separate repository: [maida-ai/maida-tutorials](https://github.com/maida-ai/maida-tutorials). Covers LangChain, OpenAI Agents SDK, and guardrails - all runnable without API keys.
+Step-by-step Jupyter notebooks live in a separate repository: [maida-ai/maida-tutorials](https://github.com/maida-ai/maida-tutorials). Covers LangChain, OpenAI Agents SDK, CrewAI, and guardrails - all runnable without API keys.
 
 
 ## Development

--- a/docs/integrations.md
+++ b/docs/integrations.md
@@ -159,7 +159,7 @@ As a defensive fallback, the exception is also stored on `PROCESSOR.abort_except
 **Requirements:** `crewai[tools]` must be installed. Install the optional dependency group:
 
 ```bash
-pip install -e ".[crewai]"
+pip install "maida-ai[crewai]"
 ```
 
 If `crewai` is not installed, importing the integration raises a clear `ImportError` with install instructions.
@@ -183,11 +183,44 @@ The adapter captures:
 
 Framework-specific context (agent role, task description, executor ID) is stored in `meta.crewai.*`.
 
+The [offline CrewAI example](../examples/crewai/minimal.py) sends deterministic
+fake data through CrewAI's public hook contexts. It starts no crew or LLM, uses
+no API key, and makes no network calls:
+
+```bash
+CREWAI_DISABLE_TELEMETRY=true python examples/crewai/minimal.py
+maida baseline --out crewai-baseline.json
+maida assert --baseline crewai-baseline.json --tool-call-tolerance 0
+```
+
+The normal signature is
+`RUN_START -> LLM_CALL -> TOOL_CALL(search_docs) -> RUN_END`, with one LLM
+call, one `search_docs` call, and terminal status `ok`.
+
+Run the deterministic regression and apply the same strict assertion:
+
+```bash
+CREWAI_DISABLE_TELEMETRY=true python examples/crewai/minimal.py --regression
+maida assert --baseline crewai-baseline.json --tool-call-tolerance 0
+```
+
+Regression mode records three consecutive `search_docs` calls, producing
+`RUN_START -> LLM_CALL -> TOOL_CALL -> TOOL_CALL -> TOOL_CALL -> LOOP_WARNING -> RUN_END`.
+The run itself remains `ok`, but the assertion reports the tool-call increase
+and exits with code `1`.
+
+When a guardrail fires in a hook, the adapter stores the public
+`GuardrailExceeded`, raises an internal `BaseException` signal past CrewAI's
+`except Exception` handling, and lets the Maida boundary record `ERROR` plus
+`RUN_END(status="error")`. As a defensive fallback inside an active run, call
+`maida_crewai.raise_if_aborted()` after framework execution.
+
 **Notes:**
 
 - The adapter requires an active Maida run — wrap your entrypoint with `@trace` or `traced_run(...)`.
 - Hook ordering caveat: if another before-hook returns `False` and blocks execution, that specific call may not be captured.
-- No runnable example script yet — see the [Known issues in CHANGELOG](../CHANGELOG.md) for status.
+- The example unregisters CrewAI's event-bus shutdown callback after its fake-hook-only run to avoid waiting on an idle daemon during interpreter shutdown.
+- For a fuller success, incomplete-call, and guardrail walkthrough, see the [CrewAI tutorial](https://github.com/maida-ai/maida-tutorials/blob/main/CrewAI/Mock%20CrewAI%20Agent.ipynb).
 
 ---
 

--- a/examples/crewai/minimal.py
+++ b/examples/crewai/minimal.py
@@ -1,0 +1,89 @@
+"""Deterministic CrewAI adapter example using public fake hook contexts.
+
+Run from the repo root:
+  CREWAI_DISABLE_TELEMETRY=true uv run --extra crewai python examples/crewai/minimal.py
+  CREWAI_DISABLE_TELEMETRY=true uv run --extra crewai python examples/crewai/minimal.py --regression
+"""
+
+import argparse
+import atexit
+from types import SimpleNamespace
+
+from crewai.events.event_bus import crewai_event_bus
+from crewai.hooks import (
+    LLMCallHookContext,
+    ToolCallHookContext,
+    get_after_llm_call_hooks,
+    get_after_tool_call_hooks,
+    get_before_llm_call_hooks,
+    get_before_tool_call_hooks,
+)
+
+from maida import traced_run
+from maida.integrations import crewai as maida_crewai
+
+
+executor = SimpleNamespace(
+    messages=[{"role": "user", "content": "Summarize Maida."}],
+    agent=SimpleNamespace(role="Release reviewer"),
+    task=SimpleNamespace(description="Explain the release gate."),
+    crew=SimpleNamespace(),
+    llm=SimpleNamespace(model="offline"),
+    iterations=0,
+)
+
+
+def emit_fake_tool_call() -> None:
+    """Send one deterministic lookup through CrewAI's public tool hooks."""
+    context = ToolCallHookContext(
+        tool_name="search_docs",
+        tool_input={"query": "Maida integrations"},
+        tool=SimpleNamespace(),
+        agent=executor.agent,
+        task=executor.task,
+        crew=executor.crew,
+        tool_result={"hits": 2},
+    )
+    for hook in get_before_tool_call_hooks():
+        hook(context)
+    for hook in get_after_tool_call_hooks():
+        hook(context)
+    maida_crewai.raise_if_aborted()
+
+
+def emit_fake_crewai_calls(*, regression: bool = False) -> None:
+    """Exercise CrewAI's public hook surface without starting an LLM."""
+    with traced_run(name="CrewAI minimal example"):
+        llm_context = LLMCallHookContext(executor)
+        for hook in get_before_llm_call_hooks():
+            hook(llm_context)
+        llm_context.response = "Maida blocks behavioral regressions before merge."
+        for hook in get_after_llm_call_hooks():
+            hook(llm_context)
+        maida_crewai.raise_if_aborted()
+
+        tool_calls = 3 if regression else 1
+        for _ in range(tool_calls):
+            emit_fake_tool_call()
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--regression",
+        action="store_true",
+        help="emit three repeated search_docs calls instead of one",
+    )
+    args = parser.parse_args()
+
+    emit_fake_crewai_calls(regression=args.regression)
+    print("Run complete. View with: maida view")
+
+
+if __name__ == "__main__":
+    main()
+
+    # Current CrewAI releases can wait indefinitely in their event-bus atexit
+    # callback after a fake-hook-only run. This one-shot script has no queued
+    # events, so leave its daemon loop to interpreter shutdown instead.
+    atexit.unregister(crewai_event_bus.shutdown)

--- a/maida/exceptions.py
+++ b/maida/exceptions.py
@@ -19,7 +19,7 @@ class MaidaException(Exception):
     pass
 
 
-class _MaidaAbortSignal(MaidaException):
+class _MaidaAbortSignal(BaseException):
     """Internal BaseException used by integration handlers to bypass framework
     error handling (e.g. LangGraph's ``except Exception``).
 

--- a/maida/integrations/crewai.py
+++ b/maida/integrations/crewai.py
@@ -15,6 +15,7 @@ from typing import Any
 
 from maida._integration_utils import register_run_enter, register_run_exit
 from maida._tracing._context import _ensure_run
+from maida.exceptions import GuardrailExceeded, _MaidaAbortSignal
 from maida.integrations._error import MissingOptionalDependencyError
 from maida.tracing import record_llm_call, record_tool_call
 
@@ -52,6 +53,10 @@ _pending_tool: dict[
 _tool_next_seq: dict[
     tuple[str, str], int
 ] = {}  # (run_id, tool_name) -> next sequence number
+
+# Per-run guardrail state. CrewAI catches Exception around hook execution, so
+# adapter callbacks escalate GuardrailExceeded to a private BaseException signal.
+_abort_exceptions: dict[str, GuardrailExceeded] = {}
 
 
 def _snapshot_messages(messages: Any) -> Any:
@@ -110,13 +115,13 @@ def _crewai_meta_llm(context: Any) -> dict[str, Any]:
             and context.agent is not None
             and getattr(context.agent, "role", None)
         ):
-            meta["agent_role"] = context.agent.role
+            meta.setdefault("crewai", {})["agent_role"] = context.agent.role
         if (
             hasattr(context, "task")
             and context.task is not None
             and getattr(context.task, "description", None)
         ):
-            meta["task_desc"] = context.task.description
+            meta.setdefault("crewai", {})["task_desc"] = context.task.description
         if hasattr(context, "crew") and context.crew is not None:
             meta.setdefault("crewai", {})["crew_id"] = id(context.crew)
     except Exception:
@@ -133,13 +138,13 @@ def _crewai_meta_tool(context: Any) -> dict[str, Any]:
             and context.agent is not None
             and getattr(context.agent, "role", None)
         ):
-            meta["agent_role"] = context.agent.role
+            meta.setdefault("crewai", {})["agent_role"] = context.agent.role
         if (
             hasattr(context, "task")
             and context.task is not None
             and getattr(context.task, "description", None)
         ):
-            meta["task_desc"] = context.task.description
+            meta.setdefault("crewai", {})["task_desc"] = context.task.description
     except Exception:
         pass
     return meta
@@ -163,12 +168,30 @@ def _get_active_run_id() -> str | None:
     return ctx[0] if ctx else None
 
 
+def _check_aborted(run_id: str) -> None:
+    """Stop CrewAI from starting or completing hooks after a guardrail abort."""
+    cause = _abort_exceptions.get(run_id)
+    if cause is not None:
+        raise _MaidaAbortSignal(cause)
+
+
+def raise_if_aborted() -> None:
+    """Re-raise a guardrail captured for the active run, if any."""
+    run_id = _get_active_run_id()
+    if run_id is None:
+        return
+    cause = _abort_exceptions.get(run_id)
+    if cause is not None:
+        raise cause
+
+
 def _before_llm_call(context: Any) -> bool | None:
-    """CrewAI before_llm_call hook. Never raises; no-op if no active run."""
+    """Capture an LLM start, or propagate a prior guardrail abort."""
     try:
         run_id = _get_active_run_id()
         if run_id is None:
             return None
+        _check_aborted(run_id)
         executor_id = (
             id(context.executor)
             if getattr(context, "executor", None) is not None
@@ -192,11 +215,12 @@ def _before_llm_call(context: Any) -> bool | None:
 
 
 def _after_llm_call(context: Any) -> str | None:
-    """CrewAI after_llm_call hook. Never raises; no-op if no active run."""
+    """Record an LLM completion, escalating guardrails past CrewAI."""
     try:
         run_id = _get_active_run_id()
         if run_id is None:
             return None
+        _check_aborted(run_id)
         executor_id = (
             id(context.executor)
             if getattr(context, "executor", None) is not None
@@ -229,16 +253,20 @@ def _after_llm_call(context: Any) -> str | None:
             status="ok",
         )
         return None
+    except GuardrailExceeded as e:
+        _abort_exceptions[run_id] = e
+        raise _MaidaAbortSignal(e) from e
     except Exception:
         return None
 
 
 def _before_tool_call(context: Any) -> bool | None:
-    """CrewAI before_tool_call hook. Never raises; no-op if no active run."""
+    """Capture a tool start, or propagate a prior guardrail abort."""
     try:
         run_id = _get_active_run_id()
         if run_id is None:
             return None
+        _check_aborted(run_id)
         tool_name = getattr(context, "tool_name", "unknown") or "unknown"
         key_base = (run_id, tool_name)
         seq = _tool_next_seq.get(key_base, 0)
@@ -255,11 +283,12 @@ def _before_tool_call(context: Any) -> bool | None:
 
 
 def _after_tool_call(context: Any) -> str | None:
-    """CrewAI after_tool_call hook. Never raises; no-op if no active run."""
+    """Record a tool completion, escalating guardrails past CrewAI."""
     try:
         run_id = _get_active_run_id()
         if run_id is None:
             return None
+        _check_aborted(run_id)
         tool_name = getattr(context, "tool_name", "unknown") or "unknown"
         by_run = _pending_tool.get(run_id, {})
         # Match FIFO: same tool_name, smallest seq (first before_hook for this tool).
@@ -284,6 +313,9 @@ def _after_tool_call(context: Any) -> str | None:
             status="ok",
         )
         return None
+    except GuardrailExceeded as e:
+        _abort_exceptions[run_id] = e
+        raise _MaidaAbortSignal(e) from e
     except Exception:
         return None
 
@@ -346,6 +378,9 @@ def _flush_pending_for_run(
                 error=incomplete_error,
             )
 
+    except Exception:
+        pass
+    finally:
         _pending_llm.pop(run_id, None)
         _pending_tool.pop(run_id, None)
         for k in list(_llm_stack.keys()):
@@ -357,8 +392,6 @@ def _flush_pending_for_run(
         for k in list(_tool_next_seq.keys()):
             if k[0] == run_id:
                 del _tool_next_seq[k]
-    except Exception:
-        pass
 
 
 def _on_run_enter() -> None:
@@ -378,8 +411,8 @@ def _on_run_exit(
     """Lifecycle: on run exit, flush pending calls for this run and clean up."""
     try:
         _flush_pending_for_run(run_id, exc_type, exc_value, tb)
-    except Exception:
-        pass
+    finally:
+        _abort_exceptions.pop(run_id, None)
 
 
 # Activate on import: register with core lifecycle (register-on-import, Option C).

--- a/tests/integrations/test_crewai_integration.py
+++ b/tests/integrations/test_crewai_integration.py
@@ -140,6 +140,7 @@ def _reset_crewai_module_state(crewai_mod) -> None:
     crewai_mod._llm_stack.clear()
     crewai_mod._llm_next_seq.clear()
     crewai_mod._tool_next_seq.clear()
+    crewai_mod._abort_exceptions.clear()
 
 
 @pytest.fixture
@@ -360,3 +361,203 @@ def test_flush_pending_with_exception_attaches_error_payload(
         call_kw["error"].get("stack") is not None
         and "ValueError" in call_kw["error"]["stack"]
     )
+
+
+def _load_latest_events():
+    from maida.config import load_config
+    from maida.storage import list_runs, load_run_for_analysis
+
+    config = load_config()
+    run = list_runs(limit=1, config=config)[0]
+    run_id = run.get("trace_id") or run["run_id"]
+    return load_run_for_analysis(run_id, config)
+
+
+def test_crewai_success_persists_exact_signature_and_namespaced_metadata(
+    crewai_module_with_mocked_hooks, temp_data_dir
+):
+    from maida import trace
+
+    crewai = crewai_module_with_mocked_hooks
+    llm_ctx = make_fake_llm_context(
+        messages=[{"role": "user", "content": "Find the docs"}],
+        response="Use search_docs",
+    )
+    tool_ctx = make_fake_tool_context(
+        tool_name="search_docs",
+        tool_input={"query": "CrewAI"},
+        tool_result={"hits": 1},
+    )
+
+    @trace(name="CrewAI conformance success")
+    def run():
+        crewai._before_llm_call(llm_ctx)
+        crewai._after_llm_call(llm_ctx)
+        crewai._before_tool_call(tool_ctx)
+        crewai._after_tool_call(tool_ctx)
+
+    run()
+
+    _, meta, events = _load_latest_events()
+    assert [event["event_type"] for event in events] == [
+        "RUN_START",
+        "LLM_CALL",
+        "TOOL_CALL",
+        "RUN_END",
+    ]
+    assert meta["counts"] == {
+        "llm_calls": 1,
+        "tool_calls": 1,
+        "errors": 0,
+        "loop_warnings": 0,
+    }
+    for event in events[1:3]:
+        assert event["payload"]["status"] == "ok"
+        assert event["meta"]["framework"] == "crewai"
+        assert event["meta"]["crewai"]["agent_role"] == "Researcher"
+        assert event["meta"]["crewai"]["task_desc"] == "Do research"
+        assert "agent_role" not in event["meta"]
+        assert "task_desc" not in event["meta"]
+    assert events[-1]["payload"] == {"status": "ok"}
+
+
+def test_crewai_missing_completion_hooks_persist_failed_calls_before_run_end(
+    crewai_module_with_mocked_hooks, temp_data_dir
+):
+    from maida import trace
+
+    crewai = crewai_module_with_mocked_hooks
+
+    @trace(name="CrewAI incomplete calls")
+    def run():
+        crewai._before_llm_call(
+            make_fake_llm_context(messages=[{"role": "user", "content": "fail"}])
+        )
+        crewai._before_tool_call(
+            make_fake_tool_context(
+                tool_name="search_docs", tool_input={"query": "fail"}
+            )
+        )
+        raise RuntimeError("simulated CrewAI failure")
+
+    with pytest.raises(RuntimeError, match="simulated CrewAI failure"):
+        run()
+
+    _, meta, events = _load_latest_events()
+    assert [event["event_type"] for event in events] == [
+        "RUN_START",
+        "ERROR",
+        "LLM_CALL",
+        "TOOL_CALL",
+        "RUN_END",
+    ]
+    for event in events[2:4]:
+        assert event["payload"]["status"] == "error"
+        assert event["payload"]["error"]["error_type"] == "RuntimeError"
+        assert event["meta"]["crewai"]["completion"] == "missing_after_hook"
+    assert meta["status"] == "error"
+    assert events[-1]["payload"] == {"status": "error"}
+
+
+def test_crewai_hooks_outside_a_run_do_not_contaminate_a_later_run(
+    crewai_module_with_mocked_hooks, temp_data_dir, monkeypatch
+):
+    from maida import trace
+    from maida.config import load_config
+    from maida.storage import list_runs
+
+    monkeypatch.delenv("MAIDA_IMPLICIT_RUN", raising=False)
+    crewai = crewai_module_with_mocked_hooks
+    outside = make_fake_tool_context(tool_name="outside_tool", tool_result="ignored")
+    crewai._before_tool_call(outside)
+    crewai._after_tool_call(outside)
+    assert list_runs(limit=10, config=load_config()) == []
+
+    inside = make_fake_tool_context(tool_name="inside_tool", tool_result="ok")
+
+    @trace(name="CrewAI isolated run")
+    def run():
+        crewai._before_tool_call(inside)
+        crewai._after_tool_call(inside)
+
+    run()
+
+    _, meta, events = _load_latest_events()
+    assert [event["event_type"] for event in events] == [
+        "RUN_START",
+        "TOOL_CALL",
+        "RUN_END",
+    ]
+    assert events[1]["payload"]["tool_name"] == "inside_tool"
+    assert meta["counts"]["tool_calls"] == 1
+
+
+def test_crewai_abort_signal_bypasses_exception_handlers_and_blocks_later_hooks(
+    crewai_module_with_mocked_hooks, temp_data_dir
+):
+    from maida import trace
+    from maida.exceptions import LoopAbort, _MaidaAbortSignal
+
+    crewai = crewai_module_with_mocked_hooks
+    completed = 0
+
+    def framework_dispatch(hook, context):
+        try:
+            return hook(context)
+        except Exception:
+            return None
+
+    @trace(
+        name="CrewAI guarded loop",
+        stop_on_loop=True,
+        stop_on_loop_min_repetitions=3,
+    )
+    def looping_run():
+        nonlocal completed
+        for _ in range(10):
+            context = make_fake_tool_context(
+                tool_name="search_docs",
+                tool_input={"query": "same query"},
+                tool_result="same result",
+            )
+            framework_dispatch(crewai._before_tool_call, context)
+            framework_dispatch(crewai._after_tool_call, context)
+            completed += 1
+
+    with pytest.raises(LoopAbort):
+        looping_run()
+
+    assert completed < 10
+    _, meta, events = _load_latest_events()
+    assert [event["event_type"] for event in events][-3:] == [
+        "LOOP_WARNING",
+        "ERROR",
+        "RUN_END",
+    ]
+    assert meta["status"] == "error"
+    assert events[-1]["payload"] == {"status": "error"}
+    assert crewai._abort_exceptions == {}
+
+    @trace(name="CrewAI clean reuse")
+    def clean_run():
+        context = make_fake_tool_context(tool_name="lookup", tool_result="ok")
+        crewai._before_tool_call(context)
+        crewai._after_tool_call(context)
+
+    clean_run()
+    _, clean_meta, clean_events = _load_latest_events()
+    assert [event["event_type"] for event in clean_events] == [
+        "RUN_START",
+        "TOOL_CALL",
+        "RUN_END",
+    ]
+    assert clean_meta["status"] == "ok"
+
+    cause = LoopAbort(threshold=3, actual=3, message="already aborted")
+    crewai._abort_exceptions["active-run"] = cause
+    with patch.object(crewai, "_get_active_run_id", return_value="active-run"):
+        with pytest.raises(_MaidaAbortSignal) as signal:
+            framework_dispatch(crewai._before_llm_call, make_fake_llm_context())
+        assert signal.value.cause is cause
+        with pytest.raises(LoopAbort, match="already aborted"):
+            crewai.raise_if_aborted()

--- a/tests/test_docs.py
+++ b/tests/test_docs.py
@@ -137,3 +137,37 @@ def test_openai_agents_docs_include_offline_success_and_regression_workflow():
     assert missing_docs == []
     assert '"--regression"' in example
     assert "regression=args.regression" in example
+
+
+def test_crewai_docs_cover_offline_success_and_strict_regression_workflow():
+    readme = (ROOT / "README.md").read_text(encoding="utf-8")
+    integration_docs = (ROOT / "docs/integrations.md").read_text(encoding="utf-8")
+    example = (ROOT / "examples/crewai/minimal.py").read_text(encoding="utf-8")
+
+    for snippet in (
+        'pip install "maida-ai[crewai]"',
+        "examples/crewai/minimal.py",
+        "--regression",
+    ):
+        assert snippet in readme or snippet in integration_docs
+
+    for snippet in (
+        "RUN_START -> LLM_CALL -> TOOL_CALL(search_docs) -> RUN_END",
+        "three consecutive `search_docs` calls",
+        "maida baseline --out crewai-baseline.json",
+        "maida assert --baseline crewai-baseline.json --tool-call-tolerance 0",
+        "exits with code `1`",
+        "maida_crewai.raise_if_aborted()",
+        "Mock%20CrewAI%20Agent.ipynb",
+    ):
+        assert snippet in integration_docs
+
+    for snippet in (
+        "LLMCallHookContext",
+        "ToolCallHookContext",
+        "get_before_llm_call_hooks",
+        "get_after_tool_call_hooks",
+        "crewai_event_bus.shutdown",
+        "tool_calls = 3 if regression else 1",
+    ):
+        assert snippet in example

--- a/tests/test_exceptions.py
+++ b/tests/test_exceptions.py
@@ -77,7 +77,8 @@ def test_maida_abort_signal_wraps_cause_and_str_matches_cause():
 
     assert sig.cause is cause
     assert str(sig) == str(cause)
-    assert isinstance(sig, Exception)
+    assert isinstance(sig, BaseException)
+    assert not isinstance(sig, Exception)
 
 
 def test_exception_hierarchy():


### PR DESCRIPTION
Make CrewAI guardrail aborts reliably escape framework exception handling and provide a deterministic, documented baseline workflow.

**Changes**

- Preserve per-run guardrail abort state and namespace CrewAI metadata.
- Add persisted conformance coverage and an offline success/regression example.
- Document the strict baseline workflow and completed tutorial coverage.

**Tests**

- uv run pytest
- uv run ruff check .
- uv run ruff format --check .

Fixes #79