### PR TITLE
[tests-only] Verify adapter payload privacy protections

### DIFF
--- a/tests/integrations/test_crewai_integration.py
+++ b/tests/integrations/test_crewai_integration.py
@@ -7,6 +7,7 @@ No crewai package is imported in this module.
 """
 
 import importlib
+import secrets
 import sys
 from types import SimpleNamespace
 from unittest.mock import MagicMock, patch
@@ -14,6 +15,7 @@ from unittest.mock import MagicMock, patch
 import pytest
 
 from maida._integration_utils import _clear_test_run_lifecycle_registry
+from maida.constants import REDACTED_MARKER, TRUNCATED_MARKER
 from maida.integrations._error import MissingOptionalDependencyError
 
 
@@ -460,6 +462,55 @@ def test_crewai_missing_completion_hooks_persist_failed_calls_before_run_end(
         assert event["meta"]["crewai"]["completion"] == "missing_after_hook"
     assert meta["status"] == "error"
     assert events[-1]["payload"] == {"status": "error"}
+
+
+def test_crewai_payloads_are_sanitized_before_persistence(
+    crewai_module_with_mocked_hooks, temp_data_dir, monkeypatch
+):
+    """Adapter payloads use Maida's redaction/truncation storage boundary."""
+    from maida import trace
+    from maida.config import load_config
+
+    crewai = crewai_module_with_mocked_hooks
+    secret = secrets.token_hex(24)
+    oversized = "public-" + ("x" * 200)
+    monkeypatch.setenv("MAIDA_REDACT_KEYS", "api_key,message,stack")
+    monkeypatch.setenv("MAIDA_MAX_FIELD_BYTES", "80")
+    llm_ctx = make_fake_llm_context(
+        messages=[{"role": "user", "api_key": secret, "content": oversized}],
+        response={"api_key": secret, "content": oversized},
+    )
+    tool_ctx = make_fake_tool_context(
+        tool_name="private_tool",
+        tool_input={"api_key": secret, "query": oversized},
+    )
+
+    @trace(name="crewai privacy")
+    def _run():
+        crewai._before_llm_call(llm_ctx)
+        crewai._after_llm_call(llm_ctx)
+        crewai._before_tool_call(tool_ctx)
+        raise RuntimeError(secret)
+
+    with pytest.raises(RuntimeError, match=secret):
+        _run()
+
+    config = load_config()
+    run_id, _, events = _load_latest_events()
+    raw = (config.data_dir / "runs" / run_id / "spans.jsonl").read_text(
+        encoding="utf-8"
+    )
+    assert secret not in raw
+
+    llm = next(event for event in events if event["event_type"] == "LLM_CALL")
+    tool = next(event for event in events if event["event_type"] == "TOOL_CALL")
+    assert REDACTED_MARKER in llm["payload"]["prompt"]
+    assert REDACTED_MARKER in llm["payload"]["response"]
+    assert TRUNCATED_MARKER in llm["payload"]["prompt"]
+    assert TRUNCATED_MARKER in llm["payload"]["response"]
+    assert tool["payload"]["args"]["api_key"] == REDACTED_MARKER
+    assert tool["payload"]["args"]["query"].endswith(TRUNCATED_MARKER)
+    assert tool["payload"]["error"]["message"] == REDACTED_MARKER
 
 
 def test_crewai_hooks_outside_a_run_do_not_contaminate_a_later_run(

--- a/tests/integrations/test_langchain_integration.py
+++ b/tests/integrations/test_langchain_integration.py
@@ -4,7 +4,9 @@ Uses temp dir; no network calls. Asserts TOOL_CALL and LLM_CALL events.
 """
 
 import logging
+import secrets
 import sys
+from types import SimpleNamespace
 
 import pytest
 from tests.conftest import get_latest_run_id
@@ -12,6 +14,7 @@ from tests.conftest import get_latest_run_id
 from maida import trace
 from maida.baseline import extract_run_metrics
 from maida.config import load_config
+from maida.constants import REDACTED_MARKER, TRUNCATED_MARKER
 from maida.events import EventType, spans_to_events
 from maida.exceptions import (
     GuardrailExceeded,
@@ -281,6 +284,67 @@ def test_langchain_handler_tool_error_emits_error_status(temp_data_dir):
     )
     assert err.get("error_type") == "ValueError"
     assert "simulated failure" in str(err.get("message", ""))
+
+
+@pytest.mark.skipif(LANGCHAIN_MISSING, reason="langchain_core not installed")
+def test_langchain_payloads_are_sanitized_before_persistence(
+    temp_data_dir, monkeypatch
+):
+    """Adapter payloads use Maida's redaction/truncation storage boundary."""
+    secret = secrets.token_hex(24)
+    oversized = "public-" + ("x" * 200)
+    monkeypatch.setenv("MAIDA_REDACT_KEYS", "api_key,message,stack")
+    monkeypatch.setenv("MAIDA_MAX_FIELD_BYTES", "80")
+    handler = LangChainCallbackHandler()
+
+    @trace(name="langchain privacy")
+    def _run():
+        handler.on_chat_model_start(
+            {"id": ["langchain", "PrivateChatModel"]},
+            [
+                [
+                    SimpleNamespace(
+                        type="human", content={"api_key": secret, "text": oversized}
+                    )
+                ]
+            ],
+            run_id="llm-private",
+        )
+        handler.on_llm_end(
+            SimpleNamespace(
+                generations=[
+                    [SimpleNamespace(text={"api_key": secret, "text": oversized})]
+                ],
+                llm_output=None,
+            ),
+            run_id="llm-private",
+        )
+        handler.on_tool_start(
+            {"name": "private_tool"},
+            f'{{"api_key": "{secret}", "query": "{oversized}"}}',
+            run_id="tool-private",
+        )
+        handler.on_tool_error(ValueError(secret), run_id="tool-private")
+
+    _run()
+
+    config = load_config()
+    run_id = get_latest_run_id(config)
+    raw = (config.data_dir / "runs" / run_id / "spans.jsonl").read_text(
+        encoding="utf-8"
+    )
+    assert secret not in raw
+
+    _, _, events = load_run_for_analysis(run_id, config)
+    llm = next(event for event in events if event["event_type"] == "LLM_CALL")
+    tool = next(event for event in events if event["event_type"] == "TOOL_CALL")
+    assert REDACTED_MARKER in llm["payload"]["prompt"]
+    assert REDACTED_MARKER in llm["payload"]["response"]
+    assert TRUNCATED_MARKER in llm["payload"]["prompt"]
+    assert TRUNCATED_MARKER in llm["payload"]["response"]
+    assert tool["payload"]["args"]["api_key"] == REDACTED_MARKER
+    assert tool["payload"]["args"]["query"].endswith(TRUNCATED_MARKER)
+    assert tool["payload"]["error"]["message"] == REDACTED_MARKER
 
 
 def _simulate_langchain_handle_event(handler, event_name: str, *args, **kwargs) -> None:

--- a/tests/integrations/test_openai_integration.py
+++ b/tests/integrations/test_openai_integration.py
@@ -7,6 +7,7 @@ import and translates spans into Maida events.
 """
 
 import importlib
+import secrets
 import sys
 from types import ModuleType, SimpleNamespace
 from unittest.mock import MagicMock, patch
@@ -16,6 +17,7 @@ import pytest
 from maida import trace
 from maida.baseline import extract_run_metrics
 from maida.config import load_config
+from maida.constants import REDACTED_MARKER, TRUNCATED_MARKER
 from maida.events import EventType
 from maida.integrations._error import MissingOptionalDependencyError
 from maida.storage import list_runs, load_run_for_analysis
@@ -464,6 +466,64 @@ def test_openai_agents_errors_persist_on_normalized_calls(
     assert meta["status"] == "ok"
     assert meta["counts"]["errors"] == 0
     assert events[-1]["payload"] == {"status": "ok"}
+
+
+def test_openai_agents_payloads_are_sanitized_before_persistence(
+    openai_agents_module, temp_data_dir, monkeypatch
+):
+    """Adapter payloads use Maida's redaction/truncation storage boundary."""
+    openai_agents, _, span_data = openai_agents_module
+    secret = secrets.token_hex(24)
+    oversized = "public-" + ("x" * 200)
+    monkeypatch.setenv("MAIDA_REDACT_KEYS", "api_key,message,stack")
+    monkeypatch.setenv("MAIDA_MAX_FIELD_BYTES", "80")
+    processor = openai_agents.OpenAIAgentsTracingProcessor()
+
+    @trace(name="openai agents privacy")
+    def _run():
+        processor.on_span_end(
+            _fake_span(
+                span_data.GenerationSpanData(
+                    input={"api_key": secret, "text": oversized},
+                    output={"api_key": secret, "text": oversized},
+                    model="gpt-private",
+                )
+            )
+        )
+        processor.on_span_end(
+            _fake_span(
+                span_data.FunctionSpanData(
+                    name="private_tool",
+                    input={"api_key": secret, "query": oversized},
+                    output=None,
+                ),
+                error={
+                    "message": secret,
+                    "data": {"api_key": secret, "diagnostic": oversized},
+                    "stack": secret,
+                },
+            )
+        )
+
+    _run()
+
+    config = load_config()
+    run_id = get_latest_run_id(config)
+    raw = (config.data_dir / "runs" / run_id / "spans.jsonl").read_text(
+        encoding="utf-8"
+    )
+    assert secret not in raw
+
+    _, _, events = load_run_for_analysis(run_id, config)
+    llm = next(event for event in events if event["event_type"] == "LLM_CALL")
+    tool = next(event for event in events if event["event_type"] == "TOOL_CALL")
+    assert REDACTED_MARKER in llm["payload"]["prompt"]
+    assert REDACTED_MARKER in llm["payload"]["response"]
+    assert TRUNCATED_MARKER in llm["payload"]["prompt"]
+    assert TRUNCATED_MARKER in llm["payload"]["response"]
+    assert tool["payload"]["args"]["api_key"] == REDACTED_MARKER
+    assert tool["payload"]["args"]["query"].endswith(TRUNCATED_MARKER)
+    assert tool["payload"]["error"]["message"] == REDACTED_MARKER
 
 
 def test_calls_outside_run_do_not_create_or_contaminate_run(


### PR DESCRIPTION
Add offline persistence coverage for LangChain, OpenAI Agents, and CrewAI payload redaction, truncation, and error sanitization. Runtime-generated sentinels prove sensitive values never reach raw trace storage.

Fixes #80