### PR TITLE
Add Wilson-bound three-verdict aggregation

### DIFF
--- a/maida/runner.py
+++ b/maida/runner.py
@@ -15,6 +15,12 @@ from typing import Any
 from maida.assertions import AssertionPolicy, AssertionReport, run_assertions
 from maida.config import MaidaConfig
 from maida.storage import load_run_meta
+from maida.statistics import (
+    GateVerdict,
+    StatisticalResult,
+    aggregate_outcomes,
+    aggregate_verdict,
+)
 
 
 class RunExecutionError(RuntimeError):
@@ -67,16 +73,29 @@ class TrialRunReport:
 
     trials_requested: int
     trials: list[TrialRecord] = field(default_factory=list)
+    aggregate_results: list[StatisticalResult] = field(default_factory=list)
+    confidence_level: float = 0.95
+    pass_rate_threshold: float = 0.90
+
+    @property
+    def verdict(self) -> GateVerdict:
+        return aggregate_verdict(self.aggregate_results)
 
     @property
     def passed(self) -> bool:
-        return all(trial.passed for trial in self.trials)
+        return self.verdict is not GateVerdict.FAIL
 
     def to_dict(self) -> dict[str, Any]:
         return {
             "trials_requested": self.trials_requested,
             "passed": self.passed,
+            "verdict": self.verdict.value,
+            "confidence_level": self.confidence_level,
+            "pass_rate_threshold": self.pass_rate_threshold,
             "trials": [trial.to_dict() for trial in self.trials],
+            "aggregate_results": [
+                result.to_dict() for result in self.aggregate_results
+            ],
         }
 
     def to_json(self) -> str:
@@ -90,7 +109,7 @@ class TrialRunReport:
                 f"Trial {trial.trial}/{self.trials_requested}: {verdict} "
                 f"(trace {trial.trace_id[:8]})"
             )
-        lines.extend(["", f"RESULT: {'PASSED' if self.passed else 'FAILED'}"])
+        lines.extend(["", f"RESULT: {self.verdict.value.upper()}"])
         return "\n".join(lines)
 
 
@@ -133,6 +152,8 @@ def run_trials(
     config: MaidaConfig,
     project_root: Path | None = None,
     baseline: dict | None = None,
+    confidence_level: float = 0.95,
+    pass_rate_threshold: float = 0.90,
 ) -> TrialRunReport:
     """Execute *agent_script* in a fresh copied workspace for every trial."""
     if trials < 1:
@@ -197,4 +218,26 @@ def run_trials(
                 )
             )
 
-    return TrialRunReport(trials_requested=trials, trials=records)
+    outcomes: dict[str, list[bool]] = {"agent_process": []}
+    for record in records:
+        outcomes["agent_process"].append(record.process_exit_code == 0)
+        for result in record.assertion_report.results:
+            if not result.ignored:
+                outcomes.setdefault(result.check_name, []).append(result.passed)
+
+    aggregate_results = [
+        aggregate_outcomes(
+            check_name,
+            check_outcomes,
+            confidence_level=confidence_level,
+            pass_rate_threshold=pass_rate_threshold,
+        )
+        for check_name, check_outcomes in outcomes.items()
+    ]
+    return TrialRunReport(
+        trials_requested=trials,
+        trials=records,
+        aggregate_results=aggregate_results,
+        confidence_level=confidence_level,
+        pass_rate_threshold=pass_rate_threshold,
+    )

--- a/maida/statistics.py
+++ b/maida/statistics.py
@@ -1,0 +1,131 @@
+"""Statistical aggregation for repeated binary gate outcomes."""
+
+from __future__ import annotations
+
+import math
+from dataclasses import dataclass
+from enum import Enum
+from statistics import NormalDist
+from typing import Any, Iterable
+
+
+class GateVerdict(str, Enum):
+    """A merge-gate result that distinguishes uncertainty from failure."""
+
+    PASS = "pass"
+    FAIL = "fail"
+    INCONCLUSIVE = "inconclusive"
+
+
+@dataclass(frozen=True)
+class StatisticalResult:
+    """Wilson-bound verdict and the complete rationale needed to reproduce it."""
+
+    check_name: str
+    verdict: GateVerdict
+    trials: int
+    successes: int
+    pass_rate: float
+    confidence_interval: tuple[float, float]
+    confidence_level: float
+    pass_rate_threshold: float
+    decision_rule: str
+    trial_outcomes: tuple[bool, ...]
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "check_name": self.check_name,
+            "verdict": self.verdict.value,
+            "trials": self.trials,
+            "successes": self.successes,
+            "pass_rate": self.pass_rate,
+            "confidence_interval": list(self.confidence_interval),
+            "confidence_level": self.confidence_level,
+            "pass_rate_threshold": self.pass_rate_threshold,
+            "decision_rule": self.decision_rule,
+            "trial_outcomes": list(self.trial_outcomes),
+        }
+
+
+def wilson_interval(
+    successes: int, trials: int, *, confidence_level: float = 0.95
+) -> tuple[float, float]:
+    """Return a two-sided Wilson score interval for a binomial proportion."""
+    if trials < 1:
+        raise ValueError("trials must be at least 1")
+    if successes < 0 or successes > trials:
+        raise ValueError("successes must be between 0 and trials")
+    if not 0.0 < confidence_level < 1.0:
+        raise ValueError("confidence_level must be between 0 and 1")
+
+    alpha = 1.0 - confidence_level
+    z = NormalDist().inv_cdf(1.0 - alpha / 2.0)
+    proportion = successes / trials
+    z_squared = z * z
+    denominator = 1.0 + z_squared / trials
+    center = (proportion + z_squared / (2.0 * trials)) / denominator
+    margin = (
+        z
+        * math.sqrt(
+            proportion * (1.0 - proportion) / trials
+            + z_squared / (4.0 * trials * trials)
+        )
+        / denominator
+    )
+    return max(0.0, center - margin), min(1.0, center + margin)
+
+
+def aggregate_outcomes(
+    check_name: str,
+    outcomes: Iterable[bool],
+    *,
+    confidence_level: float = 0.95,
+    pass_rate_threshold: float = 0.90,
+) -> StatisticalResult:
+    """Aggregate binary outcomes into PASS, FAIL, or INCONCLUSIVE."""
+    values = tuple(bool(value) for value in outcomes)
+    if not values:
+        raise ValueError("at least one trial outcome is required")
+    if not 0.0 <= pass_rate_threshold <= 1.0:
+        raise ValueError("pass_rate_threshold must be between 0 and 1")
+
+    trials = len(values)
+    successes = sum(values)
+    interval = wilson_interval(successes, trials, confidence_level=confidence_level)
+    decision_rule = "wilson_two_sided"
+
+    if trials == 1:
+        verdict = GateVerdict.PASS if successes else GateVerdict.FAIL
+        decision_rule = "single_trial_binary"
+    elif trials == 3 and successes in {0, 3}:
+        verdict = GateVerdict.PASS if successes == 3 else GateVerdict.FAIL
+        decision_rule = "small_n_unanimous"
+    elif interval[0] >= pass_rate_threshold:
+        verdict = GateVerdict.PASS
+    elif interval[1] < pass_rate_threshold:
+        verdict = GateVerdict.FAIL
+    else:
+        verdict = GateVerdict.INCONCLUSIVE
+
+    return StatisticalResult(
+        check_name=check_name,
+        verdict=verdict,
+        trials=trials,
+        successes=successes,
+        pass_rate=successes / trials,
+        confidence_interval=interval,
+        confidence_level=confidence_level,
+        pass_rate_threshold=pass_rate_threshold,
+        decision_rule=decision_rule,
+        trial_outcomes=values,
+    )
+
+
+def aggregate_verdict(results: Iterable[StatisticalResult]) -> GateVerdict:
+    """Return FAIL over INCONCLUSIVE over PASS for a collection of checks."""
+    verdicts = {result.verdict for result in results}
+    if GateVerdict.FAIL in verdicts:
+        return GateVerdict.FAIL
+    if GateVerdict.INCONCLUSIVE in verdicts:
+        return GateVerdict.INCONCLUSIVE
+    return GateVerdict.PASS

--- a/tests/test_runner.py
+++ b/tests/test_runner.py
@@ -11,6 +11,7 @@ import pytest
 from maida.assertions import AssertionPolicy
 from maida.config import load_config
 from maida.runner import RunExecutionError, run_trials
+from maida.statistics import GateVerdict
 
 
 def _git(*args: str, cwd: Path) -> None:
@@ -64,6 +65,11 @@ with traced_run(name="isolated-agent"):
     assert len({trial.trace_id for trial in report.trials}) == 3
     assert all(trial.process_exit_code == 0 for trial in report.trials)
     assert all(trial.assertion_report.passed for trial in report.trials)
+    assert report.verdict is GateVerdict.PASS
+    assert {result.check_name for result in report.aggregate_results} == {
+        "agent_process",
+        "tool_calls",
+    }
     assert not (agent_repo / "trial-state.txt").exists()
     for trial in report.trials:
         assert (temp_data_dir / "runs" / trial.trace_id / "meta.json").is_file()

--- a/tests/test_statistics.py
+++ b/tests/test_statistics.py
@@ -1,0 +1,115 @@
+"""Tests for Wilson-bound three-verdict aggregation."""
+
+from __future__ import annotations
+
+import math
+
+import pytest
+
+from maida.statistics import (
+    GateVerdict,
+    aggregate_outcomes,
+    aggregate_verdict,
+    wilson_interval,
+)
+
+
+@pytest.mark.parametrize(
+    ("successes", "trials", "expected"),
+    [
+        (0, 1, GateVerdict.FAIL),
+        (1, 1, GateVerdict.PASS),
+        (0, 3, GateVerdict.FAIL),
+        (3, 3, GateVerdict.PASS),
+        (2, 3, GateVerdict.INCONCLUSIVE),
+        (0, 5, GateVerdict.FAIL),
+        (4, 5, GateVerdict.INCONCLUSIVE),
+        (0, 10, GateVerdict.FAIL),
+        (10, 10, GateVerdict.INCONCLUSIVE),
+    ],
+)
+def test_default_verdicts_cover_supported_small_trial_counts(
+    successes: int, trials: int, expected: GateVerdict
+) -> None:
+    result = aggregate_outcomes(
+        "check", [True] * successes + [False] * (trials - successes)
+    )
+
+    assert result.verdict is expected
+    assert result.trials == trials
+    assert result.successes == successes
+
+
+def test_wilson_pass_when_lower_bound_meets_threshold() -> None:
+    result = aggregate_outcomes(
+        "check", [True] * 10, pass_rate_threshold=0.70, confidence_level=0.95
+    )
+
+    assert result.verdict is GateVerdict.PASS
+    assert result.confidence_interval[0] >= 0.70
+
+
+def test_wilson_fail_when_upper_bound_is_below_threshold() -> None:
+    result = aggregate_outcomes("check", [False] * 9 + [True], pass_rate_threshold=0.90)
+
+    assert result.verdict is GateVerdict.FAIL
+    assert result.confidence_interval[1] < 0.90
+
+
+def test_wilson_inconclusive_when_interval_straddles_threshold() -> None:
+    result = aggregate_outcomes("check", [True] * 4 + [False], pass_rate_threshold=0.75)
+
+    lower, upper = result.confidence_interval
+    assert result.verdict is GateVerdict.INCONCLUSIVE
+    assert lower < 0.75 <= upper
+
+
+def test_wilson_interval_matches_reference_value() -> None:
+    lower, upper = wilson_interval(3, 3, confidence_level=0.95)
+
+    assert lower == pytest.approx(0.4385, abs=0.0001)
+    assert upper == pytest.approx(1.0)
+
+
+def test_result_serializes_verdict_rationale() -> None:
+    result = aggregate_outcomes("step_count", [True, True, False])
+    payload = result.to_dict()
+
+    assert payload == {
+        "check_name": "step_count",
+        "verdict": "inconclusive",
+        "trials": 3,
+        "successes": 2,
+        "pass_rate": pytest.approx(2 / 3),
+        "confidence_interval": pytest.approx([0.2076596008, 0.9385080553]),
+        "confidence_level": 0.95,
+        "pass_rate_threshold": 0.9,
+        "decision_rule": "wilson_two_sided",
+        "trial_outcomes": [True, True, False],
+    }
+
+
+@pytest.mark.parametrize(
+    ("successes", "trials", "threshold", "confidence"),
+    [(-1, 3, 0.9, 0.95), (4, 3, 0.9, 0.95), (1, 0, 0.9, 0.95)],
+)
+def test_wilson_interval_rejects_invalid_counts(
+    successes: int, trials: int, threshold: float, confidence: float
+) -> None:
+    with pytest.raises(ValueError):
+        wilson_interval(successes, trials, confidence_level=confidence)
+
+
+def test_wilson_interval_is_finite() -> None:
+    lower, upper = wilson_interval(5, 10, confidence_level=0.95)
+    assert math.isfinite(lower)
+    assert math.isfinite(upper)
+
+
+def test_aggregate_verdict_prioritizes_fail_then_inconclusive() -> None:
+    passed = aggregate_outcomes("passed", [True])
+    failed = aggregate_outcomes("failed", [False])
+    inconclusive = aggregate_outcomes("uncertain", [True, True, False])
+
+    assert aggregate_verdict([passed, inconclusive]) is GateVerdict.INCONCLUSIVE
+    assert aggregate_verdict([passed, inconclusive, failed]) is GateVerdict.FAIL


### PR DESCRIPTION
Classify repeated check outcomes with reproducible confidence intervals while preserving binary single-trial behavior and the temporary unanimous three-trial compatibility rule.

**Changes**

- compute and serialize two-sided Wilson verdict rationale
- aggregate check verdicts with failure precedence over uncertainty
- cover PASS, FAIL, and INCONCLUSIVE boundaries and small trial counts

**Tests**

- uv run pytest tests/test_statistics.py tests/test_runner.py -q

Fixes #139

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>