### PR TITLE
Record baseline acceptance provenance

### DIFF
--- a/README.md
+++ b/README.md
@@ -255,7 +255,7 @@ maida accept --baseline .maida/baselines/my_agent.json --reason "expected tool f
 git diff .maida/baselines/my_agent.json
 ```
 
-Use `maida accept` only after inspecting the diff and trace. It updates the baseline from the selected run, records the acceptance reason and previous baseline hash in the JSON, and leaves the baseline diff reviewable in Git. If the run already matches the baseline, Maida exits successfully without rewriting the file.
+Use `maida accept` only after inspecting the diff and trace. It updates the baseline from the selected run and records who accepted it, when, the source PR/commit when available, an accepted-run verdict summary, the reason, and the previous baseline hash. Subsequent Markdown gate reports show this baseline provenance. If the run already matches the baseline, Maida exits successfully without rewriting the file.
 
 ### Diff two runs
 

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -220,7 +220,20 @@ git diff .maida/baselines/my_agent.json
 
 **Exit codes:** `0` baseline updated or already matched; `2` run or baseline not found, invalid baseline, invalid run, or missing reason; `10` internal error.
 
-When the accepted run changes baseline behavior, the baseline JSON is rewritten with the same structural fields produced by `maida baseline` plus an `acceptance` object containing the reason, timestamp, Maida version, source run ID, previous baseline source run ID, and previous baseline SHA-256. If the selected run already matches the baseline structurally, Maida prints `no update written` and leaves the file untouched.
+When the accepted run changes baseline behavior, the baseline JSON is rewritten
+with the same structural fields produced by `maida baseline` plus an
+`acceptance` provenance object. It records `accepted_by`, `accepted_at`, the
+reason, Maida version, source run ID, source repository/PR/commit, an
+accepted-run verdict summary, and the previous baseline source run ID and
+SHA-256. Subsequent Markdown assertion reports render this block under
+**Baseline provenance**.
+
+In GitHub write-back jobs, Maida reads `GITHUB_ACTOR`, `GITHUB_REPOSITORY`,
+`GITHUB_SERVER_URL`, `MAIDA_PR_NUMBER`, and `MAIDA_EXPECTED_HEAD_SHA` so the
+artifact identifies the approving user and exact PR revision. A local accept
+records the local OS user and leaves unavailable PR/commit fields empty. If the
+selected run already matches the baseline structurally, Maida prints
+`no update written` and leaves the file untouched.
 
 ---
 

--- a/docs/regression-testing.md
+++ b/docs/regression-testing.md
@@ -283,7 +283,15 @@ maida accept --baseline .maida/baselines/my_agent.json --reason "expected retrie
 git diff .maida/baselines/my_agent.json
 ```
 
-`maida accept` rewrites the baseline from the selected run and records acceptance metadata in the JSON: reason, timestamp, Maida version, source run ID, previous baseline source run ID, and previous baseline SHA-256. If the selected run already matches the baseline structurally, it exits `0` and leaves the file untouched.
+`maida accept` rewrites the baseline from the selected run and records an
+`acceptance` provenance object in the JSON: who accepted, when, why, the source
+repository/PR/commit when available, an accepted-run verdict summary, Maida
+version, source run ID, and the previous baseline source run ID and SHA-256.
+GitHub write-back provides the actor and exact PR-head revision automatically;
+local acceptance records the local OS user. Subsequent `--format markdown`
+reports render the metadata under **Baseline provenance**. If the selected run
+already matches the baseline structurally, it exits `0` and leaves the file
+untouched.
 
 Always inspect the trace and Git diff before committing the updated baseline. Accepting a baseline change means the new behavior is what future PRs will be gated against; if the change is not intentional, fix the agent and rerun `maida assert` instead.
 

--- a/maida/acceptance.py
+++ b/maida/acceptance.py
@@ -35,6 +35,30 @@ class BaselineAcceptResult:
     diff: RunDiff
 
 
+@dataclass(frozen=True)
+class AcceptanceSource:
+    """Identity and source revision for an accepted baseline change."""
+
+    accepted_by: str
+    repository: str | None = None
+    pull_request: int | None = None
+    pull_request_url: str | None = None
+    commit_sha: str | None = None
+
+    def as_dict(self) -> dict:
+        pull_request = None
+        if self.pull_request is not None:
+            pull_request = {
+                "number": self.pull_request,
+                "url": self.pull_request_url,
+            }
+        return {
+            "repository": self.repository,
+            "pull_request": pull_request,
+            "commit_sha": self.commit_sha,
+        }
+
+
 def _baseline_sha256(path: Path) -> str:
     return sha256(path.read_bytes()).hexdigest()
 
@@ -53,6 +77,20 @@ def baseline_matches_run(existing_baseline: dict, new_baseline: dict) -> bool:
     return _structural_snapshot(existing_baseline) == _structural_snapshot(new_baseline)
 
 
+def _accepted_run_verdict(baseline: dict) -> dict[str, str]:
+    summary = baseline.get("summary") or {}
+    return {
+        "outcome": "accepted",
+        "summary": (
+            f"Accepted run status {baseline.get('final_status') or 'unknown'}: "
+            f"{summary.get('total_events', 0)} events, "
+            f"{summary.get('tool_calls', 0)} tool calls, "
+            f"{summary.get('errors', 0)} errors, "
+            f"{summary.get('loop_warnings', 0)} loop warnings."
+        ),
+    }
+
+
 def accept_baseline_update(
     *,
     run_id: str,
@@ -61,6 +99,7 @@ def accept_baseline_update(
     reason: str,
     maida_version: str,
     config: MaidaConfig,
+    source: AcceptanceSource | None = None,
 ) -> BaselineAcceptResult:
     """Update *baseline_path* from *run_id* and attach acceptance metadata.
 
@@ -84,11 +123,15 @@ def accept_baseline_update(
             diff=diff,
         )
 
+    source = source or AcceptanceSource(accepted_by="unknown")
     new_baseline["acceptance"] = {
         "accepted_at": utc_now_iso_ms_z(),
+        "accepted_by": source.accepted_by,
         "reason": reason,
         "maida_version": maida_version,
         "source_run_id": new_baseline["source_run_id"],
+        "source": source.as_dict(),
+        "verdict": _accepted_run_verdict(new_baseline),
         "previous_baseline": {
             "path": str(baseline_path),
             "source_run_id": previous_source_run_id,

--- a/maida/assertions.py
+++ b/maida/assertions.py
@@ -105,6 +105,7 @@ class AssertionReport:
 
     run_id: str
     baseline_run_id: str | None
+    baseline_acceptance: dict | None = None
     results: list[AssertionResult] = field(default_factory=list)
     passed: bool = True
 
@@ -257,6 +258,11 @@ def run_assertions(
     report = AssertionReport(
         run_id=full_id,
         baseline_run_id=(baseline or {}).get("source_run_id"),
+        baseline_acceptance=(
+            (baseline or {}).get("acceptance")
+            if isinstance((baseline or {}).get("acceptance"), dict)
+            else None
+        ),
     )
 
     _ignored = set(policy.ignored_checks)
@@ -434,6 +440,54 @@ def _markdown_scope(report: AssertionReport) -> str:
     if report.baseline_run_id:
         scope += f" vs baseline `{str(report.baseline_run_id)[:8]}`"
     return scope
+
+
+def _markdown_baseline_provenance(acceptance: dict | None) -> list[str]:
+    if not isinstance(acceptance, dict):
+        return []
+
+    accepted_by = _markdown_table_cell(acceptance.get("accepted_by") or "unknown")
+    accepted_at = _markdown_table_cell(acceptance.get("accepted_at") or "unknown")
+    reason = _markdown_table_cell(acceptance.get("reason") or "not recorded")
+    source = acceptance.get("source")
+    source = source if isinstance(source, dict) else {}
+    pull_request = source.get("pull_request")
+    pull_request = pull_request if isinstance(pull_request, dict) else {}
+    pr_number = pull_request.get("number")
+    pr_url = pull_request.get("url")
+
+    if (
+        isinstance(pr_number, int)
+        and isinstance(pr_url, str)
+        and pr_url.startswith(("https://", "http://"))
+    ):
+        source_text = f"[PR #{pr_number}]({pr_url})"
+    elif isinstance(pr_number, int):
+        source_text = f"PR #{pr_number}"
+    else:
+        source_text = "local acceptance"
+
+    commit_sha = source.get("commit_sha")
+    if isinstance(commit_sha, str) and commit_sha:
+        source_text += f" at `{_markdown_table_cell(commit_sha[:8])}`"
+
+    verdict = acceptance.get("verdict")
+    verdict = verdict if isinstance(verdict, dict) else {}
+    outcome = _markdown_table_cell(verdict.get("outcome") or "accepted")
+    summary = _markdown_table_cell(verdict.get("summary") or "not recorded")
+
+    return [
+        "",
+        "### Baseline provenance",
+        "",
+        "| Accepted by | Accepted at | Source |",
+        "|---|---|---|",
+        f"| `{accepted_by}` | `{accepted_at}` | {source_text} |",
+        "",
+        f"**Acceptance verdict:** {outcome} — {summary}",
+        "",
+        f"**Reason:** {reason}",
+    ]
 
 
 def _markdown_next_steps(
@@ -642,6 +696,8 @@ def format_report_markdown(
         for r in ignored:
             lines.append(f"| \u2796 `{_markdown_table_cell(r.check_name)}` |")
         lines += ["", "</details>"]
+
+    lines += _markdown_baseline_provenance(report.baseline_acceptance)
 
     lines += [
         "",

--- a/maida/cli.py
+++ b/maida/cli.py
@@ -5,7 +5,9 @@ Commands: list, export, view, baseline, accept, assert, diff.
 Entrypoint: main() for console script maida.cli:main.
 """
 
+import getpass
 import json
+import os
 import socket
 import threading
 import time
@@ -26,7 +28,7 @@ from maida.assertions import (
     format_report_text,
     run_assertions,
 )
-from maida.acceptance import accept_baseline_update
+from maida.acceptance import AcceptanceSource, accept_baseline_update
 from maida.baseline import create_baseline, load_baseline, save_baseline
 from maida.config import load_config
 from maida.constants import LOCAL_DIR_NAME, SPEC_VERSION
@@ -88,6 +90,41 @@ def _resolve_run_or_latest(run_id: str | None, config) -> str:
         typer.echo(f"Using latest run: {resolved[:8]}", err=True)
         return resolved
     return storage.resolve_run_id(run_id, config)
+
+
+def _acceptance_source_from_environment() -> AcceptanceSource:
+    """Build acceptance provenance from local or GitHub write-back context."""
+    accepted_by = (
+        os.environ.get("MAIDA_ACCEPTED_BY")
+        or os.environ.get("GITHUB_ACTOR")
+        or getpass.getuser()
+    ).strip()
+    repository = os.environ.get("GITHUB_REPOSITORY", "").strip() or None
+    commit_sha = os.environ.get("MAIDA_EXPECTED_HEAD_SHA", "").strip() or None
+    pull_request_text = os.environ.get("MAIDA_PR_NUMBER", "").strip()
+    pull_request = None
+    if pull_request_text:
+        try:
+            pull_request = int(pull_request_text)
+        except ValueError as exc:
+            raise ValueError("MAIDA_PR_NUMBER must be a positive integer") from exc
+        if pull_request <= 0:
+            raise ValueError("MAIDA_PR_NUMBER must be a positive integer")
+
+    pull_request_url = None
+    if repository and pull_request is not None:
+        server_url = os.environ.get("GITHUB_SERVER_URL", "https://github.com").rstrip(
+            "/"
+        )
+        pull_request_url = f"{server_url}/{repository}/pull/{pull_request}"
+
+    return AcceptanceSource(
+        accepted_by=accepted_by or "unknown",
+        repository=repository,
+        pull_request=pull_request,
+        pull_request_url=pull_request_url,
+        commit_sha=commit_sha,
+    )
 
 
 def _exit_unsupported_trace_format(error: storage.UnsupportedTraceFormatError) -> None:
@@ -400,6 +437,7 @@ def accept_cmd(
             reason=reason,
             maida_version=__version__,
             config=config,
+            source=_acceptance_source_from_environment(),
         )
 
         if result.updated:

--- a/tests/test_assertions.py
+++ b/tests/test_assertions.py
@@ -250,6 +250,25 @@ def test_no_new_tools_passes_when_subset(temp_data_dir):
     assert report.passed is True
 
 
+def test_run_assertions_carries_baseline_acceptance_to_report(temp_data_dir):
+    config = load_config()
+    run_id = _make_run(config, events=[], name="accepted")
+    baseline = create_baseline(run_id, config)
+    baseline["acceptance"] = {
+        "accepted_by": "reviewer-login",
+        "accepted_at": "2026-07-22T20:15:00.000Z",
+    }
+
+    report = run_assertions(
+        run_id,
+        AssertionPolicy(max_steps=10),
+        baseline=baseline,
+        config=config,
+    )
+
+    assert report.baseline_acceptance == baseline["acceptance"]
+
+
 def test_no_new_tools_fails_on_new_tool(temp_data_dir):
     config = load_config()
     bl_events = [(EventType.TOOL_CALL, "search", {})]
@@ -772,6 +791,66 @@ def test_format_report_markdown_no_diff_section_without_diff(temp_data_dir):
     report = run_assertions(run_id, policy, config=config)
     md = format_report_markdown(report)
     assert "Top behavior changes" not in md
+
+
+def test_format_report_markdown_renders_baseline_provenance():
+    report = AssertionReport(
+        run_id="a" * 32,
+        baseline_run_id="b" * 32,
+        baseline_acceptance={
+            "accepted_at": "2026-07-22T20:15:00.000Z",
+            "accepted_by": "reviewer-login",
+            "reason": "Expected retrieval | tool split",
+            "source": {
+                "repository": "maida-ai/example-agent",
+                "pull_request": {
+                    "number": 42,
+                    "url": "https://github.com/maida-ai/example-agent/pull/42",
+                },
+                "commit_sha": "abcdef1234567890",
+            },
+            "verdict": {
+                "outcome": "accepted",
+                "summary": "Accepted run status ok: 4 events, 2 tool calls.",
+            },
+        },
+    )
+    report.add(
+        AssertionResult(
+            check_name="step_count",
+            passed=True,
+            message="4 steps (baseline: 4, tolerance: 50%)",
+        )
+    )
+
+    md = format_report_markdown(report, baseline_path="baseline.json")
+
+    assert "### Baseline provenance" in md
+    assert "`reviewer-login`" in md
+    assert "2026-07-22T20:15:00.000Z" in md
+    assert "[PR #42](https://github.com/maida-ai/example-agent/pull/42)" in md
+    assert "`abcdef12`" in md
+    assert "Accepted run status ok: 4 events, 2 tool calls." in md
+    assert "Expected retrieval \\| tool split" in md
+
+
+def test_format_report_markdown_renders_legacy_acceptance_safely():
+    report = AssertionReport(
+        run_id="a" * 32,
+        baseline_run_id="b" * 32,
+        baseline_acceptance={
+            "accepted_at": "2026-07-09T12:00:00.000Z",
+            "reason": "Legacy local acceptance",
+        },
+    )
+
+    md = format_report_markdown(report, baseline_path="baseline.json")
+
+    assert "### Baseline provenance" in md
+    assert "`unknown`" in md
+    assert "local acceptance" in md
+    assert "**Acceptance verdict:** accepted — not recorded" in md
+    assert "**Reason:** Legacy local acceptance" in md
 
 
 def test_format_report_markdown_pass_snapshot():

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -472,6 +472,133 @@ def test_accept_updates_baseline_with_metadata_and_diff(empty_data_dir):
     }
 
 
+def test_accept_records_github_provenance_and_verdict(empty_data_dir, monkeypatch):
+    config = load_config()
+    baseline_run = _make_run(
+        config,
+        name="agent",
+        events=[(EventType.TOOL_CALL, "search", {})],
+    )
+    baseline_path = empty_data_dir / "baseline.json"
+    runner.invoke(app, ["baseline", baseline_run, "--out", str(baseline_path)])
+    current_run = _make_run(
+        config,
+        name="agent",
+        events=[
+            (EventType.TOOL_CALL, "search", {}),
+            (EventType.TOOL_CALL, "new_tool", {}),
+        ],
+    )
+    monkeypatch.setenv("GITHUB_ACTOR", "reviewer-login")
+    monkeypatch.setenv("GITHUB_REPOSITORY", "maida-ai/example-agent")
+    monkeypatch.setenv("GITHUB_SERVER_URL", "https://github.example")
+    monkeypatch.setenv("MAIDA_PR_NUMBER", "42")
+    monkeypatch.setenv("MAIDA_EXPECTED_HEAD_SHA", "a" * 40)
+
+    result = runner.invoke(
+        app,
+        [
+            "accept",
+            current_run,
+            "--baseline",
+            str(baseline_path),
+            "--reason",
+            "expected tool expansion",
+        ],
+    )
+
+    assert result.exit_code == 0
+    acceptance = json.loads(baseline_path.read_text())["acceptance"]
+    assert acceptance["accepted_by"] == "reviewer-login"
+    assert acceptance["source"] == {
+        "repository": "maida-ai/example-agent",
+        "pull_request": {
+            "number": 42,
+            "url": "https://github.example/maida-ai/example-agent/pull/42",
+        },
+        "commit_sha": "a" * 40,
+    }
+    assert acceptance["verdict"] == {
+        "outcome": "accepted",
+        "summary": (
+            "Accepted run status ok: 2 events, 2 tool calls, 0 errors, 0 loop warnings."
+        ),
+    }
+
+
+def test_accept_rejects_invalid_pr_provenance_without_rewriting_baseline(
+    empty_data_dir, monkeypatch
+):
+    config = load_config()
+    baseline_run = _make_run(
+        config, name="agent", events=[(EventType.TOOL_CALL, "search", {})]
+    )
+    baseline_path = empty_data_dir / "baseline.json"
+    runner.invoke(app, ["baseline", baseline_run, "--out", str(baseline_path)])
+    before = baseline_path.read_bytes()
+    current_run = _make_run(
+        config, name="agent", events=[(EventType.TOOL_CALL, "lookup", {})]
+    )
+    monkeypatch.setenv("MAIDA_PR_NUMBER", "not-a-number")
+
+    result = runner.invoke(
+        app,
+        [
+            "accept",
+            current_run,
+            "--baseline",
+            str(baseline_path),
+            "--reason",
+            "expected rename",
+        ],
+    )
+
+    assert result.exit_code == 10
+    assert "MAIDA_PR_NUMBER must be a positive integer" in result.stderr
+    assert baseline_path.read_bytes() == before
+
+
+def test_accept_records_local_provenance_without_pr_source(empty_data_dir, monkeypatch):
+    config = load_config()
+    baseline_run = _make_run(
+        config, name="agent", events=[(EventType.TOOL_CALL, "search", {})]
+    )
+    baseline_path = empty_data_dir / "baseline.json"
+    runner.invoke(app, ["baseline", baseline_run, "--out", str(baseline_path)])
+    current_run = _make_run(
+        config, name="agent", events=[(EventType.TOOL_CALL, "lookup", {})]
+    )
+    monkeypatch.setenv("MAIDA_ACCEPTED_BY", "local-reviewer")
+    for name in (
+        "GITHUB_ACTOR",
+        "GITHUB_REPOSITORY",
+        "MAIDA_PR_NUMBER",
+        "MAIDA_EXPECTED_HEAD_SHA",
+    ):
+        monkeypatch.delenv(name, raising=False)
+
+    result = runner.invoke(
+        app,
+        [
+            "accept",
+            current_run,
+            "--baseline",
+            str(baseline_path),
+            "--reason",
+            "expected local rename",
+        ],
+    )
+
+    assert result.exit_code == 0
+    acceptance = json.loads(baseline_path.read_text())["acceptance"]
+    assert acceptance["accepted_by"] == "local-reviewer"
+    assert acceptance["source"] == {
+        "repository": None,
+        "pull_request": None,
+        "commit_sha": None,
+    }
+
+
 def test_accept_reason_alias_updates_baseline(empty_data_dir):
     config = load_config()
     baseline_run = _make_run(

--- a/tests/test_docs.py
+++ b/tests/test_docs.py
@@ -94,6 +94,25 @@ def test_action_version_references_match_scaffold():
     assert "maida-ai/maida-assert@v2" not in workflow_text
 
 
+def test_baseline_provenance_contract_is_documented():
+    combined = "\n".join(
+        (ROOT / rel_path).read_text(encoding="utf-8")
+        for rel_path in ["README.md", "docs/cli.md", "docs/regression-testing.md"]
+    )
+
+    required_snippets = [
+        "accepted_by",
+        "accepted_at",
+        "MAIDA_PR_NUMBER",
+        "MAIDA_EXPECTED_HEAD_SHA",
+        "Baseline provenance",
+        "accepted-run verdict summary",
+    ]
+
+    missing = [snippet for snippet in required_snippets if snippet not in combined]
+    assert missing == []
+
+
 def test_adapter_conformance_contract_covers_required_behavior():
     text = " ".join(
         (ROOT / "maida/integrations/CONTRIBUTING.md")


### PR DESCRIPTION
Embed approval identity, source PR revision, and the accepted-run verdict in updated baselines, then surface that context in later Markdown gate reports.

Tests: uv run pytest -q; uv run pytest --cov=maida --cov-report=term-missing:skip-covered -q; uv run ruff check .; uv run ruff format --check .

Fixes #146

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>