### PR TITLE
Add capture-backed local diff gate

### DIFF
--- a/README.md
+++ b/README.md
@@ -264,6 +264,21 @@ maida diff <RUN_A> <RUN_B>
 maida diff --baseline .maida/baselines/my_agent.json  # latest run vs baseline
 ```
 
+To gate a captured Claude Code session before pushing, import and evaluate it
+in one command:
+
+```bash
+maida diff --capture "$CLAUDE_SESSION_ID" \
+  --baseline .maida/baselines/my_agent.json \
+  --policy .maida/policy.yaml \
+  --format markdown
+```
+
+Capture mode prints the same assertion and structural-diff report used by
+`maida assert`: exit `0` means pass and exit `1` means a policy regression.
+Capture selection/import notices are written to stderr, so JSON or Markdown
+stdout can be redirected directly.
+
 ### Capture Claude Code without agent patches
 
 ```bash

--- a/docs/claude-code.md
+++ b/docs/claude-code.md
@@ -75,6 +75,23 @@ to overwrite the installed run. The trace schema remains at its current
 version; normal `maida baseline`, `maida assert`, `maida diff`, and `maida view`
 commands work without a Claude-specific downstream policy path.
 
+## Gate a capture locally
+
+Use capture-backed diff mode to import the latest segment and run the same
+behavioral gate that produces Maida's PR comment:
+
+```bash
+maida diff --capture "$CLAUDE_SESSION_ID" \
+  --baseline .maida/baselines/my_agent.json \
+  --policy .maida/policy.yaml \
+  --format markdown
+```
+
+The command exits `0` when policy checks pass, `1` for a behavioral regression,
+`2` for invalid input or capture data, and `10` for an import/runtime failure.
+The selected segment and idempotent import result are reported on stderr;
+stdout contains only the requested text, JSON, or Markdown assertion report.
+
 Use `--host` and `--port` to change the bind address. Keep the receiver on a
 trusted interface: it intentionally has no authentication because its default
 use is a local process or an isolated CI job.

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -409,15 +409,23 @@ Each assertion result includes a stable `reason_code`; JSON output also includes
 
 ## `maida diff`
 
-Compares two runs, or a run against a baseline, showing structural differences in summary metrics, tool path, and event type distribution. Useful for understanding what changed when `maida assert` reports a failure. See [Regression testing](regression-testing.md) for the workflow.
+Compares two stored runs, a stored run against a baseline, or a locally
+captured Claude Code session against a baseline. Stored-run mode is an
+inspection command and exits successfully after producing a diff. Capture mode
+is a local policy gate: it normalizes and installs the selected capture, runs
+the same assertions and structural comparison as `maida assert`, and renders
+the same report used for PR comments. See [Regression
+testing](regression-testing.md) for the workflow.
 
 **Usage:**
 
 ```bash
-maida diff [TRACE_A] [TRACE_B] [--baseline FILE] [--format FORMAT]
+maida diff [TRACE_A] [TRACE_B] [--baseline FILE]
+maida diff --capture SESSION_ID --baseline FILE [--policy FILE] [--format FORMAT]
 ```
 
-Exactly one of `TRACE_B` or `--baseline` must be provided.
+In stored-run mode, exactly one of `TRACE_B` or `--baseline` must be provided.
+Positional trace IDs cannot be combined with `--capture`.
 
 **Arguments / options:**
 
@@ -426,7 +434,9 @@ Exactly one of `TRACE_B` or `--baseline` must be provided.
 | `TRACE_A` | First OTel trace ID or prefix. Defaults to the latest run when omitted |
 | `TRACE_B` | Second OTel trace ID or prefix (mutually exclusive with `--baseline`) |
 | `--baseline`, `-b` | Baseline JSON file to compare against (mutually exclusive with `TRACE_B`) |
-| `--format`, `-f` | Output format: `text` (default) |
+| `--capture` | Raw Claude Code session ID to normalize, install, and gate |
+| `--policy` | Policy YAML for capture mode. Defaults to `.maida/policy.yaml` when present |
+| `--format`, `-f` | Capture output format: `text` (default), `json`, or `markdown` |
 
 **Examples:**
 
@@ -436,9 +446,21 @@ maida diff a1b2c3d4 e5f6a7b8
 
 # Compare the latest run against a baseline
 maida diff --baseline .maida/baselines/my_agent.json
+
+# Gate a locally captured Claude Code session before pushing
+maida diff --capture "$CLAUDE_SESSION_ID" \
+  --baseline .maida/baselines/my_agent.json \
+  --policy .maida/policy.yaml \
+  --format json
 ```
 
-**Exit codes:** `0` success; `2` run or baseline not found; `10` internal error.
+**Stored-run exit codes:** `0` successful inspection; `2` run or baseline not
+found; `10` internal error.
+
+**Capture-mode exit codes:** `0` policy pass; `1` policy regression; `2`
+missing/invalid arguments, capture, baseline, or policy; `10` capture import,
+evaluation, or other runtime failure. Capture selection and import notices go
+to stderr; stdout contains only the requested report format.
 
 **Text output sections:**
 
@@ -446,3 +468,26 @@ maida diff --baseline .maida/baselines/my_agent.json
 - **Tool path** — compact baseline/current tool-call sequences, with long paths truncated in the middle
 - **Tool call changes** — new (`+`), removed (`-`), repeated (`~`), and reordered (`!`) tool calls
 - **Event type distribution** — per-event-type counts with percentage change
+
+### Reusable stored-run evaluator
+
+Automation that already has a normalized trace can use the same evaluator
+without invoking Typer:
+
+```python
+from maida.evaluation import evaluate_stored_run_against_baseline
+
+evaluation = evaluate_stored_run_against_baseline(
+    trace_id,
+    loaded_baseline,
+    policy,
+    config,
+)
+report = evaluation.report
+structural_diff = evaluation.diff
+markdown = evaluation.render("markdown", baseline_path="baseline.json")
+```
+
+The evaluator accepts in-memory baseline and policy objects. File loading,
+capture import, and progress notices remain caller concerns, which keeps it
+suitable for scenario aggregation and other non-CLI workflows.

--- a/docs/sdk.md
+++ b/docs/sdk.md
@@ -4,6 +4,12 @@ The Maida Python SDK exposes a decorator, a context manager, and three recording
 
 For the exact shape of stored events and run metadata, see the [Trace format](reference/trace-format.md) reference.
 
+For automation that needs to evaluate an already-installed trace without a
+CLI subprocess, `maida.evaluation.evaluate_stored_run_against_baseline()`
+returns both the assertion report and structural diff. Its result renders
+text, JSON, or the same Markdown report used by Maida's PR comment. See the
+[`maida diff` reference](cli.md#maida-diff) for the API example.
+
 ---
 
 ## `@trace`

--- a/maida/cli.py
+++ b/maida/cli.py
@@ -20,6 +20,7 @@ from typing import Annotated
 
 import typer
 import uvicorn
+import yaml
 from typer import Exit
 
 import maida.storage as storage
@@ -54,6 +55,7 @@ from maida.demo import (
     run_refactored_agent,
 )
 from maida.diff import compute_diff, format_diff_text
+from maida.evaluation import evaluate_stored_run_against_baseline
 from maida.integrations.langfuse import (
     LangfuseImportError,
     LangfuseInputError,
@@ -982,24 +984,25 @@ def assert_cmd(
                 typer.echo(f"Invalid baseline file: {baseline_path}", err=True)
                 raise Exit(EXIT_NOT_FOUND)
 
-        report = run_assertions(run_id, policy, baseline=bl, config=config)
-
-        run_diff = None
         if bl is not None:
-            run_diff = compute_diff(run_id, baseline=bl, config=config)
-
-        if output_format == "json":
-            typer.echo(format_report_json(report))
-        elif output_format == "markdown":
-            typer.echo(
-                format_report_markdown(
-                    report,
-                    diff=run_diff,
-                    baseline_path=str(baseline_path) if baseline_path else None,
-                )
+            evaluation = evaluate_stored_run_against_baseline(
+                run_id, bl, policy, config
             )
+            report = evaluation.report
+            render_format = (
+                output_format
+                if output_format in {"text", "json", "markdown"}
+                else "text"
+            )
+            typer.echo(evaluation.render(render_format, baseline_path=baseline_path))
         else:
-            typer.echo(format_report_text(report, diff=run_diff))
+            report = run_assertions(run_id, policy, config=config)
+            if output_format == "json":
+                typer.echo(format_report_json(report))
+            elif output_format == "markdown":
+                typer.echo(format_report_markdown(report))
+            else:
+                typer.echo(format_report_text(report))
 
         if not report.passed:
             raise Exit(1)
@@ -1225,13 +1228,103 @@ def diff_cmd(
     baseline_path: Path | None = typer.Option(
         None, "--baseline", "-b", help="Baseline JSON file to compare against"
     ),
+    capture_session_id: str | None = typer.Option(
+        None,
+        "--capture",
+        help="Claude Code session ID to import and evaluate",
+    ),
+    policy_path: Path | None = typer.Option(
+        None,
+        "--policy",
+        help="Policy YAML file for capture gate mode",
+    ),
     output_format: str = typer.Option(
-        "text", "--format", "-f", help="Output format: text"
+        "text", "--format", "-f", help="Output format: text, json, markdown"
     ),
 ) -> None:
-    """Compare two runs or a run against a baseline."""
+    """Inspect stored runs, or gate a Claude capture against a baseline."""
     try:
         config = load_config()
+
+        if capture_session_id is not None:
+            if run_a is not None or run_b is not None:
+                typer.echo(
+                    "error: positional run IDs cannot be used with --capture",
+                    err=True,
+                )
+                raise Exit(EXIT_NOT_FOUND)
+            if baseline_path is None:
+                typer.echo("error: --baseline is required with --capture", err=True)
+                raise Exit(EXIT_NOT_FOUND)
+            if output_format not in {"text", "json", "markdown"}:
+                typer.echo(
+                    "error: --format must be text, json, or markdown",
+                    err=True,
+                )
+                raise Exit(EXIT_NOT_FOUND)
+
+            try:
+                bl = load_baseline(baseline_path)
+            except FileNotFoundError:
+                typer.echo(f"Baseline not found: {baseline_path}", err=True)
+                raise Exit(EXIT_NOT_FOUND)
+            except (json.JSONDecodeError, OSError, UnicodeError, ValueError):
+                typer.echo(f"Invalid baseline file: {baseline_path}", err=True)
+                raise Exit(EXIT_NOT_FOUND)
+
+            policy = AssertionPolicy()
+            selected_policy = policy_path
+            if selected_policy is None:
+                default_policy = LOCAL_DIR_NAME / "policy.yaml"
+                if default_policy.is_file():
+                    selected_policy = default_policy
+            if selected_policy is not None:
+                try:
+                    policy = load_policy(selected_policy)
+                except (
+                    FileNotFoundError,
+                    OSError,
+                    UnicodeError,
+                    ValueError,
+                    yaml.YAMLError,
+                ):
+                    typer.echo(f"Invalid policy file: {selected_policy}", err=True)
+                    raise Exit(EXIT_NOT_FOUND)
+
+            imported = import_claude_capture(capture_session_id, config)
+            typer.echo(
+                f"Using Claude Code capture segment: {imported.segment}",
+                err=True,
+            )
+            if imported.imported:
+                typer.echo(
+                    f"Imported Claude Code capture {imported.session_hash[:12]} "
+                    f"segment {imported.segment} as {imported.trace_id[:8]}",
+                    err=True,
+                )
+            else:
+                typer.echo(
+                    f"Claude Code capture {imported.session_hash[:12]} segment "
+                    f"{imported.segment} is already imported as "
+                    f"{imported.trace_id[:8]}",
+                    err=True,
+                )
+
+            evaluation = evaluate_stored_run_against_baseline(
+                imported.trace_id,
+                bl,
+                policy,
+                config,
+            )
+            typer.echo(evaluation.render(output_format, baseline_path=baseline_path))
+            if not evaluation.passed:
+                raise Exit(1)
+            return
+
+        if policy_path is not None:
+            typer.echo("error: --policy requires --capture", err=True)
+            raise Exit(EXIT_NOT_FOUND)
+
         try:
             run_a = _resolve_run_or_latest(run_a, config)
         except FileNotFoundError as e:
@@ -1260,9 +1353,21 @@ def diff_cmd(
         typer.echo(format_diff_text(d))
     except Exit:
         raise
+    except ClaudeCaptureInputError as e:
+        typer.echo(f"Invalid Claude Code capture: {e}", err=True)
+        raise Exit(EXIT_NOT_FOUND)
+    except ClaudeCaptureImportError as e:
+        typer.echo(f"Claude Code import failed: {e}", err=True)
+        raise Exit(EXIT_INTERNAL)
     except storage.UnsupportedTraceFormatError as e:
+        if capture_session_id is not None:
+            typer.echo(f"error: {e}", err=True)
+            raise Exit(EXIT_INTERNAL)
         _exit_unsupported_trace_format(e)
     except storage.RunValidationError as e:
+        if capture_session_id is not None:
+            typer.echo(f"error: {e}", err=True)
+            raise Exit(EXIT_INTERNAL)
         _exit_run_validation_error(e)
     except Exception as e:
         typer.echo(f"error: {e}", err=True)

--- a/maida/evaluation.py
+++ b/maida/evaluation.py
@@ -1,0 +1,73 @@
+"""Reusable evaluation of a stored run against a loaded baseline.
+
+This module intentionally has no CLI dependencies. Scenario runners and other
+local workflows can evaluate an already-installed run and render the same
+reports as ``maida assert`` without routing output through Typer.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from pathlib import Path
+
+from maida.assertions import (
+    AssertionPolicy,
+    AssertionReport,
+    format_report_json,
+    format_report_markdown,
+    format_report_text,
+    run_assertions,
+)
+from maida.config import MaidaConfig, load_config
+from maida.diff import RunDiff, compute_diff
+
+
+@dataclass(frozen=True)
+class StoredRunEvaluation:
+    """Policy verdict and structural diff for one stored run and baseline."""
+
+    report: AssertionReport
+    diff: RunDiff
+
+    @property
+    def passed(self) -> bool:
+        """Whether every enabled policy assertion passed."""
+        return self.report.passed
+
+    def render(
+        self,
+        output_format: str = "text",
+        *,
+        baseline_path: str | Path | None = None,
+    ) -> str:
+        """Render with the same formatters used by the assertion CLI/PR comment."""
+        if output_format == "text":
+            return format_report_text(self.report, diff=self.diff)
+        if output_format == "json":
+            return format_report_json(self.report)
+        if output_format == "markdown":
+            return format_report_markdown(
+                self.report,
+                diff=self.diff,
+                baseline_path=str(baseline_path) if baseline_path is not None else None,
+            )
+        raise ValueError("output format must be text, json, or markdown")
+
+
+def evaluate_stored_run_against_baseline(
+    trace_id: str,
+    baseline: dict,
+    policy: AssertionPolicy,
+    config: MaidaConfig | None = None,
+) -> StoredRunEvaluation:
+    """Evaluate one installed trace against a previously loaded baseline.
+
+    Loading and validation of baseline/policy files belongs at the caller's
+    boundary. Keeping this seam data-oriented makes it suitable for both the
+    CLI and multi-scenario aggregation.
+    """
+    if config is None:
+        config = load_config()
+    report = run_assertions(trace_id, policy, baseline=baseline, config=config)
+    run_diff = compute_diff(trace_id, baseline=baseline, config=config)
+    return StoredRunEvaluation(report=report, diff=run_diff)

--- a/tests/test_capture_diff_cli.py
+++ b/tests/test_capture_diff_cli.py
@@ -1,0 +1,311 @@
+"""CLI coverage for capture-backed local behavioral gates."""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import shutil
+from pathlib import Path
+
+import pytest
+from typer.testing import CliRunner
+
+from maida.baseline import create_baseline, save_baseline
+from maida.cli import app
+from maida.config import load_config
+from maida.integrations.claude_code import (
+    ClaudeCaptureImportError,
+    import_claude_capture,
+)
+from maida.storage import RunValidationError
+
+
+FIXTURES = Path(__file__).parent / "fixtures" / "traces" / "claude-code" / "2.1.220"
+SESSIONS = {
+    "normal": "fixture-normal",
+    "regression": "fixture-regression",
+    "malformed": "fixture-malformed",
+}
+
+
+def _install_fixture(name: str, data_dir: Path) -> None:
+    session_id = SESSIONS[name]
+    session_hash = hashlib.sha256(session_id.encode()).hexdigest()
+    destination = data_dir / "captures" / "claude-code" / session_hash / "0001"
+    shutil.copytree(FIXTURES / name, destination)
+
+
+def _capture_gate_inputs(data_dir: Path) -> tuple[Path, Path]:
+    _install_fixture("normal", data_dir)
+    _install_fixture("regression", data_dir)
+    config = load_config()
+    normal = import_claude_capture(SESSIONS["normal"], config)
+    baseline_path = data_dir / "baseline.json"
+    save_baseline(create_baseline(normal.trace_id, config), baseline_path)
+    policy_path = data_dir / "policy.yaml"
+    policy_path.write_text(
+        "assert:\n"
+        "  no_new_tools: true\n"
+        "  no_loops: true\n"
+        "  max_steps: 4\n"
+        "  max_tool_calls: 2\n"
+        "  max_cost_tokens: 30\n",
+        encoding="utf-8",
+    )
+    return baseline_path, policy_path
+
+
+@pytest.mark.parametrize("output_format", ["text", "json", "markdown"])
+def test_capture_diff_failure_matches_assert_output(temp_data_dir, output_format: str):
+    baseline_path, policy_path = _capture_gate_inputs(temp_data_dir)
+    runner = CliRunner()
+
+    capture = runner.invoke(
+        app,
+        [
+            "diff",
+            "--capture",
+            SESSIONS["regression"],
+            "--baseline",
+            str(baseline_path),
+            "--policy",
+            str(policy_path),
+            "--format",
+            output_format,
+        ],
+    )
+    imported = import_claude_capture(SESSIONS["regression"], load_config())
+    asserted = runner.invoke(
+        app,
+        [
+            "assert",
+            imported.trace_id,
+            "--baseline",
+            str(baseline_path),
+            "--policy",
+            str(policy_path),
+            "--format",
+            output_format,
+        ],
+    )
+
+    assert capture.exit_code == asserted.exit_code == 1
+    assert capture.stdout == asserted.stdout
+    assert "Using Claude Code capture segment: 0001" in capture.stderr
+    assert "Imported Claude Code capture" in capture.stderr
+    if output_format == "json":
+        assert json.loads(capture.stdout)["passed"] is False
+    elif output_format == "markdown":
+        assert "Maida verdict: fail" in capture.stdout
+        assert "Top behavior changes" in capture.stdout
+    else:
+        assert "RESULT: FAILED" in capture.stdout
+        assert "Run comparison:" in capture.stdout
+
+
+def test_capture_diff_pass_is_zero_and_keeps_notices_off_stdout(temp_data_dir):
+    baseline_path, _ = _capture_gate_inputs(temp_data_dir)
+
+    result = CliRunner().invoke(
+        app,
+        [
+            "diff",
+            "--capture",
+            SESSIONS["normal"],
+            "--baseline",
+            str(baseline_path),
+            "--format",
+            "json",
+        ],
+    )
+
+    assert result.exit_code == 0
+    assert json.loads(result.stdout)["passed"] is True
+    assert "Claude Code capture" not in result.stdout
+    assert "Using Claude Code capture segment: 0001" in result.stderr
+    assert "already imported" in result.stderr
+
+
+@pytest.mark.parametrize(
+    ("arguments", "message"),
+    [
+        (["--capture", "missing"], "--baseline is required with --capture"),
+        (
+            ["existing-run", "--capture", "missing", "--baseline", "missing.json"],
+            "positional run IDs cannot be used with --capture",
+        ),
+        (
+            [
+                "--capture",
+                "missing",
+                "--baseline",
+                "missing.json",
+                "--format",
+                "xml",
+            ],
+            "--format must be text, json, or markdown",
+        ),
+    ],
+)
+def test_capture_diff_rejects_invalid_option_combinations(
+    temp_data_dir, arguments: list[str], message: str
+):
+    result = CliRunner().invoke(app, ["diff", *arguments])
+
+    assert result.exit_code == 2
+    assert result.stdout == ""
+    assert message in result.stderr
+
+
+def test_capture_diff_invalid_capture_baseline_and_policy_are_exit_two(temp_data_dir):
+    baseline_path, policy_path = _capture_gate_inputs(temp_data_dir)
+    runner = CliRunner()
+
+    missing_capture = runner.invoke(
+        app,
+        [
+            "diff",
+            "--capture",
+            "does-not-exist",
+            "--baseline",
+            str(baseline_path),
+            "--policy",
+            str(policy_path),
+            "--format",
+            "json",
+        ],
+    )
+    assert missing_capture.exit_code == 2
+    assert missing_capture.stdout == ""
+    assert "Invalid Claude Code capture" in missing_capture.stderr
+
+    malformed_baseline = temp_data_dir / "malformed.json"
+    malformed_baseline.write_text("{", encoding="utf-8")
+    invalid_baseline = runner.invoke(
+        app,
+        [
+            "diff",
+            "--capture",
+            SESSIONS["regression"],
+            "--baseline",
+            str(malformed_baseline),
+        ],
+    )
+    assert invalid_baseline.exit_code == 2
+    assert invalid_baseline.stdout == ""
+    assert "Invalid baseline file" in invalid_baseline.stderr
+
+    missing_policy = runner.invoke(
+        app,
+        [
+            "diff",
+            "--capture",
+            SESSIONS["regression"],
+            "--baseline",
+            str(baseline_path),
+            "--policy",
+            str(temp_data_dir / "missing-policy.yaml"),
+        ],
+    )
+    assert missing_policy.exit_code == 2
+    assert missing_policy.stdout == ""
+    assert "Invalid policy file" in missing_policy.stderr
+
+    malformed_policy = temp_data_dir / "malformed-policy.yaml"
+    malformed_policy.write_text("assert: [\n", encoding="utf-8")
+    invalid_policy = runner.invoke(
+        app,
+        [
+            "diff",
+            "--capture",
+            SESSIONS["regression"],
+            "--baseline",
+            str(baseline_path),
+            "--policy",
+            str(malformed_policy),
+        ],
+    )
+    assert invalid_policy.exit_code == 2
+    assert invalid_policy.stdout == ""
+    assert "Invalid policy file" in invalid_policy.stderr
+
+
+def test_capture_diff_malformed_capture_is_exit_two(temp_data_dir):
+    baseline_path, _ = _capture_gate_inputs(temp_data_dir)
+    _install_fixture("malformed", temp_data_dir)
+
+    result = CliRunner().invoke(
+        app,
+        [
+            "diff",
+            "--capture",
+            SESSIONS["malformed"],
+            "--baseline",
+            str(baseline_path),
+        ],
+    )
+
+    assert result.exit_code == 2
+    assert result.stdout == ""
+    assert "Invalid Claude Code capture" in result.stderr
+
+
+def test_capture_diff_ingestion_and_runtime_failures_are_exit_ten(
+    monkeypatch, temp_data_dir
+):
+    baseline_path, _ = _capture_gate_inputs(temp_data_dir)
+    runner = CliRunner()
+
+    def fail_import(*args, **kwargs):
+        raise ClaudeCaptureImportError("ingestion failed")
+
+    monkeypatch.setattr("maida.cli.import_claude_capture", fail_import)
+    ingestion = runner.invoke(
+        app,
+        [
+            "diff",
+            "--capture",
+            SESSIONS["regression"],
+            "--baseline",
+            str(baseline_path),
+        ],
+    )
+    assert ingestion.exit_code == 10
+    assert ingestion.stdout == ""
+    assert "Claude Code import failed: ingestion failed" in ingestion.stderr
+
+    monkeypatch.undo()
+
+    def fail_evaluation(*args, **kwargs):
+        raise RunValidationError("a" * 32, "evaluation failed")
+
+    monkeypatch.setattr(
+        "maida.cli.evaluate_stored_run_against_baseline", fail_evaluation
+    )
+    runtime = runner.invoke(
+        app,
+        [
+            "diff",
+            "--capture",
+            SESSIONS["regression"],
+            "--baseline",
+            str(baseline_path),
+        ],
+    )
+    assert runtime.exit_code == 10
+    assert runtime.stdout == ""
+    assert "error: Run validation failed" in runtime.stderr
+    assert "evaluation failed" in runtime.stderr
+
+
+def test_legacy_diff_still_inspects_regressions_with_exit_zero(temp_data_dir):
+    baseline_path, _ = _capture_gate_inputs(temp_data_dir)
+    regression = import_claude_capture(SESSIONS["regression"], load_config())
+
+    result = CliRunner().invoke(
+        app, ["diff", regression.trace_id, "--baseline", str(baseline_path)]
+    )
+
+    assert result.exit_code == 0
+    assert "Run comparison:" in result.stdout
+    assert "Bash" in result.stdout

--- a/tests/test_evaluation.py
+++ b/tests/test_evaluation.py
@@ -1,0 +1,66 @@
+"""Tests for the reusable stored-run evaluation service."""
+
+import pytest
+
+from maida import record_tool_call, traced_run
+from maida.assertions import (
+    AssertionPolicy,
+    format_report_json,
+    format_report_markdown,
+    format_report_text,
+)
+from maida.baseline import create_baseline
+from maida.config import load_config
+from maida.evaluation import evaluate_stored_run_against_baseline
+from tests.conftest import get_latest_run_id
+
+
+def test_evaluate_stored_run_returns_report_diff_and_formatter_parity(temp_data_dir):
+    config = load_config()
+    with traced_run(name="baseline"):
+        record_tool_call("Read", args={}, result=None)
+    baseline_id = get_latest_run_id(config)
+    baseline = create_baseline(baseline_id, config)
+
+    with traced_run(name="regression"):
+        record_tool_call("Read", args={}, result=None)
+        record_tool_call("Bash", args={}, result=None)
+    current_id = get_latest_run_id(config)
+    policy = AssertionPolicy(no_new_tools=True)
+
+    evaluation = evaluate_stored_run_against_baseline(
+        current_id,
+        baseline,
+        policy,
+        config,
+    )
+
+    assert evaluation.passed is False
+    assert evaluation.report.run_id == current_id
+    assert evaluation.diff.run_a_id == current_id
+    assert evaluation.render("text") == format_report_text(
+        evaluation.report, diff=evaluation.diff
+    )
+    assert evaluation.render("json") == format_report_json(evaluation.report)
+    assert evaluation.render(
+        "markdown", baseline_path="baseline.json"
+    ) == format_report_markdown(
+        evaluation.report,
+        diff=evaluation.diff,
+        baseline_path="baseline.json",
+    )
+
+
+def test_evaluation_rejects_unknown_output_format(temp_data_dir):
+    config = load_config()
+    with traced_run(name="same"):
+        pass
+    trace_id = get_latest_run_id(config)
+    evaluation = evaluate_stored_run_against_baseline(
+        trace_id,
+        create_baseline(trace_id, config),
+        AssertionPolicy(),
+    )
+
+    with pytest.raises(ValueError, match="text, json, or markdown"):
+        evaluation.render("xml")


### PR DESCRIPTION
Evaluate imported Claude Code captures through the same policy, structural diff, and report formatters used by stored-run assertions while preserving inspection-only diff behavior.

**Changes**

- add a reusable stored-run evaluation service with text, JSON, and Markdown rendering
- add capture diff mode with stable exit codes and stderr-only import notices
- document and test CLI parity, invalid inputs, and runtime failures

**Tests**

- uv run pytest --cov
- uv run ruff check .
- uv run ruff format --check .

Fixes #152

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>