### PR TITLE
Scaffold PR baseline acceptance

### DIFF
--- a/README.md
+++ b/README.md
@@ -203,7 +203,7 @@ maida demo --regression  # baseline a good run, then watch the gate catch a bad 
 
 ```bash
 maida init           # starter .maida/policy.yaml
-maida init --github  # + .github/workflows/maida.yml (maida-ai/maida-assert@V4)
+maida init --github  # + PR gate and authorized /maida accept workflow
 ```
 
 ### List recent runs

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -47,13 +47,19 @@ maida init [--github] [--force]
 
 | Option | Description |
 |--------|-------------|
-| `--github` | Also write `.github/workflows/maida.yml` using the pinned [`maida-ai/maida-assert@V4`](https://github.com/maida-ai/maida-assert/releases/tag/V4) action |
+| `--github` | Also write `.github/workflows/maida.yml` using the pinned [`maida-ai/maida-assert@V4`](https://github.com/maida-ai/maida-assert/releases/tag/V4) gate and the `maida-ai/maida-assert/accept-command@main` handler |
 | `--force` | Overwrite existing files |
 
 **Files written:**
 
 - `.maida/policy.yaml` — commented starter policy with 50% baseline tolerances; strict checks such as `no_loops`, `no_guardrails`, `no_new_tools`, and `expect_status: ok` are shown as opt-ins
-- `.github/workflows/maida.yml` (with `--github`) — PR check running your traced agent and posting the regression report as a sticky comment; pins `actions/checkout@v7` and `maida-ai/maida-assert@V4`
+- `.github/workflows/maida.yml` (with `--github`) — PR check running your traced agent and posting the regression report as a sticky comment; also handles authorized `/maida accept [optional reason]` comments and rechecks an accepted PR-head commit; pins `actions/checkout@v7` and `maida-ai/maida-assert@V4`, with the command handler at `maida-ai/maida-assert/accept-command@main`
+
+Edit the generated `MAIDA_AGENT_SCRIPT` value for your entrypoint. After
+committing a baseline, set `MAIDA_BASELINE` to its tracked path; leaving it blank
+keeps the accept command inactive with a polite configuration response. Baseline
+write-back supports same-repository PR branches only and requires the commenter
+to have repository write access.
 
 **Exit codes:** `0` success; `10` internal error.
 

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -52,6 +52,12 @@ maida init            # starter .maida/policy.yaml
 maida init --github   # + GitHub Actions workflow
 ```
 
+In the generated workflow, replace `MAIDA_AGENT_SCRIPT` with your traced
+entrypoint. Once you have checked in a baseline, set `MAIDA_BASELINE` to its
+path. That enables authorized maintainers to accept an intentional PR change
+with `/maida accept [optional reason]`; the command stays inactive while the
+baseline value is blank.
+
 ---
 
 ## Quickstart

--- a/docs/regression-testing.md
+++ b/docs/regression-testing.md
@@ -291,7 +291,27 @@ Always inspect the trace and Git diff before committing the updated baseline. Ac
 
 ## GitHub Actions example
 
-The easiest path is the pinned [`maida-ai/maida-assert@V4`](https://github.com/maida-ai/maida-assert/releases/tag/V4) action — scaffold it with `maida init --github`. It runs your traced agent, asserts the run, and posts the regression report as a sticky PR comment.
+The easiest path is the pinned [`maida-ai/maida-assert@V4`](https://github.com/maida-ai/maida-assert/releases/tag/V4) action — scaffold it with `maida init --github`. It runs your traced agent, asserts the run, and posts the regression report as a sticky PR comment. The generated workflow also references the `/maida accept` handler at `maida-ai/maida-assert/accept-command@main`.
+
+Set `MAIDA_AGENT_SCRIPT` and, after checking in your first baseline,
+`MAIDA_BASELINE` at the top of `.github/workflows/maida.yml`. Until a baseline
+path is configured, `/maida accept` replies that write-back is inactive and does
+not run PR code.
+
+When a baseline regression is intentional, a repository maintainer with write
+access can review the trace and comment either command on a same-repository PR:
+
+```text
+/maida accept
+/maida accept expected retrieval tool split
+```
+
+The optional trailing text becomes the acceptance reason. The handler verifies
+authorization before checking out the PR, reruns the configured agent, commits
+only the baseline to the PR branch, and replies with the resulting commit link.
+It then requests a fresh gate and publishes that result against the new PR-head
+commit. Fork PRs are refused before checkout; update their baseline locally
+instead.
 
 To wire it up by hand instead, run your agent in CI, then assert against the checked-in baseline (`maida assert` picks up the latest run automatically):
 

--- a/maida/scaffold.py
+++ b/maida/scaffold.py
@@ -6,6 +6,7 @@ POLICY_RELPATH = Path(".maida") / "policy.yaml"
 WORKFLOW_RELPATH = Path(".github") / "workflows" / "maida.yml"
 CHECKOUT_ACTION_REF = "actions/checkout@v7"
 MAIDA_ASSERT_ACTION_REF = "maida-ai/maida-assert@V4"
+MAIDA_ACCEPT_ACTION_REF = "maida-ai/maida-assert/accept-command@main"
 
 POLICY_TEMPLATE = """\
 # Maida policy - enforced by `maida assert` locally and in CI.
@@ -46,28 +47,90 @@ assert:
 
 WORKFLOW_TEMPLATE = f"""\
 name: Agent Regression Check
-on: [pull_request]
+on:
+  pull_request:
+  issue_comment:
+    types: [created]
+  repository_dispatch:
+    types: [maida_baseline_updated]
 
-permissions:
-  contents: read          # checkout only needs read access
-  pull-requests: write    # maida-assert posts a sticky PR comment
+# Each job declares only the permissions needed for its event path.
+permissions: {{}}
+
+env:
+  # Replace this with the script that runs your traced agent.
+  # It must use @trace or traced_run so Maida records a run.
+  MAIDA_AGENT_SCRIPT: my_agent.py
+  MAIDA_POLICY: .maida/policy.yaml
+  # After committing a baseline, point this at it to enable `/maida accept`:
+  MAIDA_BASELINE: ''
 
 jobs:
   agent-check:
+    if: >-
+      github.event_name == 'pull_request' ||
+      github.event_name == 'repository_dispatch'
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: write
+      # A repository_dispatch run belongs to the default branch, so publish the
+      # gate result explicitly against the accepted PR-head SHA.
+      statuses: write
     steps:
       - name: Check out repository
         uses: {CHECKOUT_ACTION_REF}
+        with:
+          ref: ${{{{ github.event_name == 'repository_dispatch' && github.event.client_payload.sha || github.sha }}}}
 
       - name: Run Maida regression gate
+        id: gate
         uses: {MAIDA_ASSERT_ACTION_REF}
         with:
-          # Replace this with the script that runs your traced agent.
-          # It must use @trace or traced_run so Maida records a run.
-          agent-script: my_agent.py
-          policy: .maida/policy.yaml
-          # After committing a baseline, uncomment and point this at it:
-          # baseline: .maida/baselines/my_agent.json
+          agent-script: ${{{{ env.MAIDA_AGENT_SCRIPT }}}}
+          policy: ${{{{ env.MAIDA_POLICY }}}}
+          baseline: ${{{{ env.MAIDA_BASELINE }}}}
+          accept-command-enabled: ${{{{ env.MAIDA_BASELINE != '' }}}}
+
+      - name: Publish dispatched gate status
+        if: always() && github.event_name == 'repository_dispatch'
+        env:
+          GH_TOKEN: ${{{{ github.token }}}}
+          TARGET_SHA: ${{{{ github.event.client_payload.sha }}}}
+          GATE_OUTCOME: ${{{{ steps.gate.outcome }}}}
+        shell: bash
+        run: |
+          if [ "$GATE_OUTCOME" = "success" ]; then
+            state=success
+            description="Maida behavioral regression gate passed"
+          else
+            state=failure
+            description="Maida behavioral regression gate failed"
+          fi
+          gh api --method POST \\
+            "repos/${{GITHUB_REPOSITORY}}/statuses/${{TARGET_SHA}}" \\
+            -f state="$state" \\
+            -f context="Maida / agent-check" \\
+            -f description="$description" \\
+            -f target_url="${{GITHUB_SERVER_URL}}/${{GITHUB_REPOSITORY}}/actions/runs/${{GITHUB_RUN_ID}}"
+
+  accept-command:
+    if: >-
+      github.event_name == 'issue_comment' &&
+      github.event.issue.pull_request &&
+      startsWith(github.event.comment.body, '/maida accept')
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      pull-requests: write
+    steps:
+      - name: Accept intentional baseline change
+        uses: {MAIDA_ACCEPT_ACTION_REF}
+        with:
+          agent-script: ${{{{ env.MAIDA_AGENT_SCRIPT }}}}
+          policy: ${{{{ env.MAIDA_POLICY }}}}
+          baseline: ${{{{ env.MAIDA_BASELINE }}}}
+          github-token: ${{{{ github.token }}}}
 """
 
 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -21,7 +21,11 @@ from maida.cli import _wait_for_port, app
 from maida.config import load_config
 from maida.events import EventType
 from maida.policy import load_policy
-from maida.scaffold import CHECKOUT_ACTION_REF, MAIDA_ASSERT_ACTION_REF
+from maida.scaffold import (
+    CHECKOUT_ACTION_REF,
+    MAIDA_ACCEPT_ACTION_REF,
+    MAIDA_ASSERT_ACTION_REF,
+)
 from maida.storage import list_runs
 from tests.conftest import get_latest_run_id
 
@@ -1165,16 +1169,30 @@ def test_init_github_writes_valid_workflow(empty_data_dir, tmp_path, monkeypatch
     assert policy.no_new_tools is False
 
     wf = yaml.safe_load(workflow_text)
-    assert set(wf["permissions"]) == {"contents", "pull-requests"}
-    assert wf["permissions"]["contents"] == "read"
-    assert wf["permissions"]["pull-requests"] == "write"
+    triggers = wf.get("on", wf.get(True))
+    assert set(triggers) == {"pull_request", "issue_comment", "repository_dispatch"}
+    assert triggers["issue_comment"]["types"] == ["created"]
+    assert triggers["repository_dispatch"]["types"] == ["maida_baseline_updated"]
+    assert wf["permissions"] == {}
+    assert wf["env"] == {
+        "MAIDA_AGENT_SCRIPT": "my_agent.py",
+        "MAIDA_POLICY": ".maida/policy.yaml",
+        "MAIDA_BASELINE": "",
+    }
 
     job = wf["jobs"]["agent-check"]
-    assert set(wf["jobs"]) == {"agent-check"}
+    assert set(wf["jobs"]) == {"agent-check", "accept-command"}
     assert job["runs-on"] == "ubuntu-latest"
-    assert len(job["steps"]) == 2
+    assert job["permissions"] == {
+        "contents": "read",
+        "pull-requests": "write",
+        "statuses": "write",
+    }
+    assert "repository_dispatch" in job["if"]
+    assert len(job["steps"]) == 3
     assert job["steps"][0]["name"] == "Check out repository"
     assert job["steps"][1]["name"] == "Run Maida regression gate"
+    assert job["steps"][2]["name"] == "Publish dispatched gate status"
 
     uses = [step.get("uses", "") for step in job["steps"]]
     assert CHECKOUT_ACTION_REF in uses
@@ -1183,9 +1201,39 @@ def test_init_github_writes_valid_workflow(empty_data_dir, tmp_path, monkeypatch
     assert "maida-ai/maida-assert@v2" not in uses
 
     action_inputs = job["steps"][1]["with"]
-    assert action_inputs["agent-script"] == "my_agent.py"
-    assert action_inputs["policy"] == ".maida/policy.yaml"
-    assert "baseline" not in action_inputs
+    assert action_inputs["agent-script"] == "${{ env.MAIDA_AGENT_SCRIPT }}"
+    assert action_inputs["policy"] == "${{ env.MAIDA_POLICY }}"
+    assert action_inputs["baseline"] == "${{ env.MAIDA_BASELINE }}"
+    assert action_inputs["accept-command-enabled"] == (
+        "${{ env.MAIDA_BASELINE != '' }}"
+    )
+    assert "client_payload.sha" in job["steps"][0]["with"]["ref"]
+
+    status_step = job["steps"][2]
+    assert "always()" in status_step["if"]
+    assert status_step["env"]["TARGET_SHA"] == (
+        "${{ github.event.client_payload.sha }}"
+    )
+    assert status_step["env"]["GATE_OUTCOME"] == "${{ steps.gate.outcome }}"
+    assert "statuses/${TARGET_SHA}" in status_step["run"]
+    assert "Maida / agent-check" in status_step["run"]
+    assert "gh api --method POST \\\n" in workflow_text
+
+    command_job = wf["jobs"]["accept-command"]
+    assert "issue_comment" in command_job["if"]
+    assert "github.event.issue.pull_request" in command_job["if"]
+    assert "/maida accept" in command_job["if"]
+    assert command_job["permissions"] == {
+        "contents": "write",
+        "pull-requests": "write",
+    }
+    assert len(command_job["steps"]) == 1
+    command_step = command_job["steps"][0]
+    assert command_step["uses"] == MAIDA_ACCEPT_ACTION_REF
+    assert command_step["with"]["agent-script"] == "${{ env.MAIDA_AGENT_SCRIPT }}"
+    assert command_step["with"]["policy"] == "${{ env.MAIDA_POLICY }}"
+    assert command_step["with"]["baseline"] == "${{ env.MAIDA_BASELINE }}"
+    assert command_step["with"]["github-token"] == "${{ github.token }}"
     assert "Replace this with the script that runs your traced agent." in workflow_text
     assert "After committing a baseline" in workflow_text
     assert "secrets." not in workflow_text.lower()

--- a/tests/test_docs.py
+++ b/tests/test_docs.py
@@ -1,6 +1,10 @@
 from pathlib import Path
 
-from maida.scaffold import CHECKOUT_ACTION_REF, MAIDA_ASSERT_ACTION_REF
+from maida.scaffold import (
+    CHECKOUT_ACTION_REF,
+    MAIDA_ACCEPT_ACTION_REF,
+    MAIDA_ASSERT_ACTION_REF,
+)
 
 ROOT = Path(__file__).resolve().parents[1]
 
@@ -78,12 +82,14 @@ def test_action_version_references_match_scaffold():
     )
 
     assert MAIDA_ASSERT_ACTION_REF in combined
+    assert MAIDA_ACCEPT_ACTION_REF in combined
     assert "maida-ai/maida-assert@v2" not in combined
     assert "maida-ai/maida-assert@V2" not in combined
 
     workflow_text = (ROOT / "maida/scaffold.py").read_text(encoding="utf-8")
     assert CHECKOUT_ACTION_REF in workflow_text
     assert MAIDA_ASSERT_ACTION_REF in workflow_text
+    assert MAIDA_ACCEPT_ACTION_REF in workflow_text
     assert "actions/checkout@v4" not in workflow_text
     assert "maida-ai/maida-assert@v2" not in workflow_text
 


### PR DESCRIPTION
Generate authorization-first /maida accept handling, rerun accepted PR heads through repository dispatch, and publish the fresh gate status against the resulting commit. Document configuration, authorization, and same-repository limits.

Fixes #144

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>