### PR TITLE
Add isolated multi-trial agent runner

### DIFF
--- a/maida/cli.py
+++ b/maida/cli.py
@@ -9,6 +9,7 @@ import getpass
 import json
 import os
 import socket
+import subprocess
 import threading
 import time
 import webbrowser
@@ -40,6 +41,7 @@ from maida.demo import (
 )
 from maida.diff import compute_diff, format_diff_text
 from maida.policy import load_policy, merge_policy
+from maida.runner import RunExecutionError, run_trials
 from maida.scaffold import (
     POLICY_RELPATH,
     POLICY_TEMPLATE,
@@ -135,6 +137,69 @@ def _exit_unsupported_trace_format(error: storage.UnsupportedTraceFormatError) -
 def _exit_run_validation_error(error: storage.RunValidationError) -> None:
     typer.echo(str(error), err=True)
     raise Exit(EXIT_NOT_FOUND)
+
+
+@app.command(name="run")
+def run_cmd(
+    agent_script: Path = typer.Argument(..., help="Traced Python agent script to run"),
+    trials: int = typer.Option(3, "--trials", min=1, help="Number of isolated trials"),
+    baseline_path: Path | None = typer.Option(
+        None, "--baseline", "-b", help="Baseline JSON file to compare against"
+    ),
+    policy_path: Path | None = typer.Option(None, "--policy", help="Policy YAML file"),
+    max_steps: int | None = typer.Option(
+        None, "--max-steps", help="Max total events allowed"
+    ),
+    output_format: str = typer.Option(
+        "text", "--format", "-f", help="Output format: text or json"
+    ),
+) -> None:
+    """Run a traced agent repeatedly in isolated workspace copies."""
+    try:
+        if not agent_script.is_file():
+            typer.echo(f"Agent script not found: {agent_script}", err=True)
+            raise Exit(EXIT_NOT_FOUND)
+        if output_format not in {"text", "json"}:
+            raise ValueError("format must be 'text' or 'json'")
+
+        config = load_config()
+        policy = AssertionPolicy()
+        selected_policy = policy_path
+        if selected_policy is None:
+            default_policy = LOCAL_DIR_NAME / "policy.yaml"
+            if default_policy.is_file():
+                selected_policy = default_policy
+        if selected_policy is not None:
+            policy = load_policy(selected_policy)
+        policy = merge_policy(policy, {"max_steps": max_steps})
+
+        baseline = None
+        if baseline_path is not None:
+            try:
+                baseline = load_baseline(baseline_path)
+            except (FileNotFoundError, json.JSONDecodeError):
+                typer.echo(f"Invalid or missing baseline: {baseline_path}", err=True)
+                raise Exit(EXIT_NOT_FOUND)
+
+        report = run_trials(
+            agent_script,
+            trials=trials,
+            policy=policy,
+            config=config,
+            project_root=Path.cwd(),
+            baseline=baseline,
+        )
+        typer.echo(report.to_json() if output_format == "json" else report.to_text())
+        if not report.passed:
+            raise Exit(1)
+    except Exit:
+        raise
+    except (RunExecutionError, ValueError, subprocess.SubprocessError) as error:
+        typer.echo(f"error: {error}", err=True)
+        raise Exit(EXIT_INTERNAL)
+    except Exception as error:
+        typer.echo(f"error: {error}", err=True)
+        raise Exit(EXIT_INTERNAL)
 
 
 def _wait_for_port(host: str, port: int, timeout_s: float = 5.0) -> bool:

--- a/maida/runner.py
+++ b/maida/runner.py
@@ -1,0 +1,200 @@
+"""Repeated, isolated execution of a traced agent script."""
+
+from __future__ import annotations
+
+import json
+import os
+import shutil
+import subprocess
+import sys
+import tempfile
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any
+
+from maida.assertions import AssertionPolicy, AssertionReport, run_assertions
+from maida.config import MaidaConfig
+from maida.storage import load_run_meta
+
+
+class RunExecutionError(RuntimeError):
+    """The agent process could not produce an unambiguous completed trace."""
+
+
+@dataclass(frozen=True)
+class TrialRecord:
+    """One isolated agent invocation and its assertion outcome."""
+
+    trial: int
+    trace_id: str
+    run_name: str | None
+    process_exit_code: int
+    stdout: str
+    stderr: str
+    assertion_report: AssertionReport
+
+    @property
+    def passed(self) -> bool:
+        return self.process_exit_code == 0 and self.assertion_report.passed
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "trial": self.trial,
+            "trace_id": self.trace_id,
+            "run_name": self.run_name,
+            "process_exit_code": self.process_exit_code,
+            "passed": self.passed,
+            "checks": [
+                {
+                    "check_name": result.check_name,
+                    "passed": result.passed,
+                    "reason_code": str(
+                        getattr(result.reason_code, "value", result.reason_code)
+                    ),
+                    "message": result.message,
+                    "expected": result.expected,
+                    "actual": result.actual,
+                    "ignored": result.ignored,
+                }
+                for result in self.assertion_report.results
+            ],
+        }
+
+
+@dataclass(frozen=True)
+class TrialRunReport:
+    """Collected results for a fixed number of isolated trials."""
+
+    trials_requested: int
+    trials: list[TrialRecord] = field(default_factory=list)
+
+    @property
+    def passed(self) -> bool:
+        return all(trial.passed for trial in self.trials)
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "trials_requested": self.trials_requested,
+            "passed": self.passed,
+            "trials": [trial.to_dict() for trial in self.trials],
+        }
+
+    def to_json(self) -> str:
+        return json.dumps(self.to_dict(), ensure_ascii=False, indent=2)
+
+    def to_text(self) -> str:
+        lines = []
+        for trial in self.trials:
+            verdict = "PASS" if trial.passed else "FAIL"
+            lines.append(
+                f"Trial {trial.trial}/{self.trials_requested}: {verdict} "
+                f"(trace {trial.trace_id[:8]})"
+            )
+        lines.extend(["", f"RESULT: {'PASSED' if self.passed else 'FAILED'}"])
+        return "\n".join(lines)
+
+
+def _workspace_files(project_root: Path) -> list[Path]:
+    """Return tracked and nonignored untracked files from *project_root*."""
+    result = subprocess.run(
+        ["git", "ls-files", "--cached", "--others", "--exclude-standard", "-z"],
+        cwd=project_root,
+        check=True,
+        capture_output=True,
+    )
+    return [Path(item.decode()) for item in result.stdout.split(b"\0") if item]
+
+
+def _copy_workspace(project_root: Path, destination: Path) -> None:
+    for relative_path in _workspace_files(project_root):
+        source = project_root / relative_path
+        target = destination / relative_path
+        target.parent.mkdir(parents=True, exist_ok=True)
+        if source.is_symlink():
+            target.symlink_to(os.readlink(source))
+        elif source.is_file():
+            shutil.copy2(source, target)
+
+
+def _preserve_trace(trace_id: str, trial_data_dir: Path, config: MaidaConfig) -> None:
+    source = trial_data_dir / "runs" / trace_id
+    destination = config.data_dir.expanduser() / "runs" / trace_id
+    destination.parent.mkdir(parents=True, exist_ok=True)
+    if destination.exists():
+        raise RunExecutionError(f"Trace destination already exists: {trace_id}")
+    shutil.copytree(source, destination)
+
+
+def run_trials(
+    agent_script: Path,
+    *,
+    trials: int,
+    policy: AssertionPolicy,
+    config: MaidaConfig,
+    project_root: Path | None = None,
+    baseline: dict | None = None,
+) -> TrialRunReport:
+    """Execute *agent_script* in a fresh copied workspace for every trial."""
+    if trials < 1:
+        raise ValueError("trials must be at least 1")
+
+    root = (project_root or Path.cwd()).resolve()
+    script = agent_script if agent_script.is_absolute() else root / agent_script
+    script = script.resolve()
+    try:
+        relative_script = script.relative_to(root)
+    except ValueError as error:
+        raise ValueError("agent script must be inside the project workspace") from error
+    if not script.is_file():
+        raise FileNotFoundError(f"Agent script not found: {agent_script}")
+
+    records: list[TrialRecord] = []
+    for trial_number in range(1, trials + 1):
+        with tempfile.TemporaryDirectory(prefix="maida-trial-") as temp:
+            trial_root = Path(temp) / "workspace"
+            trial_data_dir = Path(temp) / "data"
+            trial_root.mkdir()
+            _copy_workspace(root, trial_root)
+
+            env = os.environ.copy()
+            env["MAIDA_DATA_DIR"] = str(trial_data_dir)
+            completed = subprocess.run(
+                [sys.executable, str(relative_script)],
+                cwd=trial_root,
+                env=env,
+                capture_output=True,
+                text=True,
+                check=False,
+            )
+
+            runs_dir = trial_data_dir / "runs"
+            trace_dirs = (
+                sorted(path for path in runs_dir.iterdir() if path.is_dir())
+                if runs_dir.is_dir()
+                else []
+            )
+            if len(trace_dirs) != 1:
+                raise RunExecutionError(
+                    f"Trial {trial_number} must produce exactly one trace; "
+                    f"found {len(trace_dirs)}"
+                )
+
+            trace_id = trace_dirs[0].name
+            _preserve_trace(trace_id, trial_data_dir, config)
+            meta = load_run_meta(trace_id, config)
+            assertion_report = run_assertions(
+                trace_id, policy, baseline=baseline, config=config
+            )
+            records.append(
+                TrialRecord(
+                    trial=trial_number,
+                    trace_id=trace_id,
+                    run_name=meta.get("run_name"),
+                    process_exit_code=completed.returncode,
+                    stdout=completed.stdout,
+                    stderr=completed.stderr,
+                    assertion_report=assertion_report,
+                )
+            )
+
+    return TrialRunReport(trials_requested=trials, trials=records)

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -7,6 +7,7 @@ Covers: list, export, view, baseline, assert, diff commands.
 import json
 import os
 import socket
+import subprocess
 import threading
 import time
 from hashlib import sha256
@@ -800,6 +801,39 @@ def test_accept_malformed_run_exit_two(empty_data_dir):
 # ---------------------------------------------------------------------------
 # assert command
 # ---------------------------------------------------------------------------
+
+
+def test_run_command_executes_requested_trials(empty_data_dir, tmp_path, monkeypatch):
+    project = tmp_path / "project"
+    project.mkdir()
+    subprocess.run(["git", "init", "--quiet"], cwd=project, check=True)
+    script = project / "agent.py"
+    script.write_text(
+        "from maida import traced_run\nwith traced_run(name='cli-agent'):\n    pass\n",
+        encoding="utf-8",
+    )
+    subprocess.run(["git", "add", "agent.py"], cwd=project, check=True)
+    monkeypatch.chdir(project)
+
+    result = runner.invoke(
+        app,
+        ["run", "agent.py", "--trials", "2", "--max-steps", "10", "--format", "json"],
+    )
+
+    assert result.exit_code == 0, result.output
+    payload = json.loads(result.stdout)
+    assert payload["trials_requested"] == 2
+    assert len(payload["trials"]) == 2
+
+
+def test_run_command_missing_script_exits_two(empty_data_dir, tmp_path, monkeypatch):
+    subprocess.run(["git", "init", "--quiet"], cwd=tmp_path, check=True)
+    monkeypatch.chdir(tmp_path)
+
+    result = runner.invoke(app, ["run", "missing.py"])
+
+    assert result.exit_code == 2
+    assert "Agent script not found" in result.stderr
 
 
 def test_assert_exit_zero_on_pass(empty_data_dir):

--- a/tests/test_runner.py
+++ b/tests/test_runner.py
@@ -1,0 +1,154 @@
+"""Tests for repeated, workspace-isolated agent execution."""
+
+from __future__ import annotations
+
+import json
+import subprocess
+from pathlib import Path
+
+import pytest
+
+from maida.assertions import AssertionPolicy
+from maida.config import load_config
+from maida.runner import RunExecutionError, run_trials
+
+
+def _git(*args: str, cwd: Path) -> None:
+    subprocess.run(["git", *args], cwd=cwd, check=True, capture_output=True, text=True)
+
+
+def _write_agent(repo: Path, body: str) -> Path:
+    script = repo / "agent.py"
+    script.write_text(body, encoding="utf-8")
+    _git("add", "agent.py", cwd=repo)
+    return script
+
+
+@pytest.fixture
+def agent_repo(tmp_path: Path) -> Path:
+    repo = tmp_path / "project"
+    repo.mkdir()
+    _git("init", "--quiet", cwd=repo)
+    return repo
+
+
+def test_run_trials_isolates_workspace_and_preserves_one_trace_per_trial(
+    agent_repo: Path, temp_data_dir: Path
+) -> None:
+    _write_agent(
+        agent_repo,
+        """
+from pathlib import Path
+from maida import record_tool_call, traced_run
+
+state = Path("trial-state.txt")
+if state.exists():
+    raise RuntimeError("workspace leaked from an earlier trial")
+state.write_text("created", encoding="utf-8")
+with traced_run(name="isolated-agent"):
+    record_tool_call("work", args={}, result="ok")
+""".lstrip(),
+    )
+
+    config = load_config(project_root=agent_repo)
+    report = run_trials(
+        agent_repo / "agent.py",
+        trials=3,
+        policy=AssertionPolicy(max_tool_calls=1),
+        config=config,
+        project_root=agent_repo,
+    )
+
+    assert report.trials_requested == 3
+    assert len(report.trials) == 3
+    assert len({trial.trace_id for trial in report.trials}) == 3
+    assert all(trial.process_exit_code == 0 for trial in report.trials)
+    assert all(trial.assertion_report.passed for trial in report.trials)
+    assert not (agent_repo / "trial-state.txt").exists()
+    for trial in report.trials:
+        assert (temp_data_dir / "runs" / trial.trace_id / "meta.json").is_file()
+
+
+def test_run_trials_copies_nonignored_untracked_files(
+    agent_repo: Path, temp_data_dir: Path
+) -> None:
+    (agent_repo / "scenario.txt").write_text("expected", encoding="utf-8")
+    _write_agent(
+        agent_repo,
+        """
+from pathlib import Path
+from maida import record_tool_call, traced_run
+
+value = Path("scenario.txt").read_text(encoding="utf-8")
+with traced_run(name="untracked-input"):
+    record_tool_call("read", args={}, result=value)
+""".lstrip(),
+    )
+
+    report = run_trials(
+        agent_repo / "agent.py",
+        trials=1,
+        policy=AssertionPolicy(),
+        config=load_config(project_root=agent_repo),
+        project_root=agent_repo,
+    )
+
+    assert report.trials[0].process_exit_code == 0
+
+
+def test_run_trials_rejects_agent_that_does_not_produce_exactly_one_trace(
+    agent_repo: Path, temp_data_dir: Path
+) -> None:
+    _write_agent(agent_repo, "print('no trace')\n")
+
+    with pytest.raises(RunExecutionError, match="exactly one trace"):
+        run_trials(
+            agent_repo / "agent.py",
+            trials=1,
+            policy=AssertionPolicy(),
+            config=load_config(project_root=agent_repo),
+            project_root=agent_repo,
+        )
+
+
+def test_run_trials_rejects_non_positive_trial_count(
+    agent_repo: Path, temp_data_dir: Path
+) -> None:
+    _write_agent(agent_repo, "print('unused')\n")
+
+    with pytest.raises(ValueError, match="at least 1"):
+        run_trials(
+            agent_repo / "agent.py",
+            trials=0,
+            policy=AssertionPolicy(),
+            config=load_config(project_root=agent_repo),
+            project_root=agent_repo,
+        )
+
+
+def test_trial_report_json_records_metadata_and_check_outcomes(
+    agent_repo: Path, temp_data_dir: Path
+) -> None:
+    _write_agent(
+        agent_repo,
+        """
+from maida import traced_run
+
+with traced_run(name="json-agent"):
+    pass
+""".lstrip(),
+    )
+    report = run_trials(
+        agent_repo / "agent.py",
+        trials=1,
+        policy=AssertionPolicy(max_steps=10),
+        config=load_config(project_root=agent_repo),
+        project_root=agent_repo,
+    )
+
+    payload = json.loads(report.to_json())
+    assert payload["trials_requested"] == 1
+    assert payload["trials"][0]["trial"] == 1
+    assert payload["trials"][0]["run_name"] == "json-agent"
+    assert payload["trials"][0]["process_exit_code"] == 0
+    assert payload["trials"][0]["checks"][0]["check_name"] == "step_count"


### PR DESCRIPTION
Run traced agent scripts in fresh workspace and trace-store copies so repeated trials cannot leak local state into one another.

**Changes**

- add the maida run command and per-trial report metadata
- preserve exactly one completed trace from each isolated subprocess
- cover workspace isolation, untracked inputs, invalid runs, and CLI behavior

**Tests**

- uv run pytest tests/test_runner.py -q
- uv run ruff check maida/runner.py maida/cli.py tests/test_runner.py tests/test_cli.py

Fixes #138

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>