### PR TITLE
OTel ingestion for Claude Code telemetry


### DIFF
--- a/.github/workflows/claude-code-capture-smoke.yml
+++ b/.github/workflows/claude-code-capture-smoke.yml
@@ -1,0 +1,37 @@
+name: Claude Code capture smoke
+
+on:
+  pull_request:
+    paths:
+      - "maida/capture/**"
+      - "scripts/claude_code_capture_smoke.py"
+      - ".github/workflows/claude-code-capture-smoke.yml"
+      - "pyproject.toml"
+      - "uv.lock"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  offline-real-cli:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@v7
+      - uses: actions/setup-node@v6
+        with:
+          node-version: "22"
+      - uses: astral-sh/setup-uv@v7
+        with:
+          version: "0.11.25"
+          enable-cache: true
+      - uses: actions/setup-python@v6
+        with:
+          python-version: "3.13"
+      - name: Install pinned Claude Code
+        run: npm install --global @anthropic-ai/claude-code@2.1.220
+      - name: Install Maida
+        run: uv sync --dev
+      - name: Run isolated canned capture smoke
+        run: uv run python scripts/claude_code_capture_smoke.py

--- a/README.md
+++ b/README.md
@@ -264,6 +264,17 @@ maida diff <RUN_A> <RUN_B>
 maida diff --baseline .maida/baselines/my_agent.json  # latest run vs baseline
 ```
 
+### Capture Claude Code without agent patches
+
+```bash
+maida capture claude-code
+```
+
+Point Claude Code's OTLP HTTP/protobuf logs and beta traces at
+`http://127.0.0.1:4318`. Maida validates, redacts, and persists the source
+capture locally for later import and gating. See
+[docs/claude-code.md](docs/claude-code.md) for the complete configuration.
+
 
 ## Regression testing
 

--- a/docs/claude-code.md
+++ b/docs/claude-code.md
@@ -1,0 +1,56 @@
+# Capture Claude Code telemetry
+
+Maida can receive Claude Code's OpenTelemetry events and beta traces without
+patching agent code. The receiver binds to loopback by default and writes only
+to local Maida storage.
+
+Start the receiver:
+
+```bash
+maida capture claude-code
+```
+
+In a second terminal, configure Claude Code to export logs and traces over
+OTLP HTTP/protobuf:
+
+```bash
+export CLAUDE_CODE_ENABLE_TELEMETRY=1
+export CLAUDE_CODE_ENHANCED_TELEMETRY_BETA=1
+export OTEL_LOGS_EXPORTER=otlp
+export OTEL_TRACES_EXPORTER=otlp
+export OTEL_EXPORTER_OTLP_PROTOCOL=http/protobuf
+export OTEL_EXPORTER_OTLP_ENDPOINT=http://127.0.0.1:4318
+export OTEL_LOG_USER_PROMPTS=0
+export OTEL_LOG_ASSISTANT_RESPONSES=0
+export OTEL_LOG_TOOL_CONTENT=0
+claude -p "Inspect the project and report its test command."
+```
+
+The receiver exposes `GET /healthz`, `POST /v1/logs`, and
+`POST /v1/traces`. It requires protobuf requests from the `claude-code`
+service, validates a complete export batch before writing, and rejects
+malformed known signals. Unknown newer signals are retained so an additive
+Claude Code update does not silently discard source evidence.
+
+Captures are stored under:
+
+```text
+~/.maida/captures/claude-code/<hashed-session-id>/<segment>/
+├── manifest.json
+├── logs.jsonl
+└── spans.jsonl
+```
+
+Session directory names never contain the raw Claude session ID. Existing
+Maida redaction and field-size limits apply recursively before persistence;
+numeric duration and token counters remain available for regression policy.
+Exact exporter retries are deduplicated, while the receiver rejects a retry
+that reuses a source identity with different content.
+
+Use `--host` and `--port` to change the bind address. Keep the receiver on a
+trusted interface: it intentionally has no authentication because its default
+use is a local process or an isolated CI job.
+
+See Claude Code's official [monitoring
+reference](https://code.claude.com/docs/en/monitoring-usage) for exporter
+variables and the beta trace hierarchy.

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -6,6 +6,24 @@ Commands that take a run ID (`assert`, `baseline`, `accept`, `export`, `diff`) d
 
 ---
 
+## `maida capture claude-code`
+
+Starts a local OTLP HTTP/protobuf receiver for Claude Code logs and beta traces.
+
+```bash
+maida capture claude-code [--host 127.0.0.1] [--port 4318]
+```
+
+The receiver provides `/healthz`, `/v1/logs`, and `/v1/traces`, validates and
+redacts batches before writing, and stores source captures under
+`~/.maida/captures/claude-code/`. Progress is written to stderr. See
+[Capture Claude Code telemetry](claude-code.md) for exporter configuration and
+the local storage contract.
+
+**Exit codes:** `0` after normal shutdown; `10` receiver startup/runtime error.
+
+---
+
 ## `maida demo`
 
 Runs a bundled simulated customer-support agent and records a trace. No network, no API keys; all LLM/tool data is canned and nothing leaves your machine.

--- a/maida/capture/__init__.py
+++ b/maida/capture/__init__.py
@@ -1,0 +1,1 @@
+"""Local capture sources that feed Maida's normalized trace pipeline."""

--- a/maida/capture/claude_code.py
+++ b/maida/capture/claude_code.py
@@ -1,0 +1,729 @@
+"""Loopback OTLP/HTTP receiver for Claude Code telemetry."""
+
+from __future__ import annotations
+
+import base64
+import fcntl
+import hashlib
+import json
+import os
+import threading
+import uuid
+from contextlib import contextmanager
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any, Iterator
+
+from fastapi import FastAPI, HTTPException, Request, Response
+from google.protobuf.message import DecodeError
+from opentelemetry.proto.collector.logs.v1.logs_service_pb2 import (
+    ExportLogsServiceRequest,
+    ExportLogsServiceResponse,
+)
+from opentelemetry.proto.collector.trace.v1.trace_service_pb2 import (
+    ExportTraceServiceRequest,
+    ExportTraceServiceResponse,
+)
+
+from maida._tracing._redact import (
+    _key_matches_redact,
+    _truncate_string,
+)
+from maida.config import MaidaConfig
+from maida.constants import REDACTED_MARKER, TRUNCATED_MARKER
+from maida.events import utc_now_iso_ms_z
+
+DEFAULT_MAX_REQUEST_BYTES = 8 * 1024 * 1024
+_PROTOBUF_CONTENT_TYPES = frozenset({"application/x-protobuf", "application/protobuf"})
+_SERVICE_NAME = "claude-code"
+_SEGMENT = "0001"
+_TOKEN_COUNTERS = frozenset(
+    {
+        "input_tokens",
+        "output_tokens",
+        "cache_read_tokens",
+        "cache_creation_tokens",
+        "result_tokens",
+        "prompt_tokens",
+        "completion_tokens",
+        "total_tokens",
+        "totalTokens",
+    }
+)
+_NONNEGATIVE_FIELDS = _TOKEN_COUNTERS | frozenset(
+    {
+        "duration_ms",
+        "interaction.duration_ms",
+        "ttft_ms",
+        "prompt_length",
+        "response_length",
+        "tool_input_size_bytes",
+        "tool_result_size_bytes",
+        "cost_usd",
+        "cost_usd_micros",
+        "attempt",
+        "event.sequence",
+        "num_hooks",
+        "num_success",
+        "num_blocking",
+        "num_non_blocking_error",
+        "num_cancelled",
+    }
+)
+_JSON_CONTENT_FIELDS = frozenset(
+    {
+        "body",
+        "hook_definitions",
+        "tool_input",
+        "tool_parameters",
+    }
+)
+_KNOWN_LOG_EVENTS = frozenset(
+    {
+        "claude_code.user_prompt",
+        "claude_code.assistant_response",
+        "claude_code.tool_result",
+        "claude_code.api_request",
+        "claude_code.api_error",
+        "claude_code.api_refusal",
+        "claude_code.api_request_body",
+        "claude_code.api_response_body",
+        "claude_code.tool_decision",
+        "claude_code.permission_mode_changed",
+        "claude_code.auth",
+        "claude_code.mcp_server_connection",
+        "claude_code.internal_error",
+        "claude_code.plugin_installed",
+        "claude_code.plugin_loaded",
+        "claude_code.skill_activated",
+        "claude_code.at_mention",
+        "claude_code.api_retries_exhausted",
+        "claude_code.hook_registered",
+        "claude_code.hook_execution_start",
+        "claude_code.hook_execution_complete",
+        "claude_code.hook_plugin_metrics",
+        "claude_code.compaction",
+        "claude_code.feedback_survey",
+    }
+)
+_KNOWN_SPANS = frozenset(
+    {
+        "claude_code.interaction",
+        "claude_code.llm_request",
+        "claude_code.tool",
+        "claude_code.tool.blocked_on_user",
+        "claude_code.tool.execution",
+        "claude_code.hook",
+    }
+)
+_REQUIRED_LOG_FIELDS: dict[str, tuple[str, ...]] = {
+    "claude_code.user_prompt": ("prompt_length",),
+    "claude_code.assistant_response": ("response_length", "model"),
+    "claude_code.tool_result": (
+        "tool_name",
+        "tool_use_id",
+        "success",
+        "duration_ms",
+    ),
+    "claude_code.api_request": (
+        "model",
+        "duration_ms",
+        "input_tokens",
+        "output_tokens",
+    ),
+    "claude_code.api_error": ("model", "duration_ms", "attempt"),
+    "claude_code.tool_decision": (
+        "tool_name",
+        "tool_use_id",
+        "decision",
+    ),
+}
+_REQUIRED_SPAN_FIELDS: dict[str, tuple[str, ...]] = {
+    "claude_code.interaction": ("interaction.duration_ms",),
+    "claude_code.llm_request": (
+        "model",
+        "duration_ms",
+        "input_tokens",
+        "output_tokens",
+        "success",
+    ),
+    "claude_code.tool": ("tool_name", "duration_ms", "tool_use_id"),
+    "claude_code.tool.blocked_on_user": ("duration_ms", "decision"),
+    "claude_code.tool.execution": ("duration_ms", "tool_use_id", "success"),
+    "claude_code.hook": ("hook_event", "hook_name", "duration_ms"),
+}
+
+
+class CaptureValidationError(ValueError):
+    """An OTLP batch does not satisfy the Claude Code capture contract."""
+
+
+class CaptureConflictError(RuntimeError):
+    """A source identity was delivered again with different content."""
+
+
+def _any_value(value: Any) -> Any:
+    kind = value.WhichOneof("value")
+    if kind is None:
+        return None
+    if kind == "array_value":
+        return [_any_value(item) for item in value.array_value.values]
+    if kind == "kvlist_value":
+        return _attributes(value.kvlist_value.values)
+    if kind == "bytes_value":
+        return {"bytes_b64": base64.b64encode(value.bytes_value).decode("ascii")}
+    return getattr(value, kind)
+
+
+def _attributes(values: Any) -> dict[str, Any]:
+    result: dict[str, Any] = {}
+    for item in values:
+        if item.key in result:
+            raise CaptureValidationError(f"duplicate attribute {item.key!r}")
+        result[item.key] = _any_value(item.value)
+    return result
+
+
+def _json_sanitize_string(value: str, config: MaidaConfig) -> str:
+    try:
+        decoded = json.loads(value)
+    except (json.JSONDecodeError, TypeError):
+        return _truncate_string(value, config.max_field_bytes)
+    return json.dumps(
+        _sanitize(decoded, config),
+        ensure_ascii=False,
+        separators=(",", ":"),
+    )
+
+
+def _sanitize(
+    value: Any, config: MaidaConfig, *, key: str | None = None, depth: int = 0
+) -> Any:
+    if depth > 12:
+        return TRUNCATED_MARKER
+    if (
+        key in _TOKEN_COUNTERS
+        and isinstance(value, int)
+        and not isinstance(value, bool)
+    ):
+        return value
+    if (
+        key is not None
+        and config.redact
+        and _key_matches_redact(key, config.redact_keys)
+    ):
+        return REDACTED_MARKER
+    if value is None or isinstance(value, (bool, int, float)):
+        return value
+    if isinstance(value, str):
+        if key in _JSON_CONTENT_FIELDS:
+            return _json_sanitize_string(value, config)
+        return _truncate_string(value, config.max_field_bytes)
+    if isinstance(value, dict):
+        return {
+            str(child_key): _sanitize(
+                child_value,
+                config,
+                key=str(child_key),
+                depth=depth + 1,
+            )
+            for child_key, child_value in value.items()
+        }
+    if isinstance(value, (list, tuple)):
+        return [_sanitize(item, config, depth=depth + 1) for item in value]
+    return _truncate_string(str(value), config.max_field_bytes)
+
+
+def _session_hash(session_id: str) -> str:
+    return hashlib.sha256(session_id.encode("utf-8")).hexdigest()
+
+
+def _require_service(resource: dict[str, Any]) -> None:
+    if resource.get("service.name") != _SERVICE_NAME:
+        raise CaptureValidationError("resource service.name must be 'claude-code'")
+
+
+def _session_id(resource: dict[str, Any], attributes: dict[str, Any]) -> str:
+    value = attributes.get("session.id", resource.get("session.id"))
+    if not isinstance(value, str) or not value.strip():
+        raise CaptureValidationError("session.id must be a nonempty string")
+    return value.strip()
+
+
+def _event_name(record: Any, attributes: dict[str, Any], body: Any) -> str:
+    value = getattr(record, "event_name", "") or attributes.get("event.name")
+    if not value and isinstance(body, str):
+        value = body
+    if not isinstance(value, str) or not value.strip():
+        raise CaptureValidationError("log record is missing event.name")
+    value = value.strip()
+    if not value.startswith("claude_code."):
+        value = f"claude_code.{value}"
+    return value
+
+
+def _validate_fields(
+    signal_name: str,
+    attributes: dict[str, Any],
+    *,
+    known_names: frozenset[str],
+    required: dict[str, tuple[str, ...]],
+) -> None:
+    if signal_name not in known_names:
+        return
+    missing = [
+        field for field in required.get(signal_name, ()) if field not in attributes
+    ]
+    if missing:
+        raise CaptureValidationError(
+            f"{signal_name} is missing required field(s): {', '.join(missing)}"
+        )
+    for field in _NONNEGATIVE_FIELDS:
+        value = attributes.get(field)
+        if value is None:
+            continue
+        if isinstance(value, bool) or not isinstance(value, (int, float)) or value < 0:
+            raise CaptureValidationError(
+                f"{signal_name} field {field!r} must be nonnegative"
+            )
+    if signal_name == "claude_code.api_error" and attributes.get("attempt", 0) < 1:
+        raise CaptureValidationError("claude_code.api_error attempt must be at least 1")
+    if signal_name in {"claude_code.tool_result", "claude_code.tool.execution"}:
+        if not isinstance(attributes.get("success"), (bool, str)):
+            raise CaptureValidationError(f"{signal_name} success must be boolean-like")
+    if signal_name == "claude_code.tool_decision" and attributes.get(
+        "decision"
+    ) not in {
+        "accept",
+        "reject",
+    }:
+        raise CaptureValidationError("claude_code.tool_decision has invalid decision")
+
+
+def _valid_trace_id(value: bytes, *, optional: bool = False) -> str:
+    if optional and not value:
+        return ""
+    if len(value) != 16 or not any(value):
+        raise CaptureValidationError("trace_id must be a nonzero 16-byte identifier")
+    return value.hex()
+
+
+def _valid_span_id(value: bytes, *, optional: bool = False) -> str:
+    if optional and not value:
+        return ""
+    if len(value) != 8 or not any(value):
+        raise CaptureValidationError("span_id must be a nonzero 8-byte identifier")
+    return value.hex()
+
+
+def _scope(scope: Any) -> dict[str, Any]:
+    return {
+        "name": scope.name,
+        "version": scope.version,
+        "attributes": _attributes(scope.attributes),
+        "dropped_attributes_count": scope.dropped_attributes_count,
+    }
+
+
+def _decode_logs(
+    request: ExportLogsServiceRequest, config: MaidaConfig
+) -> list[dict[str, Any]]:
+    decoded: list[dict[str, Any]] = []
+    for resource_logs in request.resource_logs:
+        resource = _attributes(resource_logs.resource.attributes)
+        _require_service(resource)
+        for scope_logs in resource_logs.scope_logs:
+            scope = _scope(scope_logs.scope)
+            for record in scope_logs.log_records:
+                attributes = _attributes(record.attributes)
+                session_id = _session_id(resource, attributes)
+                body = _any_value(record.body)
+                event_name = _event_name(record, attributes, body)
+                _validate_fields(
+                    event_name,
+                    attributes,
+                    known_names=_KNOWN_LOG_EVENTS,
+                    required=_REQUIRED_LOG_FIELDS,
+                )
+                trace_id = _valid_trace_id(record.trace_id, optional=True)
+                span_id = _valid_span_id(record.span_id, optional=True)
+                session_hash = _session_hash(session_id)
+                attributes["session.id"] = session_hash
+                resource = dict(resource)
+                if "session.id" in resource:
+                    resource["session.id"] = session_hash
+                decoded.append(
+                    _sanitize(
+                        {
+                            "resource": {
+                                "attributes": resource,
+                                "dropped_attributes_count": resource_logs.resource.dropped_attributes_count,
+                                "schema_url": resource_logs.schema_url,
+                            },
+                            "scope": scope,
+                            "record": {
+                                "event_name": event_name,
+                                "time_unix_nano": record.time_unix_nano,
+                                "observed_time_unix_nano": record.observed_time_unix_nano,
+                                "severity_number": record.severity_number,
+                                "severity_text": record.severity_text,
+                                "body": body,
+                                "attributes": attributes,
+                                "dropped_attributes_count": record.dropped_attributes_count,
+                                "flags": record.flags,
+                                "trace_id": trace_id,
+                                "span_id": span_id,
+                            },
+                            "session_hash": session_hash,
+                        },
+                        config,
+                    )
+                )
+    if not decoded:
+        raise CaptureValidationError("OTLP logs batch is empty")
+    return decoded
+
+
+def _span_event(event: Any) -> dict[str, Any]:
+    return {
+        "time_unix_nano": event.time_unix_nano,
+        "name": event.name,
+        "attributes": _attributes(event.attributes),
+        "dropped_attributes_count": event.dropped_attributes_count,
+    }
+
+
+def _span_link(link: Any) -> dict[str, Any]:
+    return {
+        "trace_id": _valid_trace_id(link.trace_id),
+        "span_id": _valid_span_id(link.span_id),
+        "trace_state": link.trace_state,
+        "attributes": _attributes(link.attributes),
+        "dropped_attributes_count": link.dropped_attributes_count,
+        "flags": link.flags,
+    }
+
+
+def _status_code(status: Any) -> str:
+    names = {0: "UNSET", 1: "OK", 2: "ERROR"}
+    if status.code not in names:
+        raise CaptureValidationError("span has invalid status code")
+    return names[status.code]
+
+
+def _nanos_iso(value: int) -> str:
+    if value <= 0:
+        raise CaptureValidationError("span timestamps must be positive")
+    return (
+        datetime.fromtimestamp(value / 1_000_000_000, timezone.utc)
+        .isoformat()
+        .replace("+00:00", "Z")
+    )
+
+
+def _decode_traces(
+    request: ExportTraceServiceRequest, config: MaidaConfig
+) -> list[dict[str, Any]]:
+    decoded: list[dict[str, Any]] = []
+    for resource_spans in request.resource_spans:
+        resource = _attributes(resource_spans.resource.attributes)
+        _require_service(resource)
+        for scope_spans in resource_spans.scope_spans:
+            scope = _scope(scope_spans.scope)
+            for span in scope_spans.spans:
+                attributes = _attributes(span.attributes)
+                session_id = _session_id(resource, attributes)
+                if span.name in _KNOWN_SPANS:
+                    _validate_fields(
+                        span.name,
+                        attributes,
+                        known_names=_KNOWN_SPANS,
+                        required=_REQUIRED_SPAN_FIELDS,
+                    )
+                trace_id = _valid_trace_id(span.trace_id)
+                span_id = _valid_span_id(span.span_id)
+                parent_span_id = _valid_span_id(span.parent_span_id, optional=True)
+                if span.end_time_unix_nano < span.start_time_unix_nano:
+                    raise CaptureValidationError("span end time precedes start time")
+                duration_ms = (
+                    span.end_time_unix_nano - span.start_time_unix_nano
+                ) // 1_000_000
+                session_hash = _session_hash(session_id)
+                attributes["session.id"] = session_hash
+                resource = dict(resource)
+                if "session.id" in resource:
+                    resource["session.id"] = session_hash
+                decoded.append(
+                    _sanitize(
+                        {
+                            "resource": {
+                                "attributes": resource,
+                                "dropped_attributes_count": resource_spans.resource.dropped_attributes_count,
+                                "schema_url": resource_spans.schema_url,
+                            },
+                            "scope": scope,
+                            "span": {
+                                "trace_id": trace_id,
+                                "span_id": span_id,
+                                "trace_state": span.trace_state,
+                                "parent_span_id": parent_span_id or None,
+                                "flags": span.flags,
+                                "name": span.name,
+                                "kind": int(span.kind),
+                                "start_time_unix_nano": span.start_time_unix_nano,
+                                "end_time_unix_nano": span.end_time_unix_nano,
+                                "start_time": _nanos_iso(span.start_time_unix_nano),
+                                "end_time": _nanos_iso(span.end_time_unix_nano),
+                                "duration_ms": duration_ms,
+                                "attributes": attributes,
+                                "events": [_span_event(event) for event in span.events],
+                                "links": [_span_link(link) for link in span.links],
+                                "dropped_attributes_count": span.dropped_attributes_count,
+                                "dropped_events_count": span.dropped_events_count,
+                                "dropped_links_count": span.dropped_links_count,
+                                "status_code": _status_code(span.status),
+                                "status_description": span.status.message,
+                            },
+                            "session_hash": session_hash,
+                        },
+                        config,
+                    )
+                )
+    if not decoded:
+        raise CaptureValidationError("OTLP traces batch is empty")
+    return decoded
+
+
+def _canonical(record: dict[str, Any]) -> str:
+    return json.dumps(record, ensure_ascii=False, sort_keys=True, separators=(",", ":"))
+
+
+def _record_identity(record: dict[str, Any], signal: str) -> str:
+    source = record["record"] if signal == "logs" else record["span"]
+    if signal == "spans":
+        parts = (record["session_hash"], source["trace_id"], source["span_id"])
+    else:
+        attrs = source["attributes"]
+        parts = (
+            record["session_hash"],
+            source["event_name"],
+            attrs.get("event.sequence"),
+            source.get("time_unix_nano"),
+            source.get("trace_id"),
+            source.get("span_id"),
+            attrs.get("tool_use_id"),
+            attrs.get("request_id"),
+            attrs.get("prompt.id"),
+        )
+    return hashlib.sha256(repr(parts).encode("utf-8")).hexdigest()
+
+
+def _read_jsonl(path: Path) -> list[dict[str, Any]]:
+    if not path.is_file():
+        return []
+    records: list[dict[str, Any]] = []
+    with path.open(encoding="utf-8") as stream:
+        for line_no, line in enumerate(stream, 1):
+            if not line.strip():
+                continue
+            try:
+                value = json.loads(line)
+            except json.JSONDecodeError as exc:
+                raise CaptureConflictError(
+                    f"existing capture {path} line {line_no} is invalid JSON"
+                ) from exc
+            if not isinstance(value, dict):
+                raise CaptureConflictError(
+                    f"existing capture {path} line {line_no} is not an object"
+                )
+            records.append(value)
+    return records
+
+
+def _atomic_json(path: Path, payload: dict[str, Any]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    temporary = path.with_name(f".{path.name}.{uuid.uuid4().hex}.tmp")
+    with temporary.open("w", encoding="utf-8") as stream:
+        json.dump(payload, stream, ensure_ascii=False, indent=2, sort_keys=True)
+        stream.write("\n")
+        stream.flush()
+        os.fsync(stream.fileno())
+    os.replace(temporary, path)
+
+
+def _atomic_jsonl(path: Path, records: list[dict[str, Any]]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    temporary = path.with_name(f".{path.name}.{uuid.uuid4().hex}.tmp")
+    with temporary.open("w", encoding="utf-8") as stream:
+        for record in records:
+            stream.write(_canonical(record) + "\n")
+        stream.flush()
+        os.fsync(stream.fileno())
+    os.replace(temporary, path)
+
+
+_PROCESS_LOCK = threading.RLock()
+
+
+@contextmanager
+def _capture_lock(root: Path) -> Iterator[None]:
+    root.mkdir(parents=True, exist_ok=True)
+    lock_path = root / ".claude-code.lock"
+    with _PROCESS_LOCK, lock_path.open("a+") as lock_file:
+        fcntl.flock(lock_file.fileno(), fcntl.LOCK_EX)
+        try:
+            yield
+        finally:
+            fcntl.flock(lock_file.fileno(), fcntl.LOCK_UN)
+
+
+def _capture_dir(config: MaidaConfig, session_hash: str) -> Path:
+    return (
+        config.data_dir.expanduser()
+        / "captures"
+        / _SERVICE_NAME
+        / session_hash
+        / _SEGMENT
+    )
+
+
+def _store(
+    records: list[dict[str, Any]], signal: str, config: MaidaConfig
+) -> tuple[int, int]:
+    filename = "logs.jsonl" if signal == "logs" else "spans.jsonl"
+    groups: dict[str, list[dict[str, Any]]] = {}
+    for record in records:
+        groups.setdefault(record["session_hash"], []).append(record)
+
+    captures_root = config.data_dir.expanduser() / "captures"
+    accepted = 0
+    deduplicated = 0
+    with _capture_lock(captures_root):
+        planned: list[tuple[Path, list[dict[str, Any]], list[dict[str, Any]]]] = []
+        for session_hash, incoming in groups.items():
+            path = _capture_dir(config, session_hash) / filename
+            existing = _read_jsonl(path)
+            identities = {
+                _record_identity(item, signal): _canonical(item) for item in existing
+            }
+            additions: list[dict[str, Any]] = []
+            for item in incoming:
+                identity = _record_identity(item, signal)
+                canonical = _canonical(item)
+                previous = identities.get(identity)
+                if previous is None:
+                    identities[identity] = canonical
+                    additions.append(item)
+                elif previous == canonical:
+                    deduplicated += 1
+                else:
+                    raise CaptureConflictError(
+                        "conflicting duplicate Claude Code telemetry identity"
+                    )
+            planned.append((path, existing, additions))
+
+        now = utc_now_iso_ms_z()
+        for path, existing, additions in planned:
+            if additions:
+                _atomic_jsonl(path, existing + additions)
+                accepted += len(additions)
+            segment_dir = path.parent
+            manifest_path = segment_dir / "manifest.json"
+            manifest = {
+                "capture_version": 1,
+                "source": _SERVICE_NAME,
+                "session_hash": segment_dir.parent.name,
+                "segment": _SEGMENT,
+                "created_at": now,
+                "updated_at": now,
+                "signals": {},
+            }
+            if manifest_path.is_file():
+                with manifest_path.open(encoding="utf-8") as stream:
+                    current = json.load(stream)
+                if isinstance(current, dict):
+                    manifest.update(current)
+                    manifest["updated_at"] = now
+            signals = dict(manifest.get("signals") or {})
+            signals[signal] = len(existing) + len(additions)
+            manifest["signals"] = signals
+            _atomic_json(manifest_path, manifest)
+    return accepted, deduplicated
+
+
+async def _body(request: Request, max_request_bytes: int) -> bytes:
+    content_type = (
+        request.headers.get("content-type", "").split(";", 1)[0].strip().lower()
+    )
+    if content_type not in _PROTOBUF_CONTENT_TYPES:
+        raise HTTPException(
+            status_code=415, detail="content type must be application/x-protobuf"
+        )
+    content_length = request.headers.get("content-length")
+    if content_length:
+        try:
+            if int(content_length) > max_request_bytes:
+                raise HTTPException(status_code=413, detail="OTLP request is too large")
+        except ValueError as exc:
+            raise HTTPException(
+                status_code=400, detail="invalid Content-Length"
+            ) from exc
+    body = await request.body()
+    if len(body) > max_request_bytes:
+        raise HTTPException(status_code=413, detail="OTLP request is too large")
+    if not body:
+        raise HTTPException(status_code=400, detail="OTLP request body is empty")
+    return body
+
+
+def create_claude_code_app(
+    config: MaidaConfig,
+    *,
+    max_request_bytes: int = DEFAULT_MAX_REQUEST_BYTES,
+) -> FastAPI:
+    """Create the isolated loopback OTLP application."""
+    app = FastAPI(title="Maida Claude Code capture", docs_url=None, redoc_url=None)
+
+    @app.get("/healthz")
+    def health() -> dict[str, str]:
+        return {"status": "ok"}
+
+    @app.post("/v1/logs")
+    async def logs(request: Request) -> Response:
+        body = await _body(request, max_request_bytes)
+        message = ExportLogsServiceRequest()
+        try:
+            message.ParseFromString(body)
+            decoded = _decode_logs(message, config)
+            _store(decoded, "logs", config)
+        except DecodeError as exc:
+            raise HTTPException(
+                status_code=400, detail="invalid OTLP logs protobuf"
+            ) from exc
+        except CaptureValidationError as exc:
+            raise HTTPException(status_code=400, detail=str(exc)) from exc
+        except CaptureConflictError as exc:
+            raise HTTPException(status_code=409, detail=str(exc)) from exc
+        response = ExportLogsServiceResponse().SerializeToString()
+        return Response(response, media_type="application/x-protobuf")
+
+    @app.post("/v1/traces")
+    async def traces(request: Request) -> Response:
+        body = await _body(request, max_request_bytes)
+        message = ExportTraceServiceRequest()
+        try:
+            message.ParseFromString(body)
+            decoded = _decode_traces(message, config)
+            _store(decoded, "spans", config)
+        except DecodeError as exc:
+            raise HTTPException(
+                status_code=400, detail="invalid OTLP traces protobuf"
+            ) from exc
+        except CaptureValidationError as exc:
+            raise HTTPException(status_code=400, detail=str(exc)) from exc
+        except CaptureConflictError as exc:
+            raise HTTPException(status_code=409, detail=str(exc)) from exc
+        response = ExportTraceServiceResponse().SerializeToString()
+        return Response(response, media_type="application/x-protobuf")
+
+    return app

--- a/maida/capture/claude_code.py
+++ b/maida/capture/claude_code.py
@@ -300,6 +300,24 @@ def _validate_fields(
         raise CaptureValidationError("claude_code.tool_decision has invalid decision")
 
 
+def _coerce_known_scalars(attributes: dict[str, Any]) -> dict[str, Any]:
+    """Normalize Claude's OTel log string encoding for numeric signal fields."""
+    normalized = dict(attributes)
+    for field in _NONNEGATIVE_FIELDS:
+        value = normalized.get(field)
+        if not isinstance(value, str) or not value.strip():
+            continue
+        text = value.strip()
+        try:
+            if any(character in text.lower() for character in (".", "e")):
+                normalized[field] = float(text)
+            else:
+                normalized[field] = int(text)
+        except ValueError:
+            pass
+    return normalized
+
+
 def _valid_trace_id(value: bytes, *, optional: bool = False) -> str:
     if optional and not value:
         return ""
@@ -335,7 +353,7 @@ def _decode_logs(
         for scope_logs in resource_logs.scope_logs:
             scope = _scope(scope_logs.scope)
             for record in scope_logs.log_records:
-                attributes = _attributes(record.attributes)
+                attributes = _coerce_known_scalars(_attributes(record.attributes))
                 session_id = _session_id(resource, attributes)
                 body = _any_value(record.body)
                 event_name = _event_name(record, attributes, body)

--- a/maida/cli.py
+++ b/maida/cli.py
@@ -36,6 +36,7 @@ from maida.baseline import (
     load_baseline,
     save_baseline,
 )
+from maida.capture.claude_code import create_claude_code_app
 from maida.config import load_config
 from maida.constants import LOCAL_DIR_NAME, SPEC_VERSION
 from maida.demo import (
@@ -68,7 +69,9 @@ EXIT_INTERNAL = 10
 _DEMO_TRACE_DURATION_MS = 120
 
 app = typer.Typer(help="Capture, inspect, and gate agent behavior.")
+capture_app = typer.Typer(help="Capture external agent behavior locally.")
 import_app = typer.Typer(help="Import existing traces into local Maida storage.")
+app.add_typer(capture_app, name="capture")
 app.add_typer(import_app, name="import")
 
 
@@ -165,6 +168,45 @@ def _emit_langfuse_error(
         )
     else:
         typer.echo(f"{prefix}: {error}", err=True)
+
+
+@capture_app.command("claude-code")
+def capture_claude_code_cmd(
+    host: str = typer.Option(
+        "127.0.0.1",
+        "--host",
+        help="OTLP HTTP bind host",
+    ),
+    port: int = typer.Option(
+        4318,
+        "--port",
+        min=1,
+        max=65535,
+        help="OTLP HTTP bind port",
+    ),
+) -> None:
+    """Receive Claude Code logs and beta traces over OTLP HTTP/protobuf."""
+    try:
+        import uvicorn
+
+        config = load_config()
+        receiver = create_claude_code_app(config)
+        typer.echo(
+            f"Listening for Claude Code OTLP on http://{host}:{port}",
+            err=True,
+        )
+        uvicorn.run(
+            app=receiver,
+            host=host,
+            port=port,
+            access_log=False,
+            log_level="warning",
+        )
+    except (KeyboardInterrupt, typer.Exit):
+        raise
+    except Exception as exc:
+        typer.echo(f"error: {exc}", err=True)
+        raise Exit(EXIT_INTERNAL)
 
 
 @import_app.command("langfuse")

--- a/maida/cli.py
+++ b/maida/cli.py
@@ -18,6 +18,7 @@ from pathlib import Path
 from typing import Annotated
 
 import typer
+import uvicorn
 from typer import Exit
 
 import maida.storage as storage
@@ -187,8 +188,6 @@ def capture_claude_code_cmd(
 ) -> None:
     """Receive Claude Code logs and beta traces over OTLP HTTP/protobuf."""
     try:
-        import uvicorn
-
         config = load_config()
         receiver = create_claude_code_app(config)
         typer.echo(

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,6 +14,7 @@ dependencies = [
     "fastapi>=0.138.0,<0.139.0",
     "opentelemetry-api>=1.42.0",
     "opentelemetry-exporter-otlp-proto-http>=1.42.0",
+    "opentelemetry-proto>=1.42.0",
     "opentelemetry-sdk>=1.42.0",
     "pyyaml>=6.0.3,<6.1.0",
     "typer>=0.26.8,<0.27.0",

--- a/scripts/claude_code_capture_smoke.py
+++ b/scripts/claude_code_capture_smoke.py
@@ -1,0 +1,355 @@
+#!/usr/bin/env python3
+"""Offline real-Claude smoke for the Claude Code OTLP capture path."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import socket
+import subprocess
+import tempfile
+import threading
+import time
+from dataclasses import replace
+from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
+from pathlib import Path
+from typing import Any
+
+import uvicorn
+
+from maida.capture.claude_code import create_claude_code_app
+from maida.config import load_config
+
+PINNED_CLAUDE_VERSION = "2.1.220"
+SESSION_ID = "06106d0c-8a68-4ac7-a5d8-3448ff8e0243"
+
+
+def _sse(events: list[dict[str, Any]]) -> bytes:
+    chunks = []
+    for event in events:
+        chunks.append(f"event: {event['type']}\ndata: {json.dumps(event)}\n\n")
+    return "".join(chunks).encode("utf-8")
+
+
+def _message_start(message_id: str) -> dict[str, Any]:
+    return {
+        "type": "message_start",
+        "message": {
+            "id": message_id,
+            "type": "message",
+            "role": "assistant",
+            "model": "claude-test",
+            "content": [],
+            "stop_reason": None,
+            "stop_sequence": None,
+            "usage": {
+                "input_tokens": 9,
+                "output_tokens": 1,
+                "cache_creation_input_tokens": 0,
+                "cache_read_input_tokens": 0,
+            },
+        },
+    }
+
+
+def _tool_response(read_path: Path) -> bytes:
+    tool_input = json.dumps({"file_path": str(read_path)}, separators=(",", ":"))
+    return _sse(
+        [
+            _message_start("msg_smoke_tool"),
+            {
+                "type": "content_block_start",
+                "index": 0,
+                "content_block": {
+                    "type": "tool_use",
+                    "id": "toolu_smoke_read",
+                    "name": "Read",
+                    "input": {},
+                },
+            },
+            {
+                "type": "content_block_delta",
+                "index": 0,
+                "delta": {"type": "input_json_delta", "partial_json": tool_input},
+            },
+            {"type": "content_block_stop", "index": 0},
+            {
+                "type": "message_delta",
+                "delta": {"stop_reason": "tool_use", "stop_sequence": None},
+                "usage": {"output_tokens": 8},
+            },
+            {"type": "message_stop"},
+        ]
+    )
+
+
+def _final_response() -> bytes:
+    return _sse(
+        [
+            _message_start("msg_smoke_final"),
+            {
+                "type": "content_block_start",
+                "index": 0,
+                "content_block": {"type": "text", "text": ""},
+            },
+            {
+                "type": "content_block_delta",
+                "index": 0,
+                "delta": {"type": "text_delta", "text": "Smoke complete."},
+            },
+            {"type": "content_block_stop", "index": 0},
+            {
+                "type": "message_delta",
+                "delta": {"stop_reason": "end_turn", "stop_sequence": None},
+                "usage": {"output_tokens": 4},
+            },
+            {"type": "message_stop"},
+        ]
+    )
+
+
+class _CannedAnthropicHandler(BaseHTTPRequestHandler):
+    protocol_version = "HTTP/1.1"
+    request_count = 0
+    read_path = Path("README.md")
+
+    def log_message(self, *_args: object) -> None:
+        return
+
+    def do_POST(self) -> None:  # noqa: N802 - stdlib handler contract
+        if not self.path.startswith("/v1/messages"):
+            self.send_error(404)
+            return
+        try:
+            length = int(self.headers.get("content-length", "0"))
+        except ValueError:
+            self.send_error(400)
+            return
+        request_body = self.rfile.read(length)
+        try:
+            request = json.loads(request_body)
+        except json.JSONDecodeError:
+            self.send_error(400)
+            return
+        if request.get("model") != "claude-test" or request.get("stream") is not True:
+            self.send_error(400)
+            return
+
+        type(self).request_count += 1
+        if type(self).request_count == 1:
+            response = _tool_response(type(self).read_path)
+        else:
+            response = _final_response()
+        self.send_response(200)
+        self.send_header("content-type", "text/event-stream")
+        self.send_header("cache-control", "no-cache")
+        self.send_header("connection", "close")
+        self.send_header("content-length", str(len(response)))
+        self.send_header("request-id", f"req_smoke_{type(self).request_count}")
+        self.end_headers()
+        self.wfile.write(response)
+
+
+def _receiver(data_dir: Path) -> tuple[uvicorn.Server, threading.Thread, int]:
+    config = replace(load_config(), data_dir=data_dir)
+    app = create_claude_code_app(config)
+    server = uvicorn.Server(
+        uvicorn.Config(app=app, log_level="error", access_log=False)
+    )
+    listener = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+    listener.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
+    listener.bind(("127.0.0.1", 0))
+    listener.listen(128)
+    port = listener.getsockname()[1]
+    thread = threading.Thread(
+        target=server.run,
+        kwargs={"sockets": [listener]},
+        daemon=True,
+    )
+    thread.start()
+    deadline = time.monotonic() + 5
+    while not server.started and time.monotonic() < deadline:
+        time.sleep(0.01)
+    if not server.started:
+        raise RuntimeError("capture receiver did not start")
+    return server, thread, port
+
+
+def _filtered_environment(
+    *, home: Path, anthropic_port: int, capture_port: int
+) -> dict[str, str]:
+    environment = {
+        key: os.environ[key]
+        for key in ("PATH", "LANG", "LC_ALL", "TMPDIR")
+        if key in os.environ
+    }
+    environment.update(
+        {
+            "HOME": str(home),
+            "ANTHROPIC_API_KEY": "sk-ant-api03-local-smoke-not-a-secret",
+            "ANTHROPIC_BASE_URL": f"http://127.0.0.1:{anthropic_port}",
+            "CLAUDE_CODE_DISABLE_NONESSENTIAL_TRAFFIC": "1",
+            "DISABLE_AUTOUPDATER": "1",
+            "CLAUDE_CODE_ENABLE_TELEMETRY": "1",
+            "CLAUDE_CODE_ENHANCED_TELEMETRY_BETA": "1",
+            "CLAUDE_CODE_PROPAGATE_TRACEPARENT": "1",
+            "OTEL_LOGS_EXPORTER": "otlp",
+            "OTEL_TRACES_EXPORTER": "otlp",
+            "OTEL_METRICS_EXPORTER": "none",
+            "OTEL_EXPORTER_OTLP_PROTOCOL": "http/protobuf",
+            "OTEL_EXPORTER_OTLP_ENDPOINT": f"http://127.0.0.1:{capture_port}",
+            "OTEL_LOGS_EXPORT_INTERVAL": "100",
+            "OTEL_TRACES_EXPORT_INTERVAL": "100",
+            "OTEL_LOG_USER_PROMPTS": "0",
+            "OTEL_LOG_ASSISTANT_RESPONSES": "0",
+            "OTEL_LOG_TOOL_DETAILS": "1",
+            "OTEL_LOG_TOOL_CONTENT": "0",
+        }
+    )
+    return environment
+
+
+def _jsonl(path: Path) -> list[dict[str, Any]]:
+    return [
+        json.loads(line)
+        for line in path.read_text(encoding="utf-8").splitlines()
+        if line.strip()
+    ]
+
+
+def _assert_capture(data_dir: Path) -> dict[str, Any]:
+    manifests = list(
+        (data_dir / "captures" / "claude-code").glob("*/0001/manifest.json")
+    )
+    if len(manifests) != 1:
+        raise RuntimeError("expected exactly one captured Claude session")
+    capture_dir = manifests[0].parent
+    logs = _jsonl(capture_dir / "logs.jsonl")
+    spans = _jsonl(capture_dir / "spans.jsonl")
+    event_names = {record["record"]["event_name"] for record in logs}
+    span_names = {record["span"]["name"] for record in spans}
+    required_events = {"claude_code.api_request", "claude_code.tool_result"}
+    required_spans = {"claude_code.llm_request", "claude_code.tool"}
+    if not required_events.issubset(event_names):
+        raise RuntimeError("Claude smoke did not export required log signals")
+    if not required_spans.issubset(span_names):
+        raise RuntimeError("Claude smoke did not export required trace signals")
+    api_records = [
+        record
+        for record in logs
+        if record["record"]["event_name"] == "claude_code.api_request"
+    ]
+    if not any(
+        isinstance(record["record"]["attributes"].get("input_tokens"), int)
+        and record["record"]["attributes"]["input_tokens"] > 0
+        for record in api_records
+    ):
+        raise RuntimeError("Claude smoke did not retain numeric token counters")
+    manifest = json.loads((capture_dir / "manifest.json").read_text(encoding="utf-8"))
+    return {
+        "status": "pass",
+        "claude_version": PINNED_CLAUDE_VERSION,
+        "session_hash": manifest["session_hash"][:12],
+        "log_records": len(logs),
+        "spans": len(spans),
+        "required_signals": "present",
+    }
+
+
+def run_smoke(claude: str) -> dict[str, Any]:
+    version = subprocess.run(
+        [claude, "--version"],
+        check=True,
+        capture_output=True,
+        text=True,
+        timeout=10,
+    ).stdout.strip()
+    if not version.startswith(PINNED_CLAUDE_VERSION):
+        raise RuntimeError(
+            f"Claude Code {PINNED_CLAUDE_VERSION} is required for this smoke"
+        )
+
+    with tempfile.TemporaryDirectory(prefix="maida-claude-smoke-") as temporary:
+        root = Path(temporary)
+        project = root / "project"
+        home = root / "home"
+        data_dir = root / "maida"
+        project.mkdir()
+        home.mkdir()
+        read_path = project / "README.md"
+        read_path.write_text("# Offline smoke fixture\n", encoding="utf-8")
+        _CannedAnthropicHandler.read_path = read_path
+        _CannedAnthropicHandler.request_count = 0
+        anthropic = ThreadingHTTPServer(("127.0.0.1", 0), _CannedAnthropicHandler)
+        anthropic_thread = threading.Thread(target=anthropic.serve_forever, daemon=True)
+        anthropic_thread.start()
+        receiver, receiver_thread, capture_port = _receiver(data_dir)
+        try:
+            environment = _filtered_environment(
+                home=home,
+                anthropic_port=anthropic.server_address[1],
+                capture_port=capture_port,
+            )
+            command = [
+                claude,
+                "--bare",
+                "--print",
+                "--model",
+                "claude-test",
+                "--session-id",
+                SESSION_ID,
+                "--no-session-persistence",
+                "--setting-sources",
+                "project",
+                "--strict-mcp-config",
+                "--mcp-config",
+                '{"mcpServers":{}}',
+                "--tools",
+                "Read",
+                "--allowedTools",
+                "Read",
+                "--permission-mode",
+                "dontAsk",
+                "--max-budget-usd",
+                "0.01",
+                "Read README.md, then reply with a short confirmation.",
+            ]
+            completed = subprocess.run(
+                command,
+                cwd=project,
+                env=environment,
+                capture_output=True,
+                text=True,
+                timeout=30,
+            )
+            if completed.returncode != 0:
+                raise RuntimeError("offline Claude Code invocation failed")
+            deadline = time.monotonic() + 5
+            while time.monotonic() < deadline:
+                try:
+                    return _assert_capture(data_dir)
+                except (FileNotFoundError, RuntimeError):
+                    time.sleep(0.05)
+            return _assert_capture(data_dir)
+        finally:
+            receiver.should_exit = True
+            receiver_thread.join(timeout=5)
+            anthropic.shutdown()
+            anthropic.server_close()
+            anthropic_thread.join(timeout=5)
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--claude", default="claude")
+    args = parser.parse_args()
+    try:
+        print(json.dumps(run_smoke(args.claude), sort_keys=True))
+    except Exception as exc:
+        print(json.dumps({"status": "fail", "error": str(exc)}), file=os.sys.stderr)
+        raise SystemExit(1) from None
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/test_claude_capture.py
+++ b/tests/test_claude_capture.py
@@ -1,0 +1,244 @@
+import hashlib
+import json
+
+from fastapi.testclient import TestClient
+from opentelemetry.proto.collector.logs.v1.logs_service_pb2 import (
+    ExportLogsServiceRequest,
+)
+from opentelemetry.proto.collector.trace.v1.trace_service_pb2 import (
+    ExportTraceServiceRequest,
+)
+from opentelemetry.proto.common.v1.common_pb2 import AnyValue, KeyValue
+from opentelemetry.proto.logs.v1.logs_pb2 import LogRecord, ResourceLogs, ScopeLogs
+from opentelemetry.proto.resource.v1.resource_pb2 import Resource
+from opentelemetry.proto.trace.v1.trace_pb2 import (
+    ResourceSpans,
+    ScopeSpans,
+    Span,
+    Status,
+)
+
+from maida.capture.claude_code import create_claude_code_app
+from maida.config import load_config
+
+
+def _kv(key: str, value: object) -> KeyValue:
+    any_value = AnyValue()
+    if isinstance(value, bool):
+        any_value.bool_value = value
+    elif isinstance(value, int):
+        any_value.int_value = value
+    elif isinstance(value, float):
+        any_value.double_value = value
+    else:
+        any_value.string_value = str(value)
+    return KeyValue(key=key, value=any_value)
+
+
+def _logs_request(
+    *,
+    session_id: str = "session/with traversal/../chars",
+    event_name: str = "claude_code.api_request",
+    sequence: int = 1,
+    input_tokens: int = 12,
+    extra: list[KeyValue] | None = None,
+) -> ExportLogsServiceRequest:
+    attrs = [
+        _kv("session.id", session_id),
+        _kv("event.name", event_name.removeprefix("claude_code.")),
+        _kv("event.sequence", sequence),
+        _kv("event.timestamp", "2026-08-08T12:00:00Z"),
+    ]
+    if event_name == "claude_code.api_request":
+        attrs += [
+            _kv("model", "claude-test"),
+            _kv("duration_ms", 25),
+            _kv("input_tokens", input_tokens),
+            _kv("output_tokens", 4),
+            _kv("cache_read_tokens", 0),
+            _kv("cache_creation_tokens", 0),
+            _kv("cost_usd", 0.001),
+        ]
+    attrs += extra or []
+    record = LogRecord(
+        time_unix_nano=1_754_656_800_000_000_000,
+        observed_time_unix_nano=1_754_656_800_000_000_001,
+        body=AnyValue(string_value=event_name),
+        attributes=attrs,
+        trace_id=bytes.fromhex("11" * 16),
+        span_id=bytes.fromhex("22" * 8),
+    )
+    return ExportLogsServiceRequest(
+        resource_logs=[
+            ResourceLogs(
+                resource=Resource(attributes=[_kv("service.name", "claude-code")]),
+                scope_logs=[ScopeLogs(log_records=[record])],
+            )
+        ]
+    )
+
+
+def _traces_request(
+    *, session_id: str = "trace-session", duration_ms: int = 20
+) -> ExportTraceServiceRequest:
+    start = 1_754_656_800_000_000_000
+    span = Span(
+        trace_id=bytes.fromhex("33" * 16),
+        span_id=bytes.fromhex("44" * 8),
+        name="claude_code.llm_request",
+        kind=Span.SPAN_KIND_CLIENT,
+        start_time_unix_nano=start,
+        end_time_unix_nano=start + duration_ms * 1_000_000,
+        attributes=[
+            _kv("session.id", session_id),
+            _kv("span.type", "claude_code.llm_request"),
+            _kv("model", "claude-test"),
+            _kv("duration_ms", duration_ms),
+            _kv("input_tokens", 8),
+            _kv("output_tokens", 3),
+            _kv("success", True),
+        ],
+        status=Status(code=Status.STATUS_CODE_OK),
+    )
+    return ExportTraceServiceRequest(
+        resource_spans=[
+            ResourceSpans(
+                resource=Resource(attributes=[_kv("service.name", "claude-code")]),
+                scope_spans=[ScopeSpans(spans=[span])],
+            )
+        ]
+    )
+
+
+def _capture_dir(temp_data_dir, session_id: str):
+    digest = hashlib.sha256(session_id.encode()).hexdigest()
+    return temp_data_dir / "captures" / "claude-code" / digest / "0001"
+
+
+def _post(client: TestClient, path: str, message) -> object:
+    return client.post(
+        path,
+        content=message.SerializeToString(),
+        headers={"content-type": "application/x-protobuf"},
+    )
+
+
+def test_health_and_log_capture_redacts_nested_content_but_keeps_tokens(temp_data_dir):
+    client = TestClient(create_claude_code_app(load_config()))
+    assert client.get("/healthz").json() == {"status": "ok"}
+
+    request = _logs_request(
+        extra=[
+            _kv(
+                "tool_input",
+                json.dumps(
+                    {
+                        "path": "/tmp/a.py",
+                        "nested": {"api_key": "sk-secret", "value": "ok"},
+                    }
+                ),
+            )
+        ]
+    )
+    response = _post(client, "/v1/logs", request)
+    assert response.status_code == 200
+
+    capture_dir = _capture_dir(temp_data_dir, "session/with traversal/../chars")
+    assert capture_dir.is_dir()
+    manifest = json.loads((capture_dir / "manifest.json").read_text())
+    assert manifest["source"] == "claude-code"
+    assert manifest["segment"] == "0001"
+    assert "session/with" not in json.dumps(manifest)
+
+    records = [
+        json.loads(line)
+        for line in (capture_dir / "logs.jsonl").read_text().splitlines()
+    ]
+    assert len(records) == 1
+    attrs = records[0]["record"]["attributes"]
+    assert attrs["input_tokens"] == 12
+    assert attrs["output_tokens"] == 4
+    nested = json.loads(attrs["tool_input"])
+    assert nested["nested"] == {"api_key": "__REDACTED__", "value": "ok"}
+    assert attrs["session.id"] == manifest["session_hash"]
+
+
+def test_trace_capture_persists_source_shape(temp_data_dir):
+    client = TestClient(create_claude_code_app(load_config()))
+    response = _post(client, "/v1/traces", _traces_request())
+    assert response.status_code == 200
+
+    capture_dir = _capture_dir(temp_data_dir, "trace-session")
+    records = [
+        json.loads(line)
+        for line in (capture_dir / "spans.jsonl").read_text().splitlines()
+    ]
+    assert len(records) == 1
+    assert records[0]["span"]["name"] == "claude_code.llm_request"
+    assert records[0]["span"]["trace_id"] == "33" * 16
+    assert records[0]["span"]["duration_ms"] == 20
+    assert records[0]["span"]["attributes"]["input_tokens"] == 8
+
+
+def test_complete_batch_is_validated_before_any_write(temp_data_dir):
+    request = _logs_request()
+    invalid = request.resource_logs[0].scope_logs[0].log_records.add()
+    invalid.CopyFrom(request.resource_logs[0].scope_logs[0].log_records[0])
+    for attribute in invalid.attributes:
+        if attribute.key == "input_tokens":
+            attribute.value.int_value = -1
+
+    response = _post(
+        TestClient(create_claude_code_app(load_config())), "/v1/logs", request
+    )
+    assert response.status_code == 400
+    assert not (temp_data_dir / "captures").exists()
+
+
+def test_exact_retry_is_deduplicated_and_conflicting_identity_is_rejected(
+    temp_data_dir,
+):
+    client = TestClient(create_claude_code_app(load_config()))
+    request = _logs_request()
+    assert _post(client, "/v1/logs", request).status_code == 200
+    retry = _post(client, "/v1/logs", request)
+    assert retry.status_code == 200
+
+    conflict = _logs_request(input_tokens=13)
+    response = _post(client, "/v1/logs", conflict)
+    assert response.status_code == 409
+    capture_dir = _capture_dir(temp_data_dir, "session/with traversal/../chars")
+    assert len((capture_dir / "logs.jsonl").read_text().splitlines()) == 1
+
+
+def test_rejects_wrong_content_type_oversized_and_invalid_ids(temp_data_dir):
+    client = TestClient(create_claude_code_app(load_config(), max_request_bytes=10))
+    body = _logs_request().SerializeToString()
+    assert client.post("/v1/logs", content=body).status_code == 415
+    assert (
+        client.post(
+            "/v1/logs",
+            content=body,
+            headers={"content-type": "application/x-protobuf"},
+        ).status_code
+        == 413
+    )
+
+    request = _traces_request()
+    request.resource_spans[0].scope_spans[0].spans[0].trace_id = b"short"
+    response = _post(
+        TestClient(create_claude_code_app(load_config())), "/v1/traces", request
+    )
+    assert response.status_code == 400
+    assert not (temp_data_dir / "captures").exists()
+
+
+def test_unknown_additive_log_record_is_preserved(temp_data_dir):
+    request = _logs_request(event_name="claude_code.future_signal")
+    response = _post(
+        TestClient(create_claude_code_app(load_config())), "/v1/logs", request
+    )
+    assert response.status_code == 200
+    capture_dir = _capture_dir(temp_data_dir, "session/with traversal/../chars")
+    record = json.loads((capture_dir / "logs.jsonl").read_text().splitlines()[0])
+    assert record["record"]["event_name"] == "claude_code.future_signal"

--- a/tests/test_claude_capture.py
+++ b/tests/test_claude_capture.py
@@ -242,3 +242,19 @@ def test_unknown_additive_log_record_is_preserved(temp_data_dir):
     capture_dir = _capture_dir(temp_data_dir, "session/with traversal/../chars")
     record = json.loads((capture_dir / "logs.jsonl").read_text().splitlines()[0])
     assert record["record"]["event_name"] == "claude_code.future_signal"
+
+
+def test_known_numeric_log_fields_accept_claude_string_encoding(temp_data_dir):
+    request = _logs_request()
+    for attribute in request.resource_logs[0].scope_logs[0].log_records[0].attributes:
+        if attribute.key in {"duration_ms", "input_tokens", "output_tokens"}:
+            attribute.value.string_value = str(attribute.value.int_value)
+
+    response = _post(
+        TestClient(create_claude_code_app(load_config())), "/v1/logs", request
+    )
+    assert response.status_code == 200
+    capture_dir = _capture_dir(temp_data_dir, "session/with traversal/../chars")
+    record = json.loads((capture_dir / "logs.jsonl").read_text().splitlines()[0])
+    assert record["record"]["attributes"]["input_tokens"] == 12
+    assert record["record"]["attributes"]["duration_ms"] == 25

--- a/tests/test_claude_capture_cli.py
+++ b/tests/test_claude_capture_cli.py
@@ -1,0 +1,32 @@
+from typer.testing import CliRunner
+
+from maida.cli import app
+
+
+def test_capture_claude_code_starts_loopback_receiver(monkeypatch, temp_data_dir):
+    invocation = {}
+
+    def fake_run(**kwargs):
+        invocation.update(kwargs)
+
+    monkeypatch.setattr("uvicorn.run", fake_run)
+    result = CliRunner().invoke(
+        app,
+        ["capture", "claude-code", "--host", "127.0.0.1", "--port", "5318"],
+    )
+
+    assert result.exit_code == 0
+    assert invocation["host"] == "127.0.0.1"
+    assert invocation["port"] == 5318
+    assert invocation["access_log"] is False
+    assert invocation["log_level"] == "warning"
+    assert invocation["app"].title == "Maida Claude Code capture"
+    assert "Listening for Claude Code OTLP" in result.stderr
+
+
+def test_capture_claude_code_rejects_invalid_port(temp_data_dir):
+    result = CliRunner().invoke(
+        app,
+        ["capture", "claude-code", "--port", "70000"],
+    )
+    assert result.exit_code == 2

--- a/uv.lock
+++ b/uv.lock
@@ -540,7 +540,7 @@ name = "coloredlogs"
 version = "15.0.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "humanfriendly" },
+    { name = "humanfriendly", marker = "python_full_version < '3.11'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/cc/c7/eed8f27100517e8c0e6b923d5f0845d0cb99763da6fdee00478f91db7325/coloredlogs-15.0.1.tar.gz", hash = "sha256:7c991aa71a4577af2f82600d8f8f3a89f936baeaf9b50a9c197da014e5bf16b0", size = 278520, upload-time = "2021-06-11T10:22:45.202Z" }
 wheels = [
@@ -851,7 +851,7 @@ name = "exceptiongroup"
 version = "1.3.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "typing-extensions" },
+    { name = "typing-extensions", marker = "python_full_version < '3.11'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/50/79/66800aadf48771f6b62f7eb014e352e5d06856655206165d775e675a02c9/exceptiongroup-1.3.1.tar.gz", hash = "sha256:8b412432c6055b0b7d14c310000ae93352ed6754f70fa8f7c34141f91c4e3219", size = 30371, upload-time = "2025-11-21T23:01:54.787Z" }
 wheels = [
@@ -1252,7 +1252,7 @@ name = "humanfriendly"
 version = "10.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "pyreadline3", marker = "sys_platform == 'win32'" },
+    { name = "pyreadline3", marker = "python_full_version < '3.11' and sys_platform == 'win32'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/cc/3f/2c29224acb2e2df4d2046e4c73ee2662023c58ff5b113c4c1adac0886c43/humanfriendly-10.0.tar.gz", hash = "sha256:6b0b831ce8f15f7300721aa49829fc4e83921a9a301cc7f606be6686a2288ddc", size = 360702, upload-time = "2021-09-17T21:40:43.31Z" }
 wheels = [
@@ -1282,7 +1282,7 @@ name = "importlib-metadata"
 version = "9.0.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "zipp" },
+    { name = "zipp", marker = "python_full_version < '3.11'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/a9/01/15bb152d77b21318514a96f43af312635eb2500c96b55398d020c93d86ea/importlib_metadata-9.0.0.tar.gz", hash = "sha256:a4f57ab599e6a2e3016d7595cfd72eb4661a5106e787a95bcc90c7105b831efc", size = 56405, upload-time = "2026-03-20T06:42:56.999Z" }
 wheels = [
@@ -1815,6 +1815,7 @@ dependencies = [
     { name = "fastapi" },
     { name = "opentelemetry-api" },
     { name = "opentelemetry-exporter-otlp-proto-http" },
+    { name = "opentelemetry-proto" },
     { name = "opentelemetry-sdk" },
     { name = "pyyaml" },
     { name = "typer" },
@@ -1855,6 +1856,7 @@ requires-dist = [
     { name = "openai-agents", marker = "extra == 'openai'", specifier = ">=0.17.0" },
     { name = "opentelemetry-api", specifier = ">=1.42.0" },
     { name = "opentelemetry-exporter-otlp-proto-http", specifier = ">=1.42.0" },
+    { name = "opentelemetry-proto", specifier = ">=1.42.0" },
     { name = "opentelemetry-sdk", specifier = ">=1.42.0" },
     { name = "pyyaml", specifier = ">=6.0.3,<6.1.0" },
     { name = "typer", specifier = ">=0.26.8,<0.27.0" },
@@ -2373,12 +2375,12 @@ resolution-markers = [
     "python_full_version < '3.11'",
 ]
 dependencies = [
-    { name = "coloredlogs" },
-    { name = "flatbuffers" },
-    { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" } },
-    { name = "packaging" },
-    { name = "protobuf" },
-    { name = "sympy" },
+    { name = "coloredlogs", marker = "python_full_version < '3.11'" },
+    { name = "flatbuffers", marker = "python_full_version < '3.11'" },
+    { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
+    { name = "packaging", marker = "python_full_version < '3.11'" },
+    { name = "protobuf", marker = "python_full_version < '3.11'" },
+    { name = "sympy", marker = "python_full_version < '3.11'" },
 ]
 wheels = [
     { url = "https://files.pythonhosted.org/packages/76/b9/664a1ffee62fa51529fac27b37409d5d28cadee8d97db806fcba68339b7e/onnxruntime-1.22.1-cp310-cp310-macosx_13_0_universal2.whl", hash = "sha256:80e7f51da1f5201c1379b8d6ef6170505cd800e40da216290f5e06be01aadf95", size = 34319864, upload-time = "2025-07-10T19:15:15.371Z" },
@@ -2411,11 +2413,11 @@ resolution-markers = [
     "python_full_version == '3.11.*'",
 ]
 dependencies = [
-    { name = "flatbuffers" },
-    { name = "numpy", version = "2.4.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.12'" },
+    { name = "flatbuffers", marker = "python_full_version >= '3.11'" },
+    { name = "numpy", version = "2.4.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version == '3.11.*'" },
     { name = "numpy", version = "2.5.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.12'" },
-    { name = "packaging" },
-    { name = "protobuf" },
+    { name = "packaging", marker = "python_full_version >= '3.11'" },
+    { name = "protobuf", marker = "python_full_version >= '3.11'" },
 ]
 wheels = [
     { url = "https://files.pythonhosted.org/packages/d4/e4/5353d7e09ced4a8f473f843223fc75d726b2b5519dcefc12f22a6c92852d/onnxruntime-1.27.0-cp311-cp311-macosx_14_0_arm64.whl", hash = "sha256:8ba14a38c570087f3cdb8cfba33f7a38a1e826c1e5b29e17c28ceda0cc910016", size = 18416484, upload-time = "2026-06-15T22:43:43.894Z" },
@@ -4059,7 +4061,7 @@ name = "sympy"
 version = "1.14.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "mpmath" },
+    { name = "mpmath", marker = "python_full_version < '3.11'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/83/d3/803453b36afefb7c2bb238361cd4ae6125a569b4db67cd9e79846ba2d68c/sympy-1.14.0.tar.gz", hash = "sha256:d3d3fe8df1e5a0b42f0e7bdf50541697dbe7d23746e894990c030e2b05e72517", size = 7793921, upload-time = "2025-04-27T18:05:01.611Z" }
 wheels = [


### PR DESCRIPTION
Implemented a loopback OTLP HTTP/protobuf receiver for Claude Code logs and
beta traces, local source-capture storage, validation/privacy controls, and a
real Claude Code 2.1.220 offline smoke workflow.

- `maida capture claude-code --host 127.0.0.1 --port 4318`
- `GET /healthz`, `POST /v1/logs`, `POST /v1/traces`
- Complete-batch validation before writes
- Hashed session paths, nested redaction/truncation, numeric token retention
- Exact retry deduplication and conflicting identity rejection
- Unknown additive Claude signals retained structurally
- Direct `opentelemetry-proto` dependency
- Pinned, no-credential, canned real-CLI smoke in GitHub Actions

## Verification

- `uv run pytest -q tests/test_claude_capture.py tests/test_claude_capture_cli.py`
- `uv run python scripts/claude_code_capture_smoke.py --claude /home/zatoichi/.local/bin/claude`
- `uv run pytest -q`
- `uv run ruff check .`
- `uv run ruff format --check .`
- `git diff --check`

Fixes #149

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>