### PR TITLE
Add passive Claude Code hook capture

### DIFF
--- a/README.md
+++ b/README.md
@@ -268,6 +268,8 @@ maida diff --baseline .maida/baselines/my_agent.json  # latest run vs baseline
 
 ```bash
 maida capture claude-code
+# Or capture one configured Claude command-hook event from stdin:
+maida capture claude-hook
 ```
 
 Point Claude Code's OTLP HTTP/protobuf logs and beta traces at

--- a/docs/claude-code.md
+++ b/docs/claude-code.md
@@ -79,6 +79,50 @@ Use `--host` and `--port` to change the bind address. Keep the receiver on a
 trusted interface: it intentionally has no authentication because its default
 use is a local process or an isolated CI job.
 
+## Command-hook fallback
+
+When OTLP is unavailable or does not include the tool input you need, install
+the passive command hook below in the project's `.claude/settings.json`. The
+example is ten nonblank lines and observes every supported lifecycle event:
+
+```json
+{
+  "hooks": {
+    "SessionStart": [{"hooks": [{"type": "command", "command": "maida capture claude-hook"}]}],
+    "PreToolUse": [{"hooks": [{"type": "command", "command": "maida capture claude-hook"}]}],
+    "PostToolUse": [{"hooks": [{"type": "command", "command": "maida capture claude-hook"}]}],
+    "PostToolUseFailure": [{"hooks": [{"type": "command", "command": "maida capture claude-hook"}]}],
+    "PermissionDenied": [{"hooks": [{"type": "command", "command": "maida capture claude-hook"}]}],
+    "SessionEnd": [{"hooks": [{"type": "command", "command": "maida capture claude-hook"}]}]
+  }
+}
+```
+
+Claude sends one JSON object on stdin for each command-hook invocation. The
+handler writes no stdout and returns no allow, deny, retry, or context fields,
+so it never changes Claude's tool or permission behavior. Successful capture
+exits 0. Capture errors use exit 10 rather than Claude's blocking exit code 2.
+
+Hook records use the same hashed-session capture directory and normalizer as
+OTLP. `PreToolUse` and its terminal event are paired by `tool_use_id`; successful,
+failed, denied, preless, and incomplete calls all remain importable as ordinary
+Maida `TOOL_CALL` spans. The raw session ID and transcript path are not stored.
+Tool inputs and results pass through Maida's recursive redaction and field-size
+limits before the atomic append.
+
+`startup`, `resume`, `fork`, and `clear` start a new immutable capture segment.
+The `compact` SessionStart source stays in the active segment. `SessionEnd`
+closes and imports its segment automatically. If Claude exits abruptly before
+that event, recover the active segment explicitly:
+
+```bash
+maida import claude-code --session-id "$CLAUDE_SESSION_ID"
+```
+
 See Claude Code's official [monitoring
 reference](https://code.claude.com/docs/en/monitoring-usage) for exporter
 variables and the beta trace hierarchy.
+
+See Claude Code's official [hooks
+reference](https://code.claude.com/docs/en/hooks) for command-hook stdin,
+lifecycle, matcher, and exit-code behavior.

--- a/maida/capture/claude_hook.py
+++ b/maida/capture/claude_hook.py
@@ -1,0 +1,447 @@
+"""Passive Claude Code command-hook capture fallback."""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import time
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+from maida.capture.claude_code import (
+    _atomic_json,
+    _atomic_jsonl,
+    _canonical,
+    _capture_lock,
+    _read_jsonl,
+    _sanitize,
+    _session_hash,
+)
+from maida.config import MaidaConfig
+from maida.integrations.claude_code import ClaudeImportResult, import_claude_capture
+
+DEFAULT_MAX_HOOK_BYTES = 8 * 1024 * 1024
+_SERVICE_NAME = "claude-code"
+_EVENT_NAMES = {
+    "SessionStart": "claude_code.hook.session_start",
+    "PreToolUse": "claude_code.hook.pre_tool_use",
+    "PostToolUse": "claude_code.hook.post_tool_use",
+    "PostToolUseFailure": "claude_code.hook.post_tool_use_failure",
+    "PermissionDenied": "claude_code.hook.permission_denied",
+    "SessionEnd": "claude_code.hook.session_end",
+}
+_TOOL_EVENTS = frozenset(
+    {"PreToolUse", "PostToolUse", "PostToolUseFailure", "PermissionDenied"}
+)
+_SESSION_SOURCES = frozenset({"startup", "resume", "clear", "compact", "fork"})
+_OMITTED_SOURCE_FIELDS = frozenset({"session_id", "transcript_path"})
+
+
+class ClaudeHookInputError(ValueError):
+    """A Claude hook stdin payload is missing, malformed, or unsupported."""
+
+
+class ClaudeHookConflictError(RuntimeError):
+    """A hook delivery reused an identity with different sanitized content."""
+
+
+class ClaudeHookImportError(RuntimeError):
+    """A completed hook capture could not be imported automatically."""
+
+
+@dataclass(frozen=True)
+class ClaudeHookCaptureResult:
+    session_hash: str
+    segment: str
+    accepted: bool
+    import_result: ClaudeImportResult | None = None
+
+
+def _require_string(payload: dict[str, Any], field: str) -> str:
+    value = payload.get(field)
+    if not isinstance(value, str) or not value.strip():
+        raise ClaudeHookInputError(f"{field} must be a nonempty string")
+    return value.strip()
+
+
+def _validate_payload(payload: Any) -> tuple[str, str]:
+    if not isinstance(payload, dict):
+        raise ClaudeHookInputError("hook payload must be a JSON object")
+    session_id = _require_string(payload, "session_id")
+    event = _require_string(payload, "hook_event_name")
+    if event not in _EVENT_NAMES:
+        raise ClaudeHookInputError(f"unsupported hook event {event!r}")
+
+    for field in (
+        "cwd",
+        "prompt_id",
+        "permission_mode",
+        "agent_id",
+        "agent_type",
+        "model",
+        "session_title",
+    ):
+        value = payload.get(field)
+        if value is not None and not isinstance(value, str):
+            raise ClaudeHookInputError(f"{field} must be a string")
+
+    if event == "SessionStart":
+        source = _require_string(payload, "source")
+        if source not in _SESSION_SOURCES:
+            raise ClaudeHookInputError("SessionStart source is invalid")
+    elif event in _TOOL_EVENTS:
+        _require_string(payload, "tool_name")
+        _require_string(payload, "tool_use_id")
+        if not isinstance(payload.get("tool_input"), dict):
+            raise ClaudeHookInputError("tool_input must be a JSON object")
+
+    if event == "PostToolUse" and "tool_response" not in payload:
+        raise ClaudeHookInputError("PostToolUse tool_response is required")
+    if event == "PostToolUseFailure":
+        _require_string(payload, "error")
+        interrupted = payload.get("is_interrupt")
+        if interrupted is not None and not isinstance(interrupted, bool):
+            raise ClaudeHookInputError("is_interrupt must be a boolean")
+    if event in {"PermissionDenied", "SessionEnd"}:
+        _require_string(payload, "reason")
+
+    duration = payload.get("duration_ms")
+    if duration is not None and (
+        isinstance(duration, bool)
+        or not isinstance(duration, (int, float))
+        or duration < 0
+    ):
+        raise ClaudeHookInputError("duration_ms must be nonnegative")
+    return session_id, event
+
+
+def parse_claude_hook_json(
+    raw: str,
+    config: MaidaConfig,
+    *,
+    max_hook_bytes: int = DEFAULT_MAX_HOOK_BYTES,
+) -> ClaudeHookCaptureResult:
+    """Parse exactly one JSON value and capture it without emitting a decision."""
+    if len(raw.encode("utf-8")) > max_hook_bytes:
+        raise ClaudeHookInputError("hook payload is too large")
+    if not raw.strip():
+        raise ClaudeHookInputError("hook payload is empty")
+    try:
+        payload = json.loads(raw)
+    except json.JSONDecodeError as exc:
+        raise ClaudeHookInputError(
+            "hook payload must contain exactly one JSON object"
+        ) from exc
+    return capture_claude_hook(payload, config)
+
+
+def _read_json(path: Path) -> dict[str, Any]:
+    if not path.is_file():
+        return {}
+    try:
+        value = json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError) as exc:
+        raise ClaudeHookConflictError(f"existing hook state {path} is invalid") from exc
+    if not isinstance(value, dict):
+        raise ClaudeHookConflictError(f"existing hook state {path} is invalid")
+    return value
+
+
+def _next_segment(session_dir: Path) -> str:
+    numbers = (
+        [
+            int(entry.name)
+            for entry in session_dir.iterdir()
+            if entry.is_dir() and entry.name.isdigit()
+        ]
+        if session_dir.is_dir()
+        else []
+    )
+    return f"{max(numbers, default=0) + 1:04d}"
+
+
+def _safe_payload(payload: dict[str, Any], config: MaidaConfig) -> dict[str, Any]:
+    source = {
+        key: value
+        for key, value in payload.items()
+        if key not in _OMITTED_SOURCE_FIELDS
+    }
+    sanitized = _sanitize(source, config)
+    if not isinstance(sanitized, dict):  # pragma: no cover - source is always a dict
+        raise ClaudeHookInputError("hook payload could not be sanitized")
+    return sanitized
+
+
+def _payload_fingerprint(payload: dict[str, Any]) -> str:
+    return hashlib.sha256(_canonical(payload).encode("utf-8")).hexdigest()
+
+
+def _delivery_id(event: str, payload: dict[str, Any]) -> str:
+    if event in _TOOL_EVENTS:
+        parts = (event, payload.get("prompt_id"), payload["tool_use_id"])
+    elif event == "SessionStart":
+        parts = (event, payload["source"])
+    else:
+        parts = (event, payload.get("reason"))
+    return hashlib.sha256(repr(parts).encode("utf-8")).hexdigest()
+
+
+def _iso_from_nanos(value: int) -> str:
+    return (
+        datetime.fromtimestamp(value / 1_000_000_000, timezone.utc)
+        .isoformat()
+        .replace("+00:00", "Z")
+    )
+
+
+def _find_delivery(
+    records: list[dict[str, Any]], delivery_id: str
+) -> dict[str, Any] | None:
+    for record in records:
+        attributes = record.get("record", {}).get("attributes", {})
+        if attributes.get("hook.delivery_id") == delivery_id:
+            return record
+    return None
+
+
+def _record(
+    *,
+    safe_payload: dict[str, Any],
+    session_hash: str,
+    event: str,
+    delivery_id: str,
+    fingerprint: str,
+    sequence: int,
+    now_nanos: int,
+    config: MaidaConfig,
+) -> dict[str, Any]:
+    attributes = dict(safe_payload)
+    prompt_id = attributes.get("prompt_id")
+    attributes.update(
+        {
+            "session.id": session_hash,
+            "event.name": f"hook.{_EVENT_NAMES[event].rsplit('.', 1)[-1]}",
+            "event.sequence": sequence,
+            "event.timestamp": _iso_from_nanos(now_nanos),
+            "hook.delivery_id": delivery_id,
+            "hook.payload_fingerprint": fingerprint,
+        }
+    )
+    if prompt_id:
+        attributes["prompt.id"] = prompt_id
+    return _sanitize(
+        {
+            "resource": {
+                "attributes": {
+                    "service.name": _SERVICE_NAME,
+                    "capture.transport": "claude-hook",
+                },
+                "dropped_attributes_count": 0,
+                "schema_url": "",
+            },
+            "scope": {
+                "name": "maida.capture.claude-hook",
+                "version": "1",
+                "attributes": {},
+                "dropped_attributes_count": 0,
+            },
+            "record": {
+                "event_name": _EVENT_NAMES[event],
+                "time_unix_nano": now_nanos,
+                "observed_time_unix_nano": now_nanos,
+                "severity_number": 0,
+                "severity_text": "",
+                "body": _EVENT_NAMES[event],
+                "attributes": attributes,
+                "dropped_attributes_count": 0,
+                "flags": 0,
+                "trace_id": "",
+                "span_id": "",
+            },
+            "session_hash": session_hash,
+        },
+        config,
+    )
+
+
+def _write_manifest(
+    segment_dir: Path,
+    *,
+    session_hash: str,
+    segment: str,
+    log_count: int,
+    state: str,
+    now: str,
+) -> None:
+    path = segment_dir / "manifest.json"
+    manifest = {
+        "capture_version": 1,
+        "source": _SERVICE_NAME,
+        "session_hash": session_hash,
+        "segment": segment,
+        "capture_transport": "claude-hook",
+        "created_at": now,
+        "updated_at": now,
+        "state": state,
+        "signals": {"logs": log_count},
+    }
+    if path.is_file():
+        current = _read_json(path)
+        manifest.update(current)
+        manifest["updated_at"] = now
+        manifest["state"] = state
+        signals = dict(manifest.get("signals") or {})
+        signals["logs"] = log_count
+        manifest["signals"] = signals
+    if state == "closed":
+        manifest["closed_at"] = now
+    _atomic_json(path, manifest)
+
+
+def _close_segment(session_dir: Path, segment: str, now: str) -> None:
+    segment_dir = session_dir / segment
+    manifest = _read_json(segment_dir / "manifest.json")
+    if not manifest:
+        return
+    manifest["state"] = "closed"
+    manifest["updated_at"] = now
+    manifest["closed_at"] = now
+    _atomic_json(segment_dir / "manifest.json", manifest)
+
+
+def capture_claude_hook(
+    payload: Any,
+    config: MaidaConfig,
+) -> ClaudeHookCaptureResult:
+    """Validate and append one passive Claude command-hook delivery."""
+    session_id, event = _validate_payload(payload)
+    safe_payload = _safe_payload(payload, config)
+    session_hash = _session_hash(session_id)
+    fingerprint = _payload_fingerprint(safe_payload)
+    delivery_id = _delivery_id(event, safe_payload)
+    captures_root = config.data_dir.expanduser() / "captures"
+    session_dir = captures_root / _SERVICE_NAME / session_hash
+    state_path = session_dir / ".hook-state.json"
+    now_nanos = time.time_ns()
+    now = _iso_from_nanos(now_nanos)
+
+    with _capture_lock(captures_root):
+        state = _read_json(state_path)
+        active = state.get("active_segment")
+        if not isinstance(active, str):
+            active = None
+
+        if event == "SessionStart" and safe_payload["source"] != "compact":
+            if (
+                active is not None
+                and state.get("last_start_delivery_id") == delivery_id
+            ):
+                segment = active
+            else:
+                if active is not None:
+                    _close_segment(session_dir, active, now)
+                segment = _next_segment(session_dir)
+                active = segment
+                state["active_segment"] = segment
+        elif event == "SessionEnd" and active is None:
+            previous = state.get("last_closed_segment")
+            if isinstance(previous, str):
+                existing = _read_jsonl(session_dir / previous / "logs.jsonl")
+                duplicate = _find_delivery(existing, delivery_id)
+                segment = (
+                    previous if duplicate is not None else _next_segment(session_dir)
+                )
+            else:
+                segment = _next_segment(session_dir)
+            active = segment
+            state["active_segment"] = segment
+        elif active is None:
+            segment = _next_segment(session_dir)
+            active = segment
+            state["active_segment"] = segment
+        else:
+            segment = active
+
+        segment_dir = session_dir / segment
+        logs_path = segment_dir / "logs.jsonl"
+        existing = _read_jsonl(logs_path)
+        previous = _find_delivery(existing, delivery_id)
+        accepted = previous is None
+        if previous is not None:
+            previous_fingerprint = previous["record"]["attributes"].get(
+                "hook.payload_fingerprint"
+            )
+            if previous_fingerprint != fingerprint:
+                raise ClaudeHookConflictError(
+                    "conflicting duplicate Claude hook delivery identity"
+                )
+        else:
+            sequences = [
+                record.get("record", {}).get("attributes", {}).get("event.sequence", 0)
+                for record in existing
+            ]
+            sequence = (
+                max(
+                    (
+                        value
+                        for value in sequences
+                        if isinstance(value, int) and not isinstance(value, bool)
+                    ),
+                    default=0,
+                )
+                + 1
+            )
+            incoming = _record(
+                safe_payload=safe_payload,
+                session_hash=session_hash,
+                event=event,
+                delivery_id=delivery_id,
+                fingerprint=fingerprint,
+                sequence=sequence,
+                now_nanos=now_nanos,
+                config=config,
+            )
+            existing.append(incoming)
+            _atomic_jsonl(logs_path, existing)
+
+        capture_state = "closed" if event == "SessionEnd" else "active"
+        _write_manifest(
+            segment_dir,
+            session_hash=session_hash,
+            segment=segment,
+            log_count=len(existing),
+            state=capture_state,
+            now=now,
+        )
+
+        if event == "SessionStart" and safe_payload["source"] != "compact":
+            state["last_start_delivery_id"] = delivery_id
+            state["last_start_fingerprint"] = fingerprint
+        import_result = None
+        if event == "SessionEnd":
+            state["active_segment"] = None
+            state["last_closed_segment"] = segment
+        state["session_hash"] = session_hash
+        state["updated_at"] = now
+        _atomic_json(state_path, state)
+
+        if event == "SessionEnd":
+            try:
+                import_result = import_claude_capture(
+                    session_id,
+                    config,
+                    segment=segment,
+                )
+            except Exception as exc:
+                raise ClaudeHookImportError(
+                    f"completed Claude hook capture could not be imported: {exc}"
+                ) from exc
+
+    return ClaudeHookCaptureResult(
+        session_hash=session_hash,
+        segment=segment,
+        accepted=accepted,
+        import_result=import_result,
+    )

--- a/maida/cli.py
+++ b/maida/cli.py
@@ -10,6 +10,7 @@ import json
 import os
 import socket
 import subprocess
+import sys
 import threading
 import time
 import webbrowser
@@ -38,6 +39,12 @@ from maida.baseline import (
     save_baseline,
 )
 from maida.capture.claude_code import create_claude_code_app
+from maida.capture.claude_hook import (
+    ClaudeHookConflictError,
+    ClaudeHookImportError,
+    ClaudeHookInputError,
+    parse_claude_hook_json,
+)
 from maida.config import load_config
 from maida.constants import LOCAL_DIR_NAME, SPEC_VERSION
 from maida.demo import (
@@ -221,6 +228,27 @@ def capture_claude_code_cmd(
             log_level="warning",
         )
     except (KeyboardInterrupt, typer.Exit):
+        raise
+    except Exception as exc:
+        typer.echo(f"error: {exc}", err=True)
+        raise Exit(EXIT_INTERNAL)
+
+
+@capture_app.command("claude-hook")
+def capture_claude_hook_cmd() -> None:
+    """Record one passive Claude Code command-hook payload from stdin."""
+    try:
+        parse_claude_hook_json(sys.stdin.read(), load_config())
+    except ClaudeHookInputError as exc:
+        typer.echo(f"Invalid Claude hook payload: {exc}", err=True)
+        # Claude assigns blocking semantics to hook exit code 2. This capture
+        # command is an observer, so even invalid input uses a non-blocking
+        # failure code.
+        raise Exit(EXIT_INTERNAL)
+    except (ClaudeHookConflictError, ClaudeHookImportError) as exc:
+        typer.echo(f"Claude hook capture failed: {exc}", err=True)
+        raise Exit(EXIT_INTERNAL)
+    except Exit:
         raise
     except Exception as exc:
         typer.echo(f"error: {exc}", err=True)

--- a/maida/integrations/claude_code.py
+++ b/maida/integrations/claude_code.py
@@ -51,6 +51,20 @@ _KNOWN_LOGS = frozenset(
         "claude_code.api_error",
         "claude_code.api_refusal",
         "claude_code.tool_decision",
+        "claude_code.hook.session_start",
+        "claude_code.hook.pre_tool_use",
+        "claude_code.hook.post_tool_use",
+        "claude_code.hook.post_tool_use_failure",
+        "claude_code.hook.permission_denied",
+        "claude_code.hook.session_end",
+    }
+)
+_HOOK_TOOL_LOGS = frozenset(
+    {
+        "claude_code.hook.pre_tool_use",
+        "claude_code.hook.post_tool_use",
+        "claude_code.hook.post_tool_use_failure",
+        "claude_code.hook.permission_denied",
     }
 )
 _NONNEGATIVE_FIELDS = frozenset(
@@ -289,6 +303,35 @@ def _validate_log(item: dict[str, Any], session_hash: str, line_no: int) -> str 
         "claude_code.tool_decision": ("tool_name", "tool_use_id", "decision"),
         "claude_code.user_prompt": ("prompt_length",),
         "claude_code.assistant_response": ("response_length", "model"),
+        "claude_code.hook.session_start": ("hook_event_name", "source"),
+        "claude_code.hook.pre_tool_use": (
+            "hook_event_name",
+            "tool_name",
+            "tool_use_id",
+            "tool_input",
+        ),
+        "claude_code.hook.post_tool_use": (
+            "hook_event_name",
+            "tool_name",
+            "tool_use_id",
+            "tool_input",
+            "tool_response",
+        ),
+        "claude_code.hook.post_tool_use_failure": (
+            "hook_event_name",
+            "tool_name",
+            "tool_use_id",
+            "tool_input",
+            "error",
+        ),
+        "claude_code.hook.permission_denied": (
+            "hook_event_name",
+            "tool_name",
+            "tool_use_id",
+            "tool_input",
+            "reason",
+        ),
+        "claude_code.hook.session_end": ("hook_event_name", "reason"),
     }
     missing = [
         field for field in required.get(event_name, ()) if field not in attributes
@@ -297,6 +340,10 @@ def _validate_log(item: dict[str, Any], session_hash: str, line_no: int) -> str 
         raise ClaudeCaptureInputError(
             f"{event_name} is missing required field(s): {', '.join(missing)}"
         )
+    if event_name.startswith("claude_code.hook."):
+        tool_input = attributes.get("tool_input")
+        if tool_input is not None and not isinstance(tool_input, dict):
+            raise ClaudeCaptureInputError(f"{event_name} tool_input must be an object")
     return version
 
 
@@ -771,6 +818,150 @@ def normalize_claude_capture(
             _source_identity(item, "logs"),
         ),
     )
+    hook_tools: dict[str, list[dict[str, Any]]] = {}
+    for item in ordered_logs:
+        record = item["record"]
+        if record["event_name"] not in _HOOK_TOOL_LOGS:
+            continue
+        tool_use_id = record["attributes"].get("tool_use_id")
+        if isinstance(tool_use_id, str) and tool_use_id:
+            hook_tools.setdefault(tool_use_id, []).append(item)
+
+    consumed_hook_logs: set[str] = set()
+    for tool_use_id, source_logs in hook_tools.items():
+        pre = next(
+            (
+                item
+                for item in source_logs
+                if item["record"]["event_name"] == "claude_code.hook.pre_tool_use"
+            ),
+            None,
+        )
+        terminals = [
+            item
+            for item in source_logs
+            if item["record"]["event_name"] != "claude_code.hook.pre_tool_use"
+        ]
+        if len(terminals) > 1:
+            raise ClaudeCaptureInputError(
+                f"hook tool {tool_use_id!r} has conflicting terminal events"
+            )
+        terminal = terminals[0] if terminals else None
+        names = {item["record"]["attributes"].get("tool_name") for item in source_logs}
+        if len(names) != 1 or not all(isinstance(name, str) and name for name in names):
+            raise ClaudeCaptureInputError(
+                f"hook tool {tool_use_id!r} has conflicting tool names"
+            )
+
+        primary = terminal or pre
+        if primary is None:  # pragma: no cover - groups always contain a source log
+            continue
+        merged_attributes: dict[str, Any] = {}
+        if pre is not None:
+            merged_attributes.update(pre["record"]["attributes"])
+        if terminal is not None:
+            merged_attributes.update(terminal["record"]["attributes"])
+        tool_name = str(merged_attributes["tool_name"])
+        prompt_id = merged_attributes.get("prompt.id")
+        group = f"prompt:{prompt_id or 'session'}"
+        interaction_id = ensure_interaction(group)
+
+        end = _log_time(primary)
+        duration = merged_attributes.get("duration_ms", 0)
+        if not isinstance(duration, (int, float)) or isinstance(duration, bool):
+            duration = 0
+        duration_start = end - timedelta(milliseconds=duration)
+        start = (
+            min(_log_time(pre), duration_start) if pre is not None else duration_start
+        )
+        interaction_times.setdefault(group, []).extend((start, end))
+
+        terminal_name = terminal["record"]["event_name"] if terminal else None
+        terminal_missing = terminal is None
+        pre_tool_missing = pre is None
+        meta = _source_meta(
+            source_kind="hook_pair",
+            source_name="claude_code.hook.tool_call",
+            attributes=merged_attributes,
+            service_version=_service_version(primary),
+            source_record_identity=tool_use_id,
+        )
+        meta.update(
+            {
+                "terminal_missing": terminal_missing,
+                "pre_tool_missing": pre_tool_missing,
+                "source_logs": [
+                    {
+                        "event_name": item["record"]["event_name"],
+                        "record_identity": _source_identity(item, "logs"),
+                        "attributes": item["record"]["attributes"],
+                    }
+                    for item in source_logs
+                ],
+            }
+        )
+        attrs: dict[str, Any] = {
+            MAIDA_TOOL_NAME: tool_name,
+            MAIDA_META: _meta_json({"claude_code": meta}, config),
+        }
+        args = _sanitize(_tool_args(merged_attributes), config)
+        events = [
+            {
+                "name": "maida.tool.args",
+                "timestamp": _iso(start),
+                "attributes": {"args": json.dumps(args, ensure_ascii=False)},
+            }
+        ]
+        if terminal_name == "claude_code.hook.post_tool_use":
+            result = _sanitize(merged_attributes.get("tool_response"), config)
+            events.append(
+                {
+                    "name": "maida.tool.result",
+                    "timestamp": _iso(end),
+                    "attributes": {"result": json.dumps(result, ensure_ascii=False)},
+                }
+            )
+
+        status = "UNSET" if terminal_missing else "OK"
+        status_description = ""
+        if terminal_name == "claude_code.hook.post_tool_use_failure":
+            status = "ERROR"
+            status_description = str(
+                merged_attributes.get("error") or "Claude Code tool failed"
+            )
+            attrs[MAIDA_ERROR_TYPE] = (
+                "ClaudeCodeToolInterrupted"
+                if merged_attributes.get("is_interrupt") is True
+                else "ClaudeCodeToolError"
+            )
+            attrs[MAIDA_ERROR_MESSAGE] = status_description
+        elif terminal_name == "claude_code.hook.permission_denied":
+            status = "ERROR"
+            status_description = str(
+                merged_attributes.get("reason") or "Claude Code tool was denied"
+            )
+            attrs[MAIDA_ERROR_TYPE] = "ClaudeCodePermissionDenied"
+            attrs[MAIDA_ERROR_MESSAGE] = status_description
+
+        projected = _normalized_span(
+            trace_id=trace_id,
+            span_id=span_id(f"hook-tool:{tool_use_id}"),
+            parent_span_id=interaction_id,
+            name=tool_name,
+            start=start,
+            end=end,
+            kind="INTERNAL",
+            attributes=attrs,
+            events=events,
+            status_code=status,
+            status_description=status_description,
+        )
+        normalized.append(projected)
+        action_spans.append(projected)
+        consumed_hook_logs.update(
+            _source_identity(item, "logs") for item in source_logs
+        )
+
     tool_results = {
         item["record"]["attributes"].get("tool_use_id")
         for item in ordered_logs
@@ -786,6 +977,8 @@ def normalize_claude_capture(
 
     for item in ordered_logs:
         record = item["record"]
+        if _source_identity(item, "logs") in consumed_hook_logs:
+            continue
         event_name = record["event_name"]
         attributes = record["attributes"]
         when = _log_time(item)

--- a/tests/test_claude_hook_capture.py
+++ b/tests/test_claude_hook_capture.py
@@ -1,0 +1,336 @@
+from __future__ import annotations
+
+import hashlib
+import json
+import multiprocessing
+import os
+from concurrent.futures import ProcessPoolExecutor
+from pathlib import Path
+
+import pytest
+
+from maida.config import load_config
+from maida.constants import REDACTED_MARKER, TRUNCATED_MARKER
+from maida.events import spans_to_events
+from maida.integrations.claude_code import (
+    import_claude_capture,
+    load_capture_segment,
+    normalize_claude_capture,
+)
+from maida.storage import list_runs
+
+
+SESSION_ID = "hook/session/../../private"
+
+
+def _payload(event: str, **overrides: object) -> dict[str, object]:
+    payload: dict[str, object] = {
+        "session_id": SESSION_ID,
+        "transcript_path": f"/tmp/{SESSION_ID}/transcript.jsonl",
+        "cwd": "/workspace/project",
+        "permission_mode": "default",
+        "hook_event_name": event,
+    }
+    if event == "SessionStart":
+        payload.update(source="startup", model="claude-test")
+    elif event == "PreToolUse":
+        payload.update(
+            tool_name="Write",
+            tool_use_id="toolu_write",
+            tool_input={"file_path": "/workspace/project/out.txt", "content": "ok"},
+        )
+    elif event == "PostToolUse":
+        payload.update(
+            tool_name="Write",
+            tool_use_id="toolu_write",
+            tool_input={"file_path": "/workspace/project/out.txt", "content": "ok"},
+            tool_response={"filePath": "/workspace/project/out.txt", "success": True},
+            duration_ms=12,
+        )
+    elif event == "PostToolUseFailure":
+        payload.update(
+            tool_name="Bash",
+            tool_use_id="toolu_bash",
+            tool_input={"command": "pytest -q"},
+            error="Exit code 1",
+            is_interrupt=False,
+            duration_ms=25,
+        )
+    elif event == "PermissionDenied":
+        payload.update(
+            tool_name="Read",
+            tool_use_id="toolu_read",
+            tool_input={"file_path": "/workspace/private.txt"},
+            reason="Blocked by classifier",
+        )
+    elif event == "SessionEnd":
+        payload.update(reason="other")
+    payload.update(overrides)
+    return payload
+
+
+def _capture_dir(data_dir: Path, segment: str = "0001") -> Path:
+    session_hash = hashlib.sha256(SESSION_ID.encode()).hexdigest()
+    return data_dir / "captures" / "claude-code" / session_hash / segment
+
+
+def _capture_worker(data_dir: str, payload: dict[str, object]) -> str:
+    os.environ["MAIDA_DATA_DIR"] = data_dir
+    from maida.capture.claude_hook import capture_claude_hook
+
+    return capture_claude_hook(payload, load_config()).segment
+
+
+def test_hook_capture_sanitizes_before_persistence(temp_data_dir, monkeypatch):
+    from maida.capture.claude_hook import capture_claude_hook
+
+    monkeypatch.setenv("MAIDA_MAX_FIELD_BYTES", "100")
+    config = load_config()
+    capture_claude_hook(_payload("SessionStart"), config)
+    capture_claude_hook(
+        _payload(
+            "PreToolUse",
+            tool_input={
+                "file_path": "/workspace/project/out.txt",
+                "content": "x" * 200,
+                "nested": {"api_token": "secret-value", "safe": "yes"},
+            },
+        ),
+        config,
+    )
+
+    capture_dir = _capture_dir(temp_data_dir)
+    persisted = "\n".join(
+        path.read_text(encoding="utf-8")
+        for path in capture_dir.parent.rglob("*")
+        if path.is_file()
+    )
+    assert SESSION_ID not in persisted
+    records = [
+        json.loads(line)
+        for line in (capture_dir / "logs.jsonl").read_text().splitlines()
+    ]
+    tool_input = records[-1]["record"]["attributes"]["tool_input"]
+    assert tool_input["nested"] == {"api_token": REDACTED_MARKER, "safe": "yes"}
+    assert tool_input["content"].endswith(TRUNCATED_MARKER)
+    assert "transcript_path" not in records[-1]["record"]["attributes"]
+
+
+@pytest.mark.parametrize(
+    "event",
+    [
+        "SessionStart",
+        "PreToolUse",
+        "PostToolUse",
+        "PostToolUseFailure",
+        "PermissionDenied",
+        "SessionEnd",
+    ],
+)
+def test_supported_hook_events_are_accepted(event, temp_data_dir):
+    from maida.capture.claude_hook import capture_claude_hook
+
+    result = capture_claude_hook(_payload(event), load_config())
+    assert result.segment == "0001"
+
+
+def test_segments_rotate_on_session_boundaries_but_not_compaction(temp_data_dir):
+    from maida.capture.claude_hook import capture_claude_hook
+
+    config = load_config()
+    assert capture_claude_hook(_payload("SessionStart"), config).segment == "0001"
+    assert (
+        capture_claude_hook(_payload("SessionStart", source="compact"), config).segment
+        == "0001"
+    )
+    assert (
+        capture_claude_hook(_payload("SessionStart", source="resume"), config).segment
+        == "0002"
+    )
+    # An exact delivery retry belongs to the already-active segment.
+    assert (
+        capture_claude_hook(_payload("SessionStart", source="resume"), config).segment
+        == "0002"
+    )
+    assert (
+        capture_claude_hook(_payload("SessionStart", source="fork"), config).segment
+        == "0003"
+    )
+    assert (
+        capture_claude_hook(_payload("SessionStart", source="clear"), config).segment
+        == "0004"
+    )
+    assert (
+        json.loads((_capture_dir(temp_data_dir, "0003") / "manifest.json").read_text())[
+            "state"
+        ]
+        == "closed"
+    )
+
+
+def test_concurrent_appends_and_duplicate_deliveries_are_safe(temp_data_dir):
+    from maida.capture.claude_hook import capture_claude_hook
+
+    capture_claude_hook(_payload("SessionStart"), load_config())
+    unique = [
+        _payload(
+            "PreToolUse",
+            tool_name="Read",
+            tool_use_id=f"toolu_{index}",
+            tool_input={"file_path": f"/workspace/{index}.txt"},
+        )
+        for index in range(12)
+    ]
+    deliveries = [*unique, unique[0], unique[0], unique[1]]
+    with ProcessPoolExecutor(
+        max_workers=4, mp_context=multiprocessing.get_context("spawn")
+    ) as executor:
+        segments = list(
+            executor.map(
+                _capture_worker,
+                [str(temp_data_dir)] * len(deliveries),
+                deliveries,
+            )
+        )
+
+    assert set(segments) == {"0001"}
+    records = [
+        json.loads(line)
+        for line in (_capture_dir(temp_data_dir) / "logs.jsonl")
+        .read_text()
+        .splitlines()
+    ]
+    pre_records = [
+        record
+        for record in records
+        if record["record"]["event_name"] == "claude_code.hook.pre_tool_use"
+    ]
+    assert len(pre_records) == len(unique)
+    assert len(
+        {record["record"]["attributes"]["event.sequence"] for record in records}
+    ) == len(records)
+    manifest = json.loads((_capture_dir(temp_data_dir) / "manifest.json").read_text())
+    assert manifest["signals"]["logs"] == len(records)
+
+
+def test_duplicate_session_end_is_idempotent(temp_data_dir):
+    from maida.capture.claude_hook import capture_claude_hook
+
+    config = load_config()
+    capture_claude_hook(_payload("SessionStart"), config)
+    first = capture_claude_hook(_payload("SessionEnd"), config)
+    second = capture_claude_hook(_payload("SessionEnd"), config)
+
+    assert first.segment == second.segment == "0001"
+    assert first.accepted is True
+    assert second.accepted is False
+    assert first.import_result.imported is True
+    assert second.import_result.imported is False
+    assert len(list_runs(limit=20, config=config)) == 1
+
+
+def test_conflicting_duplicate_tool_delivery_is_rejected(temp_data_dir):
+    from maida.capture.claude_hook import (
+        ClaudeHookConflictError,
+        capture_claude_hook,
+    )
+
+    config = load_config()
+    capture_claude_hook(_payload("SessionStart"), config)
+    capture_claude_hook(_payload("PreToolUse"), config)
+    with pytest.raises(ClaudeHookConflictError, match="conflicting duplicate"):
+        capture_claude_hook(
+            _payload("PreToolUse", tool_input={"file_path": "/changed.txt"}),
+            config,
+        )
+
+
+def test_hook_tools_pair_by_id_and_recover_incomplete_or_preless_calls(temp_data_dir):
+    from maida.capture.claude_hook import capture_claude_hook
+
+    config = load_config()
+    for payload in (
+        _payload("SessionStart"),
+        _payload("PreToolUse"),
+        _payload("PostToolUse"),
+        _payload(
+            "PreToolUse",
+            tool_name="Bash",
+            tool_use_id="toolu_incomplete",
+            tool_input={"command": "pytest -q"},
+        ),
+        _payload(
+            "PostToolUseFailure",
+            tool_name="Edit",
+            tool_use_id="toolu_preless_failure",
+            tool_input={"file_path": "/workspace/a.py"},
+            error="file changed",
+        ),
+        _payload("PermissionDenied"),
+    ):
+        capture_claude_hook(payload, config)
+
+    segment = load_capture_segment(_capture_dir(temp_data_dir))
+    normalized = normalize_claude_capture(segment, config)
+    tools = [
+        event
+        for event in spans_to_events(normalized.spans)
+        if event["event_type"] == "TOOL_CALL"
+    ]
+    by_name = {event["name"]: event for event in tools}
+    assert set(by_name) == {"Write", "Bash", "Edit", "Read"}
+    assert normalized.meta["counts"]["tool_calls"] == 4
+    write = by_name["Write"]
+    assert write["payload"]["args"]["file_path"] == "/workspace/project/out.txt"
+    assert write["payload"]["result"]["success"] is True
+    assert write["payload"]["status"] == "ok"
+    incomplete = by_name["Bash"]
+    assert incomplete["payload"]["status"] == "ok"
+    assert incomplete["meta"]["claude_code"]["terminal_missing"] is True
+    assert by_name["Edit"]["payload"]["status"] == "error"
+    assert by_name["Read"]["payload"]["status"] == "error"
+
+
+def test_abrupt_capture_remains_importable_and_session_end_imports_automatically(
+    temp_data_dir,
+):
+    from maida.capture.claude_hook import ClaudeHookImportError, capture_claude_hook
+
+    config = load_config()
+    capture_claude_hook(_payload("SessionStart"), config)
+    capture_claude_hook(_payload("PreToolUse"), config)
+    manual = import_claude_capture(SESSION_ID, config)
+    assert manual.imported is True
+
+    # A terminal event changes the active capture, so import still refuses to overwrite it.
+    capture_claude_hook(_payload("PostToolUse"), config)
+    with pytest.raises(ClaudeHookImportError, match="changed"):
+        capture_claude_hook(_payload("SessionEnd"), config)
+
+    # A complete fresh segment imports during SessionEnd without an explicit command.
+    second_session = "complete-hook-session"
+    start = _payload("SessionStart", session_id=second_session)
+    end = _payload("SessionEnd", session_id=second_session)
+    capture_claude_hook(start, config)
+    result = capture_claude_hook(end, config)
+    assert result.import_result is not None
+    assert result.import_result.imported is True
+    assert len(list_runs(limit=20, config=config)) == 2
+
+
+@pytest.mark.parametrize(
+    ("payload", "message"),
+    [
+        ({}, "session_id"),
+        (_payload("Unknown"), "unsupported"),
+        (_payload("SessionStart", source="unknown"), "source"),
+        (_payload("PreToolUse", tool_use_id=""), "tool_use_id"),
+        (_payload("PostToolUseFailure", duration_ms=-1), "duration_ms"),
+    ],
+)
+def test_malformed_hook_payloads_are_rejected(payload, message, temp_data_dir):
+    from maida.capture.claude_hook import ClaudeHookInputError, capture_claude_hook
+
+    with pytest.raises(ClaudeHookInputError, match=message):
+        capture_claude_hook(payload, load_config())
+    assert not (temp_data_dir / "captures").exists()

--- a/tests/test_claude_hook_cli.py
+++ b/tests/test_claude_hook_cli.py
@@ -1,0 +1,107 @@
+from __future__ import annotations
+
+import json
+import re
+from pathlib import Path
+
+from typer.testing import CliRunner
+
+from maida.cli import app
+
+
+def _payload(event: str, session_id: str = "cli-hook-session") -> dict[str, object]:
+    value: dict[str, object] = {
+        "session_id": session_id,
+        "transcript_path": "/tmp/transcript.jsonl",
+        "cwd": "/workspace",
+        "hook_event_name": event,
+    }
+    if event == "SessionStart":
+        value["source"] = "startup"
+    elif event == "PreToolUse":
+        value.update(
+            tool_name="Read",
+            tool_use_id="toolu_cli",
+            tool_input={"file_path": "/workspace/README.md"},
+        )
+    elif event == "PostToolUse":
+        value.update(
+            tool_name="Read",
+            tool_use_id="toolu_cli",
+            tool_input={"file_path": "/workspace/README.md"},
+            tool_response={"success": True},
+        )
+    elif event == "SessionEnd":
+        value["reason"] = "other"
+    return value
+
+
+def test_capture_claude_hook_is_silent_and_session_end_imports(temp_data_dir):
+    runner = CliRunner()
+    for event in ("SessionStart", "PreToolUse", "PostToolUse", "SessionEnd"):
+        result = runner.invoke(
+            app,
+            ["capture", "claude-hook"],
+            input=json.dumps(_payload(event)),
+        )
+        assert result.exit_code == 0, result.stderr
+        assert result.stdout == ""
+        assert result.stderr == ""
+
+
+def test_capture_claude_hook_reads_exactly_one_json_object(temp_data_dir):
+    runner = CliRunner()
+    malformed = runner.invoke(app, ["capture", "claude-hook"], input="not json")
+    assert malformed.exit_code == 10
+    assert malformed.stdout == ""
+    assert "Invalid Claude hook payload" in malformed.stderr
+
+    multiple = runner.invoke(
+        app,
+        ["capture", "claude-hook"],
+        input=json.dumps(_payload("SessionStart")) + "\n{}",
+    )
+    assert multiple.exit_code == 10
+    assert multiple.stdout == ""
+
+
+def test_capture_claude_hook_never_emits_a_policy_decision(temp_data_dir):
+    denied = {
+        "session_id": "cli-hook-session",
+        "transcript_path": "/tmp/transcript.jsonl",
+        "cwd": "/workspace",
+        "permission_mode": "auto",
+        "hook_event_name": "PermissionDenied",
+        "tool_name": "Bash",
+        "tool_input": {"command": "rm -rf /tmp/example"},
+        "tool_use_id": "toolu_denied",
+        "reason": "Blocked by classifier",
+    }
+    result = CliRunner().invoke(
+        app,
+        ["capture", "claude-hook"],
+        input=json.dumps(denied),
+    )
+    assert result.exit_code == 0
+    assert result.stdout == ""
+
+
+def test_documented_project_hook_configuration_is_valid_and_compact():
+    docs = (Path(__file__).parents[1] / "docs" / "claude-code.md").read_text()
+    match = re.search(
+        r"## Command-hook fallback.*?```json\n(?P<config>.*?)\n```",
+        docs,
+        re.DOTALL,
+    )
+    assert match is not None
+    config_text = match.group("config")
+    assert len([line for line in config_text.splitlines() if line.strip()]) <= 10
+    config = json.loads(config_text)
+    assert set(config["hooks"]) == {
+        "SessionStart",
+        "PreToolUse",
+        "PostToolUse",
+        "PostToolUseFailure",
+        "PermissionDenied",
+        "SessionEnd",
+    }


### PR DESCRIPTION
Capture supported Claude command-hook lifecycle events into immutable local segments and normalize paired tool activity through the existing Claude import path. The handler stays silent and uses non-blocking failure exits so it cannot enforce policy.

**Changes**

- add redacted, concurrent, duplicate-safe hook persistence and automatic SessionEnd import
- project complete, failed, denied, preless, and incomplete tool calls into existing TOOL_CALL spans
- document a compact project hooks configuration and recovery flow

**Tests**

- uv run pytest
- uv run pytest --cov=maida --cov-report=term-missing:skip-covered
- uv run ruff check .
- uv run ruff format --check .

Fixes #150

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>