### PR TITLE
Neutral check conclusion for INCONCLUSIVE

### DIFF
--- a/maida/cli.py
+++ b/maida/cli.py
@@ -42,6 +42,7 @@ from maida.demo import (
 from maida.diff import compute_diff, format_diff_text
 from maida.policy import load_policy, merge_policy
 from maida.runner import RunExecutionError, run_trials
+from maida.statistics import GateVerdict
 from maida.scaffold import (
     POLICY_RELPATH,
     POLICY_TEMPLATE,
@@ -151,7 +152,10 @@ def run_cmd(
         None, "--max-steps", help="Max total events allowed"
     ),
     output_format: str = typer.Option(
-        "text", "--format", "-f", help="Output format: text or json"
+        "text", "--format", "-f", help="Output format: text, json, or markdown"
+    ),
+    json_out: Path | None = typer.Option(
+        None, "--json-out", help="Also write the machine-readable report to this path"
     ),
 ) -> None:
     """Run a traced agent repeatedly in isolated workspace copies."""
@@ -159,8 +163,8 @@ def run_cmd(
         if not agent_script.is_file():
             typer.echo(f"Agent script not found: {agent_script}", err=True)
             raise Exit(EXIT_NOT_FOUND)
-        if output_format not in {"text", "json"}:
-            raise ValueError("format must be 'text' or 'json'")
+        if output_format not in {"text", "json", "markdown"}:
+            raise ValueError("format must be 'text', 'json', or 'markdown'")
 
         config = load_config()
         policy = AssertionPolicy()
@@ -189,8 +193,20 @@ def run_cmd(
             project_root=Path.cwd(),
             baseline=baseline,
         )
-        typer.echo(report.to_json() if output_format == "json" else report.to_text())
-        if not report.passed:
+        if json_out is not None:
+            json_out.parent.mkdir(parents=True, exist_ok=True)
+            temporary = json_out.with_name(f".{json_out.name}.{os.getpid()}.tmp")
+            temporary.write_text(report.to_json() + "\n", encoding="utf-8")
+            os.replace(temporary, json_out)
+
+        if output_format == "json":
+            rendered = report.to_json()
+        elif output_format == "markdown":
+            rendered = report.to_markdown()
+        else:
+            rendered = report.to_text()
+        typer.echo(rendered)
+        if report.verdict is GateVerdict.FAIL:
             raise Exit(1)
     except Exit:
         raise

--- a/maida/runner.py
+++ b/maida/runner.py
@@ -8,12 +8,13 @@ import shutil
 import subprocess
 import sys
 import tempfile
-from dataclasses import dataclass, field
+from dataclasses import asdict, dataclass, field
 from pathlib import Path
 from typing import Any
 
 from maida.assertions import AssertionPolicy, AssertionReport, run_assertions
 from maida.config import MaidaConfig
+from maida.diff import compute_diff
 from maida.storage import load_run_meta
 from maida.statistics import (
     GateVerdict,
@@ -38,6 +39,7 @@ class TrialRecord:
     stdout: str
     stderr: str
     assertion_report: AssertionReport
+    baseline_diff: dict[str, Any] | None = None
 
     @property
     def passed(self) -> bool:
@@ -64,6 +66,7 @@ class TrialRecord:
                 }
                 for result in self.assertion_report.results
             ],
+            "baseline_diff": self.baseline_diff,
         }
 
 
@@ -82,16 +85,25 @@ class TrialRunReport:
         return aggregate_verdict(self.aggregate_results)
 
     @property
-    def passed(self) -> bool:
-        return self.verdict is not GateVerdict.FAIL
+    def passed(self) -> bool | None:
+        if self.verdict is GateVerdict.PASS:
+            return True
+        if self.verdict is GateVerdict.FAIL:
+            return False
+        return None
 
     def to_dict(self) -> dict[str, Any]:
         return {
+            "report_version": "1",
             "trials_requested": self.trials_requested,
             "passed": self.passed,
             "verdict": self.verdict.value,
-            "confidence_level": self.confidence_level,
-            "pass_rate_threshold": self.pass_rate_threshold,
+            "metadata": {
+                "trials_requested": self.trials_requested,
+                "trials_completed": len(self.trials),
+                "confidence_level": self.confidence_level,
+                "pass_rate_threshold": self.pass_rate_threshold,
+            },
             "trials": [trial.to_dict() for trial in self.trials],
             "aggregate_results": [
                 result.to_dict() for result in self.aggregate_results
@@ -110,6 +122,62 @@ class TrialRunReport:
                 f"(trace {trial.trace_id[:8]})"
             )
         lines.extend(["", f"RESULT: {self.verdict.value.upper()}"])
+        return "\n".join(lines)
+
+    def to_markdown(self) -> str:
+        icons = {
+            GateVerdict.PASS: "✅",
+            GateVerdict.FAIL: "❌",
+            GateVerdict.INCONCLUSIVE: "⚠️",
+        }
+        lines = [
+            f"## {icons[self.verdict]} Maida statistical gate: {self.verdict.value}",
+            "",
+            f"**{len(self.trials)} trials** · "
+            f"{self.confidence_level:.0%} confidence · "
+            f"{self.pass_rate_threshold:.0%} pass-rate threshold",
+            "",
+            "| Assertion | Verdict | Passed | Wilson interval | Threshold |",
+            "| --- | --- | ---: | --- | ---: |",
+        ]
+        for result in self.aggregate_results:
+            lower, upper = result.confidence_interval
+            lines.append(
+                f"| `{result.check_name}` | **{result.verdict.value.upper()}** | "
+                f"{result.successes}/{result.trials} | "
+                f"{lower:.3f}–{upper:.3f} | {result.pass_rate_threshold:.3f} |"
+            )
+
+        lines.extend(
+            [
+                "",
+                "### Trial traces",
+                "",
+                "| Trial | Outcome | Trace | Process exit | Baseline changes |",
+                "| ---: | --- | --- | ---: | --- |",
+            ]
+        )
+        for trial in self.trials:
+            diff = trial.baseline_diff
+            changes = "not configured"
+            if diff is not None:
+                changed = list((diff.get("summary_diff") or {}).keys())
+                changed.extend(
+                    f"new tool: {tool}" for tool in diff.get("new_tools", [])
+                )
+                changes = ", ".join(changed) if changed else "none"
+            lines.append(
+                f"| {trial.trial} | {'PASS' if trial.passed else 'FAIL'} | "
+                f"`{trial.trace_id[:8]}` | {trial.process_exit_code} | {changes} |"
+            )
+
+        if self.verdict is GateVerdict.INCONCLUSIVE:
+            lines.extend(
+                [
+                    "",
+                    "> This result is neutral. Re-run the gate to collect a fresh trial set.",
+                ]
+            )
         return "\n".join(lines)
 
 
@@ -179,6 +247,7 @@ def run_trials(
 
             env = os.environ.copy()
             env["MAIDA_DATA_DIR"] = str(trial_data_dir)
+            env["MAIDA_TRIAL_INDEX"] = str(trial_number)
             completed = subprocess.run(
                 [sys.executable, str(relative_script)],
                 cwd=trial_root,
@@ -206,6 +275,11 @@ def run_trials(
             assertion_report = run_assertions(
                 trace_id, policy, baseline=baseline, config=config
             )
+            baseline_diff = (
+                asdict(compute_diff(trace_id, baseline=baseline, config=config))
+                if baseline is not None
+                else None
+            )
             records.append(
                 TrialRecord(
                     trial=trial_number,
@@ -215,6 +289,7 @@ def run_trials(
                     stdout=completed.stdout,
                     stderr=completed.stderr,
                     assertion_report=assertion_report,
+                    baseline_diff=baseline_diff,
                 )
             )
 

--- a/maida/scaffold.py
+++ b/maida/scaffold.py
@@ -74,6 +74,7 @@ jobs:
     permissions:
       contents: read
       pull-requests: write
+      checks: write
       # A repository_dispatch run belongs to the default branch, so publish the
       # gate result explicitly against the accepted PR-head SHA.
       statuses: write

--- a/schemas/statistical-gate-report.schema.json
+++ b/schemas/statistical-gate-report.schema.json
@@ -1,0 +1,86 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://github.com/maida-ai/maida/schemas/statistical-gate-report.schema.json",
+  "title": "Maida statistical gate report",
+  "type": "object",
+  "required": ["report_version", "verdict", "passed", "metadata", "trials", "aggregate_results"],
+  "properties": {
+    "report_version": { "const": "1" },
+    "trials_requested": { "type": "integer", "minimum": 1 },
+    "verdict": { "enum": ["pass", "fail", "inconclusive"] },
+    "passed": { "type": ["boolean", "null"] },
+    "metadata": {
+      "type": "object",
+      "required": ["trials_requested", "trials_completed", "confidence_level", "pass_rate_threshold"],
+      "properties": {
+        "trials_requested": { "type": "integer", "minimum": 1 },
+        "trials_completed": { "type": "integer", "minimum": 1 },
+        "confidence_level": { "type": "number", "exclusiveMinimum": 0, "exclusiveMaximum": 1 },
+        "pass_rate_threshold": { "type": "number", "minimum": 0, "maximum": 1 }
+      },
+      "additionalProperties": false
+    },
+    "trials": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": ["trial", "trace_id", "run_name", "process_exit_code", "passed", "checks", "baseline_diff"],
+        "properties": {
+          "trial": { "type": "integer", "minimum": 1 },
+          "trace_id": { "type": "string", "pattern": "^[0-9a-f]{32}$" },
+          "run_name": { "type": ["string", "null"] },
+          "process_exit_code": { "type": "integer" },
+          "passed": { "type": "boolean" },
+          "checks": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "required": ["check_name", "passed", "reason_code", "message", "expected", "actual", "ignored"],
+              "properties": {
+                "check_name": { "type": "string" },
+                "passed": { "type": "boolean" },
+                "reason_code": { "type": "string" },
+                "message": { "type": "string" },
+                "expected": { "type": ["string", "null"] },
+                "actual": { "type": ["string", "null"] },
+                "ignored": { "type": "boolean" }
+              },
+              "additionalProperties": false
+            }
+          },
+          "baseline_diff": { "type": ["object", "null"] }
+        },
+        "additionalProperties": false
+      }
+    },
+    "aggregate_results": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": ["check_name", "verdict", "trials", "successes", "pass_rate", "confidence_interval", "confidence_level", "pass_rate_threshold", "decision_rule", "trial_outcomes"],
+        "properties": {
+          "check_name": { "type": "string" },
+          "verdict": { "enum": ["pass", "fail", "inconclusive"] },
+          "trials": { "type": "integer", "minimum": 1 },
+          "successes": { "type": "integer", "minimum": 0 },
+          "pass_rate": { "type": "number", "minimum": 0, "maximum": 1 },
+          "confidence_interval": {
+            "type": "array",
+            "prefixItems": [
+              { "type": "number", "minimum": 0, "maximum": 1 },
+              { "type": "number", "minimum": 0, "maximum": 1 }
+            ],
+            "minItems": 2,
+            "maxItems": 2
+          },
+          "confidence_level": { "type": "number", "exclusiveMinimum": 0, "exclusiveMaximum": 1 },
+          "pass_rate_threshold": { "type": "number", "minimum": 0, "maximum": 1 },
+          "decision_rule": { "type": "string" },
+          "trial_outcomes": { "type": "array", "items": { "type": "boolean" } }
+        },
+        "additionalProperties": false
+      }
+    }
+  },
+  "additionalProperties": false
+}

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -837,6 +837,10 @@ def test_run_command_missing_script_exits_two(empty_data_dir, tmp_path, monkeypa
     assert "Agent script not found" in result.stderr
 
 
+def test_scaffold_grants_checks_write_permission():
+    assert "checks: write" in WORKFLOW_TEMPLATE
+
+
 def test_assert_exit_zero_on_pass(empty_data_dir):
     config = load_config()
     with traced_run(name="assert_test"):
@@ -1348,6 +1352,7 @@ def test_init_github_writes_valid_workflow(empty_data_dir, tmp_path, monkeypatch
     assert job["permissions"] == {
         "contents": "read",
         "pull-requests": "write",
+        "checks": "write",
         "statuses": "write",
     }
     assert "repository_dispatch" in job["if"]

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -26,6 +26,7 @@ from maida.scaffold import (
     CHECKOUT_ACTION_REF,
     MAIDA_ACCEPT_ACTION_REF,
     MAIDA_ASSERT_ACTION_REF,
+    WORKFLOW_TEMPLATE,
 )
 from maida.storage import list_runs
 from tests.conftest import get_latest_run_id

--- a/tests/test_runner.py
+++ b/tests/test_runner.py
@@ -8,10 +8,13 @@ from pathlib import Path
 
 import pytest
 
+from maida import record_tool_call, traced_run
 from maida.assertions import AssertionPolicy
+from maida.baseline import create_baseline
 from maida.config import load_config
 from maida.runner import RunExecutionError, run_trials
 from maida.statistics import GateVerdict
+from tests.conftest import get_latest_run_id
 
 
 def _git(*args: str, cwd: Path) -> None:
@@ -153,8 +156,80 @@ with traced_run(name="json-agent"):
     )
 
     payload = json.loads(report.to_json())
-    assert payload["trials_requested"] == 1
+    assert payload["report_version"] == "1"
+    assert payload["metadata"]["trials_requested"] == 1
+    assert payload["passed"] is True
+    assert payload["verdict"] == "pass"
     assert payload["trials"][0]["trial"] == 1
     assert payload["trials"][0]["run_name"] == "json-agent"
     assert payload["trials"][0]["process_exit_code"] == 0
     assert payload["trials"][0]["checks"][0]["check_name"] == "step_count"
+
+
+def test_trial_report_markdown_is_verdict_first_with_intervals_and_traces(
+    agent_repo: Path, temp_data_dir: Path
+) -> None:
+    _write_agent(
+        agent_repo,
+        "from maida import traced_run\nwith traced_run(name='markdown-agent'):\n    pass\n",
+    )
+    report = run_trials(
+        agent_repo / "agent.py",
+        trials=1,
+        policy=AssertionPolicy(max_steps=10),
+        config=load_config(project_root=agent_repo),
+        project_root=agent_repo,
+    )
+
+    markdown = report.to_markdown()
+    assert markdown.startswith("## ✅ Maida statistical gate: pass")
+    assert "Wilson interval" in markdown
+    assert "`step_count`" in markdown
+    assert f"`{report.trials[0].trace_id[:8]}`" in markdown
+
+
+def test_trial_report_records_each_baseline_diff(
+    agent_repo: Path, temp_data_dir: Path
+) -> None:
+    config = load_config(project_root=agent_repo)
+    with traced_run(name="baseline"):
+        record_tool_call("old-tool", args={}, result="ok")
+    baseline = create_baseline(get_latest_run_id(config), config)
+    _write_agent(
+        agent_repo,
+        """
+from maida import record_tool_call, traced_run
+with traced_run(name="candidate"):
+    record_tool_call("new-tool", args={}, result="ok")
+""".lstrip(),
+    )
+
+    report = run_trials(
+        agent_repo / "agent.py",
+        trials=1,
+        policy=AssertionPolicy(no_new_tools=True),
+        baseline=baseline,
+        config=config,
+        project_root=agent_repo,
+    )
+
+    assert report.trials[0].baseline_diff is not None
+    assert report.trials[0].baseline_diff["new_tools"] == ["new-tool"]
+
+
+def test_statistical_report_schema_pins_three_verdict_contract() -> None:
+    schema = json.loads(
+        (
+            Path(__file__).parents[1]
+            / "schemas"
+            / "statistical-gate-report.schema.json"
+        ).read_text(encoding="utf-8")
+    )
+
+    assert schema["properties"]["report_version"]["const"] == "1"
+    assert schema["properties"]["verdict"]["enum"] == [
+        "pass",
+        "fail",
+        "inconclusive",
+    ]
+    assert schema["properties"]["passed"]["type"] == ["boolean", "null"]


### PR DESCRIPTION
Defined the Maida-side machine and Markdown contracts required for a CI consumer to map INCONCLUSIVE to a neutral check instead of a failure. The CLI now emits a versioned tri-state JSON report, writes an optional JSON sidecar, and exits zero for both PASS and INCONCLUSIVE while reserving exit one for FAIL.

**Changes**

- Added `schemas/statistical-gate-report.schema.json` with `pass`, `fail`, and `inconclusive` verdicts and a nullable compatibility `passed` field.
- Added verdict-first Markdown containing Wilson intervals, thresholds, trial traces, process outcomes, and baseline change summaries.
- Added atomic `--json-out` sidecar output and Markdown format support to `maida run`.
- Added `checks: write` to the scaffolded GitHub workflow permissions.

**Tests**

`uv run ruff check maida/runner.py maida/cli.py maida/scaffold.py tests/test_runner.py tests/test_cli.py`

Fixes #140 

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>