### PR TITLE
Prove Claude capture transport convergence

### DIFF
--- a/docs/claude-code.md
+++ b/docs/claude-code.md
@@ -4,6 +4,31 @@ Maida can receive Claude Code's OpenTelemetry events and beta traces without
 patching agent code. The receiver binds to loopback by default and writes only
 to local Maida storage.
 
+## Core capture-to-gate workflow
+
+The OTel receiver is the default capture path. The passive command hook is a
+fallback when exporter access or tool detail is unavailable. Both transports
+write the same source-capture contract and converge at one framework-agnostic
+normalizer:
+
+```text
+Claude Code ── OTLP logs/traces ─┐
+                                ├─ capture segment ─ import ─ Maida trace ─ gate
+Claude Code ── command hooks ────┘                                  └─ scenario run
+```
+
+After import, baseline creation, assertion policy, structural diff, report
+formatting, and trace viewing are transport-independent. `maida scenario run`
+owns the reproducible headless orchestration and uses the OTel path internally;
+it evaluates through the same stored-run service as `maida diff --capture`.
+
+Choose one entry point:
+
+- `maida capture claude-code` for normal local and CI telemetry capture.
+- `maida capture claude-hook` for the observer-only lifecycle fallback.
+- `maida scenario run` for pinned, isolated prompt fixtures and automatic
+  capture/import/evaluation.
+
 Start the receiver:
 
 ```bash

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -24,6 +24,30 @@ the local storage contract.
 
 ---
 
+## `maida capture claude-hook`
+
+Reads exactly one supported Claude Code command-hook payload from stdin and
+appends it to the hashed session capture without returning a hook decision.
+
+```bash
+maida capture claude-hook
+```
+
+The handler supports `SessionStart`, `PreToolUse`, `PostToolUse`,
+`PostToolUseFailure`, `PermissionDenied`, and `SessionEnd`. Successful handling
+writes nothing to stdout or stderr. The command is passive: it never returns
+allow, deny, retry, or context fields and never uses Claude's blocking exit
+code 2. `SessionEnd` closes and imports the segment automatically; abrupt
+segments remain available to `maida import claude-code`.
+
+**Exit codes:** `0` captured; `10` invalid payload, conflicting delivery,
+automatic-import failure, or internal error.
+
+See [Command-hook fallback](claude-code.md#command-hook-fallback) for the compact
+project settings configuration, lifecycle segmentation, and privacy contract.
+
+---
+
 ## `maida import claude-code`
 
 Normalizes one local Claude Code capture into the current Maida trace schema

--- a/maida/integrations/claude_code.py
+++ b/maida/integrations/claude_code.py
@@ -1303,9 +1303,30 @@ def normalize_claude_capture(
         "status_code": "ERROR" if errors else "OK",
         "status_description": "Claude Code capture contains failures" if errors else "",
     }
+    by_normalized_id = {span["span_id"]: span for span in normalized}
+
+    def topology_depth(span: dict[str, Any]) -> int:
+        depth = 1
+        parent = span.get("parent_span_id")
+        seen: set[str] = set()
+        while isinstance(parent, str) and parent in by_normalized_id:
+            if parent in seen:  # Defensive: source cycles were repaired above.
+                break
+            seen.add(parent)
+            depth += 1
+            parent = by_normalized_id[parent].get("parent_span_id")
+        return depth
+
     all_spans = [
         root,
-        *sorted(normalized, key=lambda span: (span["start_time"], span["span_id"])),
+        *sorted(
+            normalized,
+            key=lambda span: (
+                span["start_time"],
+                topology_depth(span),
+                span["span_id"],
+            ),
+        ),
     ]
     meta = {
         "spec_version": SPEC_VERSION,

--- a/tests/test_claude_capture_convergence.py
+++ b/tests/test_claude_capture_convergence.py
@@ -1,0 +1,159 @@
+"""Integrated equivalence coverage for Claude OTel and hook capture paths."""
+
+from __future__ import annotations
+
+import json
+
+from fastapi.testclient import TestClient
+from opentelemetry.proto.collector.logs.v1.logs_service_pb2 import (
+    ExportLogsServiceRequest,
+)
+from opentelemetry.proto.common.v1.common_pb2 import AnyValue, KeyValue
+from opentelemetry.proto.logs.v1.logs_pb2 import LogRecord, ResourceLogs, ScopeLogs
+from opentelemetry.proto.resource.v1.resource_pb2 import Resource
+from typer.testing import CliRunner
+
+from maida.baseline import create_baseline, extract_run_metrics, save_baseline
+from maida.capture.claude_code import create_claude_code_app
+from maida.capture.claude_hook import capture_claude_hook
+from maida.cli import app
+from maida.config import load_config
+from maida.integrations.claude_code import import_claude_capture
+from maida.storage import load_run_for_analysis
+
+
+def _kv(key: str, value: object) -> KeyValue:
+    encoded = AnyValue()
+    if isinstance(value, bool):
+        encoded.bool_value = value
+    elif isinstance(value, int):
+        encoded.int_value = value
+    else:
+        encoded.string_value = str(value)
+    return KeyValue(key=key, value=encoded)
+
+
+def _capture_otel_tool(session_id: str) -> None:
+    attributes = [
+        _kv("session.id", session_id),
+        _kv("event.name", "tool_result"),
+        _kv("event.sequence", 1),
+        _kv("event.timestamp", "2026-08-08T12:00:00Z"),
+        _kv("tool_name", "Read"),
+        _kv("tool_use_id", "toolu_equivalent"),
+        _kv("success", True),
+        _kv("duration_ms", 0),
+        _kv("tool_input", json.dumps({"file_path": "/workspace/README.md"})),
+    ]
+    request = ExportLogsServiceRequest(
+        resource_logs=[
+            ResourceLogs(
+                resource=Resource(
+                    attributes=[
+                        _kv("service.name", "claude-code"),
+                        _kv("app.version", "2.1.220"),
+                    ]
+                ),
+                scope_logs=[
+                    ScopeLogs(
+                        log_records=[
+                            LogRecord(
+                                time_unix_nano=1_754_656_800_000_000_000,
+                                observed_time_unix_nano=1_754_656_800_000_000_000,
+                                body=AnyValue(string_value="claude_code.tool_result"),
+                                attributes=attributes,
+                            )
+                        ]
+                    )
+                ],
+            )
+        ]
+    )
+    response = TestClient(create_claude_code_app(load_config())).post(
+        "/v1/logs",
+        content=request.SerializeToString(),
+        headers={"content-type": "application/x-protobuf"},
+    )
+    assert response.status_code == 200
+
+
+def _capture_hook_tool(session_id: str) -> None:
+    capture_claude_hook(
+        {
+            "session_id": session_id,
+            "transcript_path": "/private/transcript.jsonl",
+            "cwd": "/workspace",
+            "hook_event_name": "PreToolUse",
+            "tool_name": "Read",
+            "tool_use_id": "toolu_equivalent",
+            "tool_input": {"file_path": "/workspace/README.md"},
+        },
+        load_config(),
+    )
+
+
+def _downstream_semantics(trace_id: str) -> dict:
+    _full_id, meta, events = load_run_for_analysis(trace_id, load_config())
+    return {
+        "metrics": extract_run_metrics(meta, events),
+        "events": [
+            {
+                "event_type": event["event_type"],
+                "name": event["name"],
+                "payload": event["payload"],
+            }
+            for event in events
+            if event["event_type"] not in {"RUN_START", "RUN_END"}
+        ],
+    }
+
+
+def test_otel_and_hook_capture_converge_on_semantics_and_local_gate_output(
+    temp_data_dir,
+):
+    otel_session = "integrated-otel-session"
+    hook_session = "integrated-hook-session"
+    _capture_otel_tool(otel_session)
+    _capture_hook_tool(hook_session)
+
+    config = load_config()
+    otel = import_claude_capture(otel_session, config)
+    hook = import_claude_capture(hook_session, config)
+    assert _downstream_semantics(otel.trace_id) == _downstream_semantics(hook.trace_id)
+
+    baseline_path = temp_data_dir / "equivalent-baseline.json"
+    save_baseline(create_baseline(otel.trace_id, config), baseline_path)
+    policy_path = temp_data_dir / "equivalent-policy.yaml"
+    policy_path.write_text(
+        "assert:\n"
+        "  no_new_tools: true\n"
+        "  no_loops: true\n"
+        "  max_steps: 2\n"
+        "  max_tool_calls: 1\n",
+        encoding="utf-8",
+    )
+
+    runner = CliRunner()
+    outputs = []
+    for session_id in (otel_session, hook_session):
+        result = runner.invoke(
+            app,
+            [
+                "diff",
+                "--capture",
+                session_id,
+                "--baseline",
+                str(baseline_path),
+                "--policy",
+                str(policy_path),
+                "--format",
+                "text",
+            ],
+        )
+        assert result.exit_code == 0, result.stderr
+        assert "Claude Code capture" not in result.stdout
+        assert "already imported" in result.stderr
+        outputs.append(result.stdout)
+
+    assert outputs[0] == outputs[1]
+    assert "RESULT: PASSED" in outputs[0]


### PR DESCRIPTION
Normalize equal-timestamp spans in topology order and verify OTel and hook inputs converge on identical downstream semantics and local-gate output.

**Changes**

- add deterministic OTel-versus-hook import and capture-diff integration coverage
- order interaction parents before equal-time action children
- consolidate the core capture-to-gate and hook CLI documentation

**Tests**

- `uv run pytest -q -n 0 tests/test_claude_capture_convergence.py tests/test_claude_hook_capture.py tests/integrations/test_claude_code_integration.py tests/test_capture_diff_cli.py tests/test_scenario_runner.py tests/test_scenario_cli.py tests/test_docs.py`
- `uv run ruff check .`
- `uv run ruff format --check .`

Fixes #148

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>