### PR TITLE
Align drift with native external traces

### DIFF
--- a/docs/cli.md
+++ b/docs/cli.md
@@ -1,6 +1,6 @@
 # CLI
 
-The `maida` CLI runs the bundled demo, scaffolds a project, validates and imports existing traces, lists runs, starts the local viewer, exports runs to JSON, updates baselines intentionally, and gates runs against baselines. Storage is under `~/.maida/` by default (overridable with `MAIDA_DATA_DIR`). For all configuration options and precedence, see the [configuration reference](reference/config.md).
+The `maida` CLI runs the bundled demo, scaffolds a project, validates and imports existing traces, lists runs, starts the local viewer, exports runs to JSON, updates baselines intentionally, and gates individual runs or completed windows against baselines. Storage is under `~/.maida/` by default (overridable with `MAIDA_DATA_DIR`). For all configuration options and precedence, see the [configuration reference](reference/config.md).
 
 Commands that take a run ID (`assert`, `baseline`, `accept`, `export`, `diff`) default to the **latest run** when the ID is omitted. The selected run is announced on stderr so stdout stays machine-readable.
 
@@ -428,6 +428,38 @@ maida run my_agent.py --baseline .maida/baselines/my_agent.json \
 ```
 
 Each trial must create exactly one completed trace. Exit `1` is reserved for FAIL; PASS and the provider-neutral INCONCLUSIVE verdict exit `0`, so CI consumers must read the JSON `verdict` rather than infer uncertainty from the process status. Missing inputs exit `2` and internal execution failures exit `10`.
+
+## `maida drift`
+
+Evaluates a completed native Maida trace window against one agent baseline
+without executing the agent or changing the source traces.
+
+```bash
+maida drift --window RUNS_DIR --baseline BASELINE [options]
+```
+
+| Argument/Option | Default | Description |
+|---|---|---|
+| `--window` | required | Native Maida `runs/` directory containing completed traces |
+| `--baseline`, `-b` | required | Baseline JSON for one agent; directories are not yet accepted |
+| `--policy` | `.maida/policy.yaml` | Tier-aware gate policy |
+| `--agent` | baseline `source_run_name` | Explicit agent selector for legacy baselines |
+| `--format`, `-f` | `text` | `text`, `json`, or verdict-first `markdown` |
+| `--json-out` | - | Atomically write report schema `2.0.0` to a sidecar |
+
+```bash
+maida drift --window /srv/agents/orders/runs \
+  --baseline .maida/baselines/orders-agent.json \
+  --policy .maida/policy.yaml \
+  --format markdown --json-out orders-agent-drift.json
+```
+
+The baseline selects matching `run_name` values from a mixed-agent window. Run
+the command once per baseline. Exit `0` means PASS or neutral INCONCLUSIVE,
+`1` means FAIL, `2` means invalid input, and `10` means an internal error.
+
+See [Scheduled behavioral regression checks](scheduled-checks.md) for sample
+validation, scheduler guidance, canary promotion, and planned input adapters.
 
 ## `maida assert`
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -59,7 +59,8 @@ After any run, inspect evidence with `maida view`, capture baselines with `maida
 | [Getting started](getting-started.md) | Installation (uv/pip), quickstart, data dir, redaction |
 | [Guardrails](guardrails.md) | Stop runaway runs with loop, count, and duration limits |
 | [Regression testing](regression-testing.md) | Baseline, assert, and diff workflow for catching agent regressions |
-| [CLI](cli.md) | `demo`, `init`, `validate-trace`, `list`, `view`, `export`, `baseline`, `accept`, `assert`, `diff` with options and exit codes |
+| [Scheduled checks](scheduled-checks.md) | Batch verdicts over completed production trace windows |
+| [CLI](cli.md) | `demo`, `init`, `validate-trace`, `import`, `run`, `drift`, `list`, `view`, `export`, `baseline`, `accept`, `assert`, `diff` with options and exit codes |
 | [Viewer](viewer.md) | Timeline UI usage, URL params, live refresh, and development |
 | [SDK](sdk.md) | `@trace`, `traced_run`, `has_active_run`, `record_llm_call`, `record_tool_call`, `record_state` |
 | [Integrations](integrations.md) | LangChain handler, OpenAI Agents adapter, and planned adapters |

--- a/docs/scheduled-checks.md
+++ b/docs/scheduled-checks.md
@@ -1,0 +1,70 @@
+# Scheduled behavioral regression checks
+
+`maida drift` applies the same policy and verdict rules as the pre-merge gate
+to a completed window of production traces. It is a local batch command: the
+traces, baseline, policy, and report remain inside your infrastructure.
+
+## Run a scheduled check
+
+Point `--window` at a native Maida `runs/` directory whose direct children are
+completed trace directories containing `meta.json` and `spans.jsonl`:
+
+```bash
+maida drift \
+  --window /srv/agents/orders/runs \
+  --baseline .maida/baselines/orders-agent.json \
+  --policy .maida/policy.yaml \
+  --format markdown \
+  --json-out /srv/reports/orders-agent-drift.json
+```
+
+The command reads the window without copying or changing its traces. It
+validates the sample before evaluation and rejects empty, incomplete, corrupt,
+or unsupported traces rather than silently dropping evidence.
+
+The baseline's `source_run_name` selects the agent. A mixed directory can hold
+several agents, but this release evaluates one baseline per invocation. For a
+legacy baseline without `source_run_name`, pass `--agent` explicitly. Schedule
+one command per agent when a job owns multiple baselines.
+
+## Verdicts and scheduler behavior
+
+Drift checks preserve the gate's current metric semantics:
+
+- invariant checks fail on a violation;
+- measured checks use their configured limit or baseline tolerance;
+- distributional checks use the baseline sample's prediction bound;
+- statistical checks use the configured one-sided Wilson verdict.
+
+Markdown starts with PASS, FAIL, or INCONCLUSIVE and includes the same metric
+evidence and baseline-change language as the gate report. JSON uses report
+schema `2.0.0`, adds `report_kind: drift`, and records every source trace ID and
+run status.
+
+| Exit | Meaning |
+| ---: | --- |
+| `0` | PASS or neutral INCONCLUSIVE |
+| `1` | confirmed FAIL |
+| `2` | missing, invalid, incomplete, or ambiguous input |
+| `10` | internal execution error |
+
+Schedulers should retain the JSON report when they need to distinguish PASS
+from INCONCLUSIVE, because both are non-failing process outcomes.
+
+## Canary promotion
+
+Capture and review the pre-change window as the canary baseline. Route the
+change to one instance, collect a complete post-change window, and evaluate it
+with `maida drift`. Complete promotion only when the canary report is PASS;
+treat INCONCLUSIVE as a request for more evidence rather than a failure.
+
+## Input compatibility
+
+This first release accepts native Maida run directories only. The window
+loader is adapter-based so the published external interchange contract from
+[#172](https://github.com/maida-ai/maida/issues/172) and `maida export` JSON
+bundles can be added later without changing the per-agent verdict body.
+
+Baseline paths are files today. Directory fanout is intentionally reserved for
+a later release; automation should invoke once per baseline and should not
+invent a baseline-directory manifest in the meantime.

--- a/docs/scheduled-checks.md
+++ b/docs/scheduled-checks.md
@@ -60,10 +60,11 @@ treat INCONCLUSIVE as a request for more evidence rather than a failure.
 
 ## Input compatibility
 
-This first release accepts native Maida run directories only. The window
-loader is adapter-based so the published external interchange contract from
-[#172](https://github.com/maida-ai/maida/issues/172) and `maida export` JSON
-bundles can be added later without changing the per-agent verdict body.
+This release accepts native Maida run directories. External emitters that
+follow the native trace contract can write their completed traces directly
+beneath `runs/`; the same validation and drift analysis apply without an
+emitter-specific adapter. `maida export` JSON window inputs remain a future
+source format that can be added without changing the per-agent verdict body.
 
 Baseline paths are files today. Directory fanout is intentionally reserved for
 a later release; automation should invoke once per baseline and should not

--- a/maida/cli.py
+++ b/maida/cli.py
@@ -55,6 +55,7 @@ from maida.demo import (
     run_refactored_agent,
 )
 from maida.diff import compute_diff, format_diff_text
+from maida.drift import DriftWindowError, run_drift
 from maida.evaluation import evaluate_stored_run_against_baseline
 from maida.integrations.langfuse import (
     LangfuseImportError,
@@ -703,6 +704,85 @@ def run_cmd(
     except (RunExecutionError, subprocess.SubprocessError) as error:
         typer.echo(f"error: {error}", err=True)
         raise Exit(EXIT_INTERNAL)
+    except Exception as error:
+        typer.echo(f"error: {error}", err=True)
+        raise Exit(EXIT_INTERNAL)
+
+
+@app.command(name="drift")
+def drift_cmd(
+    window: Path = typer.Option(
+        ..., "--window", help="Native Maida runs directory to evaluate"
+    ),
+    baseline_path: Path = typer.Option(
+        ..., "--baseline", "-b", help="Baseline JSON file for one agent"
+    ),
+    policy_path: Path | None = typer.Option(None, "--policy", help="Policy YAML file"),
+    agent_name: str | None = typer.Option(
+        None,
+        "--agent",
+        help="Agent run name; required when the baseline does not record one",
+    ),
+    output_format: str = typer.Option(
+        "text", "--format", "-f", help="Output format: text, json, or markdown"
+    ),
+    json_out: Path | None = typer.Option(
+        None, "--json-out", help="Also write the machine-readable report to this path"
+    ),
+) -> None:
+    """Check a persisted production trace window for behavioral regressions."""
+    try:
+        if output_format not in {"text", "json", "markdown"}:
+            raise ValueError("format must be 'text', 'json', or 'markdown'")
+        if not baseline_path.is_file():
+            typer.echo(
+                f"Baseline must be a JSON file: {baseline_path}. "
+                "Run once per baseline; baseline-directory fanout is not yet supported.",
+                err=True,
+            )
+            raise Exit(EXIT_NOT_FOUND)
+        try:
+            baseline = load_baseline(baseline_path)
+        except (json.JSONDecodeError, ValueError, OSError) as error:
+            typer.echo(f"Invalid baseline {baseline_path}: {error}", err=True)
+            raise Exit(EXIT_NOT_FOUND)
+
+        policy = AssertionPolicy()
+        selected_policy = policy_path
+        if selected_policy is None:
+            default_policy = LOCAL_DIR_NAME / "policy.yaml"
+            if default_policy.is_file():
+                selected_policy = default_policy
+        if selected_policy is not None:
+            policy = load_policy(selected_policy)
+
+        report = run_drift(
+            window,
+            baseline=baseline,
+            policy=policy,
+            config=load_config(),
+            agent_name=agent_name,
+        )
+        if json_out is not None:
+            json_out.parent.mkdir(parents=True, exist_ok=True)
+            temporary = json_out.with_name(f".{json_out.name}.{os.getpid()}.tmp")
+            temporary.write_text(report.to_json() + "\n", encoding="utf-8")
+            os.replace(temporary, json_out)
+
+        if output_format == "json":
+            rendered = report.to_json()
+        elif output_format == "markdown":
+            rendered = report.to_markdown()
+        else:
+            rendered = report.to_text()
+        typer.echo(rendered)
+        if report.verdict is GateVerdict.FAIL:
+            raise Exit(1)
+    except Exit:
+        raise
+    except (DriftWindowError, FileNotFoundError, ValueError) as error:
+        typer.echo(f"Invalid drift input: {error}", err=True)
+        raise Exit(EXIT_NOT_FOUND)
     except Exception as error:
         typer.echo(f"error: {error}", err=True)
         raise Exit(EXIT_INTERNAL)

--- a/maida/drift.py
+++ b/maida/drift.py
@@ -1,0 +1,230 @@
+"""Read-only scheduled checks over a persisted window of Maida traces."""
+
+from __future__ import annotations
+
+from dataclasses import asdict, dataclass, replace
+from datetime import datetime
+from pathlib import Path
+from typing import Protocol
+
+import maida.storage as storage
+from maida.assertions import AssertionPolicy, run_assertions
+from maida.baseline import extract_run_metrics
+from maida.baseline_bind import validate_policy_against_baseline
+from maida.config import MaidaConfig
+from maida.diff import compute_diff
+from maida.gate import (
+    aggregate_metrics,
+    invariant_outcomes,
+    numeric_metrics,
+    structural_signature,
+)
+from maida.policy import merge_policy
+from maida.runner_v2 import TrialRecord, TrialRunReport, _v2_assertion_report
+
+
+class DriftWindowError(ValueError):
+    """The requested persisted trace window cannot be evaluated safely."""
+
+
+@dataclass(frozen=True)
+class LoadedWindowTrace:
+    """One fully validated native trace selected for a drift sample."""
+
+    trace_id: str
+    meta: dict
+    events: list[dict]
+    started_at: datetime
+
+
+class TraceWindowSource(Protocol):
+    """Adapter boundary for native and future interchange trace windows."""
+
+    analysis_config: MaidaConfig
+
+    def load(self, agent_name: str) -> list[LoadedWindowTrace]: ...
+
+
+# TODO(#172): add external-interchange and ``maida export`` window sources after
+# the published trace validator defines their stable ingestion contract.
+
+
+def _parse_started_at(trace_id: str, value: object) -> datetime:
+    if not isinstance(value, str):
+        raise DriftWindowError(f"Trace {trace_id[:8]} has no valid started_at")
+    try:
+        parsed = datetime.fromisoformat(value.replace("Z", "+00:00"))
+    except ValueError as error:
+        raise DriftWindowError(
+            f"Trace {trace_id[:8]} has invalid started_at {value!r}"
+        ) from error
+    if parsed.tzinfo is None:
+        raise DriftWindowError(
+            f"Trace {trace_id[:8]} started_at must include a timezone"
+        )
+    return parsed
+
+
+class NativeTraceWindowSource:
+    """Load current native ``runs/<trace_id>/`` directories without mutation."""
+
+    def __init__(self, runs_dir: Path, config: MaidaConfig) -> None:
+        self.runs_dir = runs_dir.expanduser().resolve()
+        if not self.runs_dir.is_dir():
+            raise DriftWindowError(f"Trace window directory not found: {runs_dir}")
+        if self.runs_dir.name != "runs":
+            raise DriftWindowError(
+                "Trace window must be a native Maida runs directory ending in /runs"
+            )
+        self.analysis_config = replace(config, data_dir=self.runs_dir.parent)
+
+    def load(self, agent_name: str) -> list[LoadedWindowTrace]:
+        candidates = sorted(
+            entry
+            for entry in self.runs_dir.iterdir()
+            if entry.is_dir() and not entry.name.startswith(".")
+        )
+        if not candidates:
+            raise DriftWindowError(f"Trace window {self.runs_dir} contains no traces")
+
+        loaded: list[LoadedWindowTrace] = []
+        for entry in candidates:
+            try:
+                trace_id, meta, events = storage.load_run_for_analysis(
+                    entry.name, self.analysis_config
+                )
+            except (FileNotFoundError, ValueError, storage.RunValidationError) as error:
+                raise DriftWindowError(
+                    f"Invalid trace window entry {entry.name}: {error}"
+                ) from error
+            except storage.UnsupportedTraceFormatError as error:
+                raise DriftWindowError(str(error)) from error
+            if meta.get("status") == "running" or meta.get("ended_at") is None:
+                raise DriftWindowError(
+                    f"Trace {trace_id[:8]} is incomplete; only completed traces "
+                    "can enter a drift window"
+                )
+            started_at = _parse_started_at(trace_id, meta.get("started_at"))
+            if meta.get("run_name") == agent_name:
+                loaded.append(
+                    LoadedWindowTrace(
+                        trace_id=trace_id,
+                        meta=meta,
+                        events=events,
+                        started_at=started_at,
+                    )
+                )
+
+        if not loaded:
+            raise DriftWindowError(
+                f"Trace window contains no completed traces for agent {agent_name!r}"
+            )
+        loaded.sort(key=lambda item: (item.started_at, item.trace_id))
+        return loaded
+
+
+@dataclass(frozen=True)
+class DriftTarget:
+    """One agent/baseline pair; future directory fanout yields multiple targets."""
+
+    agent_name: str
+    baseline: dict
+
+
+def resolve_drift_target(baseline: dict, requested: str | None) -> DriftTarget:
+    """Resolve the single target supported by the initial CLI contract."""
+    baseline_agent = baseline.get("source_run_name")
+    if baseline_agent is not None and not isinstance(baseline_agent, str):
+        raise DriftWindowError("Baseline source_run_name must be a string or null")
+    if requested is not None:
+        requested = requested.strip()
+        if not requested:
+            raise DriftWindowError("--agent must not be empty")
+        if baseline_agent and requested != baseline_agent:
+            raise DriftWindowError(
+                f"Selected agent {requested!r} does not match baseline agent "
+                f"{baseline_agent!r}"
+            )
+        return DriftTarget(agent_name=requested, baseline=baseline)
+    if baseline_agent:
+        return DriftTarget(agent_name=baseline_agent, baseline=baseline)
+    raise DriftWindowError(
+        "Baseline does not identify an agent; pass --agent to select one"
+    )
+
+
+def run_drift(
+    runs_dir: Path,
+    *,
+    baseline: dict,
+    policy: AssertionPolicy,
+    config: MaidaConfig,
+    agent_name: str | None = None,
+    source: TraceWindowSource | None = None,
+) -> TrialRunReport:
+    """Evaluate a complete persisted trace window against one agent baseline."""
+    target = resolve_drift_target(baseline, agent_name)
+    if not policy.metrics:
+        policy = merge_policy(policy, {})
+    validate_policy_against_baseline(policy, baseline)
+
+    window_source = source or NativeTraceWindowSource(runs_dir, config)
+    traces = window_source.load(target.agent_name)
+    window_config = window_source.analysis_config
+
+    records: list[TrialRecord] = []
+    for index, item in enumerate(traces, start=1):
+        extracted = extract_run_metrics(item.meta, item.events)
+        invariants = invariant_outcomes(extracted, policy, baseline)
+        assertion_report = (
+            run_assertions(
+                item.trace_id,
+                policy,
+                baseline=baseline,
+                config=window_config,
+            )
+            if policy.source_format != "v2"
+            else _v2_assertion_report(item.trace_id, invariants)
+        )
+        records.append(
+            TrialRecord(
+                trial=index,
+                trace_id=item.trace_id,
+                run_name=item.meta.get("run_name"),
+                process_exit_code=None,
+                stdout="",
+                stderr="",
+                assertion_report=assertion_report,
+                run_status=item.meta.get("status"),
+                baseline_diff=asdict(
+                    compute_diff(item.trace_id, baseline=baseline, config=window_config)
+                ),
+                metric_values=numeric_metrics(extracted),
+                invariant_outcomes=invariants,
+                structural_signature=structural_signature(extracted),
+            )
+        )
+
+    aggregate_results = aggregate_metrics(
+        policy=policy,
+        trial_values=[record.metric_values for record in records],
+        trial_invariants=[record.invariant_outcomes for record in records],
+        process_outcomes=[record.run_status == "ok" for record in records],
+        baseline=baseline,
+        trials_budgeted=len(records),
+        stopping_rule="fixed_n",
+    )
+    return TrialRunReport(
+        trials_requested=len(records),
+        trials=records,
+        aggregate_results=aggregate_results,
+        confidence_level=policy.confidence_level,
+        pass_rate_threshold=policy.pass_rate_threshold,
+        stopping_rule="fixed_n",
+        environment_fingerprint={},
+        report_kind="drift",
+        agent_name=target.agent_name,
+        window_input_format="maida_runs",
+        baseline_source_run_id=baseline.get("source_run_id"),
+        baseline_source_run_name=baseline.get("source_run_name"),
+    )

--- a/maida/drift.py
+++ b/maida/drift.py
@@ -38,15 +38,15 @@ class LoadedWindowTrace:
 
 
 class TraceWindowSource(Protocol):
-    """Adapter boundary for native and future interchange trace windows."""
+    """Source boundary for native runs and future exported-window formats."""
 
     analysis_config: MaidaConfig
 
     def load(self, agent_name: str) -> list[LoadedWindowTrace]: ...
 
 
-# TODO(#172): add external-interchange and ``maida export`` window sources after
-# the published trace validator defines their stable ingestion contract.
+# Conforming external emitters already produce native ``runs/<trace_id>/``
+# directories. A future source can add ``maida export`` JSON window inputs.
 
 
 def _parse_started_at(trace_id: str, value: object) -> datetime:

--- a/maida/runner_v2.py
+++ b/maida/runner_v2.py
@@ -46,15 +46,16 @@ class RunExecutionError(RuntimeError):
 
 @dataclass(frozen=True)
 class TrialRecord:
-    """One isolated agent invocation and its raw tier evidence."""
+    """One sampled agent execution and its raw tier evidence."""
 
     trial: int
     trace_id: str
     run_name: str | None
-    process_exit_code: int
+    process_exit_code: int | None
     stdout: str
     stderr: str
     assertion_report: AssertionReport
+    run_status: str | None = None
     baseline_diff: dict[str, Any] | None = None
     metric_values: dict[str, float] = field(default_factory=dict)
     invariant_outcomes: dict[str, bool] = field(default_factory=dict)
@@ -62,14 +63,19 @@ class TrialRecord:
 
     @property
     def passed(self) -> bool:
-        return (
+        process_succeeded = (
             self.process_exit_code == 0
+            if self.process_exit_code is not None
+            else self.run_status == "ok"
+        )
+        return (
+            process_succeeded
             and self.assertion_report.passed
             and all(self.invariant_outcomes.values())
         )
 
     def to_dict(self) -> dict[str, Any]:
-        return {
+        payload = {
             "trial": self.trial,
             "trace_id": self.trace_id,
             "run_name": self.run_name,
@@ -94,11 +100,14 @@ class TrialRecord:
             "structural_signature": self.structural_signature,
             "baseline_diff": self.baseline_diff,
         }
+        if self.run_status is not None:
+            payload["run_status"] = self.run_status
+        return payload
 
 
 @dataclass(frozen=True)
 class TrialRunReport:
-    """Collected evidence and verdicts for a fixed trial budget."""
+    """Collected evidence and verdicts for a fixed execution sample."""
 
     trials_requested: int
     trials: list[TrialRecord] = field(default_factory=list)
@@ -108,6 +117,11 @@ class TrialRunReport:
     stopping_rule: str = "fixed_n"
     abort_reason: str | None = None
     environment_fingerprint: dict[str, Any] = field(default_factory=dict)
+    report_kind: str = "gate"
+    agent_name: str | None = None
+    window_input_format: str | None = None
+    baseline_source_run_id: str | None = None
+    baseline_source_run_name: str | None = None
 
     @property
     def verdict(self) -> GateVerdict:
@@ -122,31 +136,44 @@ class TrialRunReport:
         return None
 
     def to_dict(self) -> dict[str, Any]:
-        return {
+        metadata = {
+            "trials_used": len(self.trials),
+            "trials_budgeted": self.trials_requested,
+            "stopping_rule": self.stopping_rule,
+            "abort_reason": self.abort_reason,
+            "environment_fingerprint": self.environment_fingerprint,
+        }
+        payload = {
             "report_version": REPORT_VERSION,
             "trials_requested": self.trials_requested,
             "verdict": self.verdict.value,
             "passed": self.passed,
-            "metadata": {
-                "trials_used": len(self.trials),
-                "trials_budgeted": self.trials_requested,
-                "stopping_rule": self.stopping_rule,
-                "abort_reason": self.abort_reason,
-                "environment_fingerprint": self.environment_fingerprint,
-            },
+            "metadata": metadata,
             "trials": [trial.to_dict() for trial in self.trials],
             "aggregate_results": [
                 result.to_dict() for result in self.aggregate_results
             ],
         }
+        if self.report_kind != "gate":
+            payload["report_kind"] = self.report_kind
+            metadata.update(
+                {
+                    "agent_name": self.agent_name,
+                    "window_input_format": self.window_input_format,
+                    "baseline_source_run_id": self.baseline_source_run_id,
+                    "baseline_source_run_name": self.baseline_source_run_name,
+                }
+            )
+        return payload
 
     def to_json(self) -> str:
         return json.dumps(self.to_dict(), ensure_ascii=False, indent=2)
 
     def to_text(self) -> str:
+        label = "Window trace" if self.report_kind == "drift" else "Trial"
         lines = [
             (
-                f"Trial {trial.trial}/{self.trials_requested}: "
+                f"{label} {trial.trial}/{self.trials_requested}: "
                 f"{'PASS' if trial.passed else 'FAIL'} "
                 f"(trace {trial.trace_id[:8]})"
             )
@@ -166,14 +193,23 @@ class TrialRunReport:
             GateVerdict.FAIL: "❌",
             GateVerdict.INCONCLUSIVE: "⚪",
         }
+        heading = "Maida drift check" if self.report_kind == "drift" else "Maida gate"
+        sample_description = (
+            f"{len(self.trials)} traces in window"
+            if self.report_kind == "drift"
+            else f"{len(self.trials)}/{self.trials_requested} trials used"
+        )
         lines = [
-            f"## {icons[self.verdict]} Maida gate: {self.verdict.value}",
+            f"## {icons[self.verdict]} {heading}: {self.verdict.value}",
             "",
-            f"**{len(self.trials)}/{self.trials_requested} trials used** · "
-            f"stopping rule `{self.stopping_rule}`",
+            f"**{sample_description}** · stopping rule `{self.stopping_rule}`",
         ]
         if self.abort_reason:
             lines.append(f" · aborted: `{self.abort_reason}`")
+        trace_value_heading = (
+            "Run status" if self.report_kind == "drift" else "Process exit"
+        )
+        sample_item_heading = "Trace" if self.report_kind == "drift" else "Trial"
         lines.extend(
             [
                 "",
@@ -219,9 +255,13 @@ class TrialRunReport:
         lines.extend(
             [
                 "",
-                "### Trial traces",
+                (
+                    "### Window traces"
+                    if self.report_kind == "drift"
+                    else "### Trial traces"
+                ),
                 "",
-                "| Trial | Outcome | Trace | Process exit | Baseline changes |",
+                f"| {sample_item_heading} | Outcome | Trace | {trace_value_heading} | Baseline changes |",
                 "| ---: | --- | --- | ---: | --- |",
             ]
         )
@@ -234,9 +274,13 @@ class TrialRunReport:
                     f"new tool: {tool}" for tool in diff.get("new_tools", [])
                 )
                 changes = ", ".join(changed) if changed else "none"
+            if self.report_kind == "drift":
+                execution_value = trial.run_status or "unknown"
+            else:
+                execution_value = str(trial.process_exit_code)
             lines.append(
                 f"| {trial.trial} | {'PASS' if trial.passed else 'FAIL'} | "
-                f"`{trial.trace_id[:8]}` | {trial.process_exit_code} | {changes} |"
+                f"`{trial.trace_id[:8]}` | {execution_value} | {changes} |"
             )
         if self.verdict is GateVerdict.INCONCLUSIVE:
             lines.extend(

--- a/schemas/statistical-gate-report.schema.json
+++ b/schemas/statistical-gate-report.schema.json
@@ -6,6 +6,7 @@
   "required": ["report_version", "verdict", "passed", "metadata", "trials", "aggregate_results"],
   "properties": {
     "report_version": { "const": "2.0.0" },
+    "report_kind": { "enum": ["drift"] },
     "trials_requested": { "type": "integer", "minimum": 1 },
     "verdict": { "enum": ["pass", "fail", "inconclusive"] },
     "passed": { "type": ["boolean", "null"] },
@@ -30,7 +31,8 @@
           "trial": { "type": "integer", "minimum": 1 },
           "trace_id": { "type": "string", "pattern": "^[0-9a-f]{32}$" },
           "run_name": { "type": ["string", "null"] },
-          "process_exit_code": { "type": "integer" },
+          "process_exit_code": { "type": ["integer", "null"] },
+          "run_status": { "type": ["string", "null"], "enum": ["ok", "error", "running", null] },
           "passed": { "type": "boolean" },
           "checks": { "type": "array", "items": { "type": "object" } },
           "metric_values": { "type": "object", "additionalProperties": { "type": "number" } },

--- a/tests/test_docs.py
+++ b/tests/test_docs.py
@@ -116,6 +116,21 @@ def test_baseline_provenance_contract_is_documented():
     assert missing == []
 
 
+def test_scheduled_checks_document_current_external_emitter_contract():
+    text = " ".join(
+        (ROOT / "docs/scheduled-checks.md").read_text(encoding="utf-8").split()
+    )
+
+    required_snippets = [
+        "External emitters that follow the native trace contract",
+        "`maida export` JSON window inputs remain a future source format",
+        "Directory fanout is intentionally reserved",
+    ]
+
+    assert [snippet for snippet in required_snippets if snippet not in text] == []
+    assert "[#172]" not in text
+
+
 def test_adapter_conformance_contract_covers_required_behavior():
     text = " ".join(
         (ROOT / "maida/integrations/CONTRIBUTING.md")
@@ -243,7 +258,7 @@ def test_scheduled_checks_document_drift_contract_and_future_inputs():
         "Canary promotion",
         "report_kind: drift",
         "maida export",
-        "issues/172",
+        "native trace contract",
         "Directory fanout",
         "INCONCLUSIVE",
     ):

--- a/tests/test_docs.py
+++ b/tests/test_docs.py
@@ -229,3 +229,24 @@ def test_langfuse_docs_cover_read_only_import_and_mapping_contract():
 
     assert "Maida is an observability platform" not in combined
     assert "Maida is a monitoring platform" not in combined
+
+
+def test_scheduled_checks_document_drift_contract_and_future_inputs():
+    guide = (ROOT / "docs/scheduled-checks.md").read_text(encoding="utf-8")
+    cli = (ROOT / "docs/cli.md").read_text(encoding="utf-8")
+    combined = "\n".join([guide, cli])
+
+    for snippet in (
+        "maida drift",
+        "--window",
+        "one baseline per invocation",
+        "Canary promotion",
+        "report_kind: drift",
+        "maida export",
+        "issues/172",
+        "Directory fanout",
+        "INCONCLUSIVE",
+    ):
+        assert snippet in combined
+
+    assert "monitoring" not in combined.lower()

--- a/tests/test_drift.py
+++ b/tests/test_drift.py
@@ -17,10 +17,21 @@ from maida.config import load_config
 from maida.drift import DriftWindowError, run_drift
 from maida.policy_types import MetricDirection, MetricKind, MetricMode, MetricPolicy
 from maida.statistics import GateVerdict
+from maida.trace_validation import validate_trace_path
 
 
 ROOT = Path(__file__).parents[1]
 FIXTURES = ROOT / "tests" / "fixtures" / "traces" / "current"
+EXTERNAL_EMITTER_FIXTURE = (
+    ROOT
+    / "tests"
+    / "fixtures"
+    / "traces"
+    / "external"
+    / "emitter"
+    / "current"
+    / "multithread"
+)
 runner = CliRunner()
 
 
@@ -76,6 +87,14 @@ def _hash_tree(path: Path) -> dict[str, str]:
     }
 
 
+def _read_tree(path: Path) -> dict[str, bytes]:
+    return {
+        item.relative_to(path).as_posix(): item.read_bytes()
+        for item in sorted(path.rglob("*"))
+        if item.is_file()
+    }
+
+
 def test_run_drift_filters_one_agent_and_does_not_modify_window(tmp_path: Path) -> None:
     baseline = _baseline(tmp_path)
     runs_dir = tmp_path / "window" / "runs"
@@ -109,6 +128,80 @@ def test_run_drift_filters_one_agent_and_does_not_modify_window(tmp_path: Path) 
     assert report.trials[0].run_status == "ok"
     assert report.verdict is GateVerdict.PASS
     assert _hash_tree(runs_dir) == before
+
+
+def test_drift_cli_evaluates_external_emitter_native_window_read_only(
+    tmp_path: Path,
+) -> None:
+    trace_id = "80000000000000000000000000000001"
+    source_before = _read_tree(EXTERNAL_EMITTER_FIXTURE)
+
+    baseline_data = tmp_path / "baseline-data"
+    baseline_runs = baseline_data / "runs"
+    baseline_runs.mkdir(parents=True)
+    shutil.copytree(EXTERNAL_EMITTER_FIXTURE, baseline_runs / trace_id)
+    baseline_config = load_config()
+    baseline_config.data_dir = baseline_data
+    baseline_path = tmp_path / "baseline.json"
+    save_baseline(create_baseline(trace_id, baseline_config), baseline_path)
+
+    window_runs = tmp_path / "partner-window" / "runs"
+    window_runs.mkdir(parents=True)
+    emitted_run = window_runs / trace_id
+    shutil.copytree(EXTERNAL_EMITTER_FIXTURE, emitted_run)
+    window_before = _read_tree(window_runs)
+
+    validated = validate_trace_path(emitted_run)
+    assert [span["parent_span_id"] for span in validated.spans[2:]] == [
+        "8000000000000000",
+        "8000000000000002",
+        "8000000000000003",
+    ]
+
+    result = runner.invoke(
+        app,
+        [
+            "drift",
+            "--window",
+            str(window_runs),
+            "--baseline",
+            str(baseline_path),
+            "--format",
+            "json",
+        ],
+    )
+
+    assert result.exit_code == 0, result.output
+    payload = json.loads(result.stdout)
+    assert payload["report_version"] == "2.0.0"
+    assert payload["report_kind"] == "drift"
+    assert payload["metadata"]["window_input_format"] == "maida_runs"
+    assert payload["verdict"] == "pass"
+    trial = payload["trials"][0]
+    assert trial["trace_id"] == trace_id
+    assert trial["metric_values"] == {
+        "step_count": 4.0,
+        "tool_call_count": 2.0,
+        "cost_tokens": 28.0,
+        "latency_ms": 500.0,
+        "llm_call_count": 2.0,
+        "error_count": 0.0,
+        "loop_warning_count": 0.0,
+    }
+    assert trial["structural_signature"]["tool_call_sequence"] == [
+        "delegate",
+        "read",
+    ]
+    assert trial["structural_signature"]["event_type_sequence"] == [
+        "RUN_START",
+        "LLM_CALL",
+        "TOOL_CALL",
+        "LLM_CALL",
+        "TOOL_CALL",
+        "RUN_END",
+    ]
+    assert _read_tree(window_runs) == window_before
+    assert _read_tree(EXTERNAL_EMITTER_FIXTURE) == source_before
 
 
 def test_run_drift_reports_confirmed_structural_variance(tmp_path: Path) -> None:

--- a/tests/test_drift.py
+++ b/tests/test_drift.py
@@ -1,0 +1,517 @@
+"""Windowed scheduled behavioral regression checks."""
+
+from __future__ import annotations
+
+import json
+import shutil
+from hashlib import sha256
+from pathlib import Path
+
+import pytest
+from typer.testing import CliRunner
+
+from maida.assertions import AssertionPolicy
+from maida.baseline import create_baseline, save_baseline
+from maida.cli import app
+from maida.config import load_config
+from maida.drift import DriftWindowError, run_drift
+from maida.policy_types import MetricDirection, MetricKind, MetricMode, MetricPolicy
+from maida.statistics import GateVerdict
+
+
+ROOT = Path(__file__).parents[1]
+FIXTURES = ROOT / "tests" / "fixtures" / "traces" / "current"
+runner = CliRunner()
+
+
+def _copy_trace(
+    fixture: str,
+    runs_dir: Path,
+    *,
+    trace_id: str,
+    run_name: str,
+    started_at: str = "2026-08-01T00:00:00.000Z",
+) -> Path:
+    source = FIXTURES / fixture
+    destination = runs_dir / trace_id
+    shutil.copytree(source, destination)
+
+    meta_path = destination / "meta.json"
+    meta = json.loads(meta_path.read_text(encoding="utf-8"))
+    old_trace_id = meta["trace_id"]
+    meta["trace_id"] = trace_id
+    meta["run_name"] = run_name
+    meta["started_at"] = started_at
+    meta_path.write_text(json.dumps(meta), encoding="utf-8")
+
+    spans_path = destination / "spans.jsonl"
+    spans = []
+    for line in spans_path.read_text(encoding="utf-8").splitlines():
+        span = json.loads(line)
+        assert span["trace_id"] == old_trace_id
+        span["trace_id"] = trace_id
+        spans.append(span)
+    spans_path.write_text(
+        "".join(json.dumps(span) + "\n" for span in spans), encoding="utf-8"
+    )
+    return destination
+
+
+def _baseline(tmp_path: Path, *, agent: str = "orders-agent") -> dict:
+    data_dir = tmp_path / "baseline-data"
+    runs_dir = data_dir / "runs"
+    runs_dir.mkdir(parents=True)
+    trace_id = "a" * 32
+    _copy_trace("normal", runs_dir, trace_id=trace_id, run_name=agent)
+    config = load_config()
+    config.data_dir = data_dir
+    return create_baseline(trace_id, config)
+
+
+def _hash_tree(path: Path) -> dict[str, str]:
+    return {
+        item.relative_to(path).as_posix(): sha256(item.read_bytes()).hexdigest()
+        for item in sorted(path.rglob("*"))
+        if item.is_file()
+    }
+
+
+def test_run_drift_filters_one_agent_and_does_not_modify_window(tmp_path: Path) -> None:
+    baseline = _baseline(tmp_path)
+    runs_dir = tmp_path / "window" / "runs"
+    runs_dir.mkdir(parents=True)
+    selected = _copy_trace(
+        "normal",
+        runs_dir,
+        trace_id="1" * 32,
+        run_name="orders-agent",
+        started_at="2026-08-01T00:00:01.000Z",
+    )
+    _copy_trace(
+        "tool-call-spike",
+        runs_dir,
+        trace_id="2" * 32,
+        run_name="billing-agent",
+    )
+    before = _hash_tree(runs_dir)
+
+    report = run_drift(
+        runs_dir,
+        baseline=baseline,
+        policy=AssertionPolicy(),
+        config=load_config(),
+    )
+
+    assert report.report_kind == "drift"
+    assert report.agent_name == "orders-agent"
+    assert [trial.trace_id for trial in report.trials] == [selected.name]
+    assert report.trials[0].process_exit_code is None
+    assert report.trials[0].run_status == "ok"
+    assert report.verdict is GateVerdict.PASS
+    assert _hash_tree(runs_dir) == before
+
+
+def test_run_drift_reports_confirmed_structural_variance(tmp_path: Path) -> None:
+    baseline = _baseline(tmp_path)
+    runs_dir = tmp_path / "window" / "runs"
+    runs_dir.mkdir(parents=True)
+    _copy_trace(
+        "tool-call-spike",
+        runs_dir,
+        trace_id="3" * 32,
+        run_name="orders-agent",
+    )
+
+    report = run_drift(
+        runs_dir,
+        baseline=baseline,
+        policy=AssertionPolicy(max_tool_calls=1, no_new_tools=True),
+        config=load_config(),
+    )
+
+    assert report.verdict is GateVerdict.FAIL
+    assert report.trials[0].baseline_diff is not None
+    assert report.trials[0].baseline_diff["new_tools"]
+    markdown = report.to_markdown()
+    assert markdown.startswith("## ❌ Maida drift check: fail")
+    assert "`tool_call_count`" in markdown
+    assert "### Window traces" in markdown
+
+
+def test_run_drift_preserves_inconclusive_statistical_verdict(tmp_path: Path) -> None:
+    baseline = _baseline(tmp_path)
+    runs_dir = tmp_path / "window" / "runs"
+    runs_dir.mkdir(parents=True)
+    for index in range(3):
+        _copy_trace(
+            "normal",
+            runs_dir,
+            trace_id=str(index + 4) * 32,
+            run_name="orders-agent",
+            started_at=f"2026-08-01T00:00:0{index}.000Z",
+        )
+    task_pass_rate = MetricPolicy(
+        name="task_pass_rate",
+        kind=MetricKind.STATISTICAL,
+        direction=MetricDirection.LOWER,
+        threshold=0.90,
+        confidence=0.95,
+        mode=MetricMode.GATING,
+        success_predicate="all_invariants_passed",
+        aggregate="",
+    )
+    policy = AssertionPolicy(
+        trials=3,
+        source_format="v2",
+        policy_version=(2, 0),
+        metrics={"task_pass_rate": task_pass_rate},
+    )
+
+    report = run_drift(
+        runs_dir,
+        baseline=baseline,
+        policy=policy,
+        config=load_config(),
+    )
+
+    assert report.verdict is GateVerdict.INCONCLUSIVE
+    assert "Neutral result" in report.to_markdown()
+
+
+def test_run_drift_uses_stable_oldest_first_order(tmp_path: Path) -> None:
+    baseline = _baseline(tmp_path)
+    runs_dir = tmp_path / "window" / "runs"
+    runs_dir.mkdir(parents=True)
+    _copy_trace(
+        "normal",
+        runs_dir,
+        trace_id="8" * 32,
+        run_name="orders-agent",
+        started_at="2026-08-02T00:00:00.000Z",
+    )
+    _copy_trace(
+        "normal",
+        runs_dir,
+        trace_id="9" * 32,
+        run_name="orders-agent",
+        started_at="2026-08-01T00:00:00.000Z",
+    )
+
+    report = run_drift(
+        runs_dir,
+        baseline=baseline,
+        policy=AssertionPolicy(),
+        config=load_config(),
+    )
+
+    assert [trial.trace_id for trial in report.trials] == ["9" * 32, "8" * 32]
+
+
+@pytest.mark.parametrize(
+    ("baseline_agent", "selected_agent", "message"),
+    [
+        (None, None, "does not identify an agent"),
+        ("orders-agent", "billing-agent", "does not match baseline agent"),
+    ],
+)
+def test_run_drift_requires_unambiguous_agent_selection(
+    tmp_path: Path,
+    baseline_agent: str | None,
+    selected_agent: str | None,
+    message: str,
+) -> None:
+    baseline = _baseline(tmp_path)
+    baseline["source_run_name"] = baseline_agent
+    runs_dir = tmp_path / "window" / "runs"
+    runs_dir.mkdir(parents=True)
+    _copy_trace("normal", runs_dir, trace_id="b" * 32, run_name="orders-agent")
+
+    with pytest.raises(DriftWindowError, match=message):
+        run_drift(
+            runs_dir,
+            baseline=baseline,
+            policy=AssertionPolicy(),
+            config=load_config(),
+            agent_name=selected_agent,
+        )
+
+
+def test_run_drift_rejects_empty_and_corrupt_windows(tmp_path: Path) -> None:
+    baseline = _baseline(tmp_path)
+    runs_dir = tmp_path / "window" / "runs"
+    runs_dir.mkdir(parents=True)
+
+    with pytest.raises(DriftWindowError, match="contains no traces"):
+        run_drift(
+            runs_dir,
+            baseline=baseline,
+            policy=AssertionPolicy(),
+            config=load_config(),
+        )
+
+    trace_dir = _copy_trace(
+        "normal", runs_dir, trace_id="c" * 32, run_name="orders-agent"
+    )
+    (trace_dir / "spans.jsonl").write_text("not json\n", encoding="utf-8")
+    with pytest.raises(DriftWindowError, match="malformed JSON"):
+        run_drift(
+            runs_dir,
+            baseline=baseline,
+            policy=AssertionPolicy(),
+            config=load_config(),
+        )
+
+
+def test_run_drift_rejects_wrong_layout_incomplete_and_unsupported_traces(
+    tmp_path: Path,
+) -> None:
+    baseline = _baseline(tmp_path)
+    wrong_layout = tmp_path / "window"
+    wrong_layout.mkdir()
+    with pytest.raises(DriftWindowError, match="ending in /runs"):
+        run_drift(
+            wrong_layout,
+            baseline=baseline,
+            policy=AssertionPolicy(),
+            config=load_config(),
+        )
+
+    incomplete_runs = tmp_path / "incomplete" / "runs"
+    incomplete_runs.mkdir(parents=True)
+    _copy_trace(
+        "missing-terminal-state",
+        incomplete_runs,
+        trace_id="f" * 32,
+        run_name="orders-agent",
+    )
+    with pytest.raises(DriftWindowError, match="is incomplete"):
+        run_drift(
+            incomplete_runs,
+            baseline=baseline,
+            policy=AssertionPolicy(),
+            config=load_config(),
+        )
+
+    unsupported_runs = tmp_path / "unsupported" / "runs"
+    unsupported_runs.mkdir(parents=True)
+    trace_dir = _copy_trace(
+        "normal",
+        unsupported_runs,
+        trace_id="0" * 31 + "1",
+        run_name="orders-agent",
+    )
+    meta_path = trace_dir / "meta.json"
+    meta = json.loads(meta_path.read_text(encoding="utf-8"))
+    meta["spec_version"] = "9.0.0"
+    meta_path.write_text(json.dumps(meta), encoding="utf-8")
+    with pytest.raises(DriftWindowError, match="unsupported spec_version"):
+        run_drift(
+            unsupported_runs,
+            baseline=baseline,
+            policy=AssertionPolicy(),
+            config=load_config(),
+        )
+
+
+def test_run_drift_supports_explicit_legacy_agent_and_rejects_no_match(
+    tmp_path: Path,
+) -> None:
+    baseline = _baseline(tmp_path)
+    baseline["source_run_name"] = None
+    runs_dir = tmp_path / "window" / "runs"
+    runs_dir.mkdir(parents=True)
+    _copy_trace("normal", runs_dir, trace_id="0" * 31 + "2", run_name="orders-agent")
+
+    report = run_drift(
+        runs_dir,
+        baseline=baseline,
+        policy=AssertionPolicy(),
+        config=load_config(),
+        agent_name="orders-agent",
+    )
+    assert report.agent_name == "orders-agent"
+
+    with pytest.raises(DriftWindowError, match="contains no completed traces"):
+        run_drift(
+            runs_dir,
+            baseline=baseline,
+            policy=AssertionPolicy(),
+            config=load_config(),
+            agent_name="billing-agent",
+        )
+
+
+def test_drift_cli_writes_machine_report_and_uses_scheduler_exit_codes(
+    tmp_path: Path,
+) -> None:
+    baseline = _baseline(tmp_path)
+    baseline_path = tmp_path / "baseline.json"
+    save_baseline(baseline, baseline_path)
+    runs_dir = tmp_path / "window" / "runs"
+    runs_dir.mkdir(parents=True)
+    _copy_trace(
+        "tool-call-spike",
+        runs_dir,
+        trace_id="d" * 32,
+        run_name="orders-agent",
+    )
+    report_path = tmp_path / "drift.json"
+
+    result = runner.invoke(
+        app,
+        [
+            "drift",
+            "--window",
+            str(runs_dir),
+            "--baseline",
+            str(baseline_path),
+            "--format",
+            "markdown",
+            "--json-out",
+            str(report_path),
+        ],
+    )
+
+    assert result.exit_code == 1, result.output
+    assert result.stdout.startswith("## ❌ Maida drift check: fail")
+    payload = json.loads(report_path.read_text(encoding="utf-8"))
+    assert payload["report_version"] == "2.0.0"
+    assert payload["report_kind"] == "drift"
+    assert payload["metadata"]["agent_name"] == "orders-agent"
+    assert payload["metadata"]["window_input_format"] == "maida_runs"
+    assert payload["trials"][0]["process_exit_code"] is None
+    assert payload["trials"][0]["run_status"] == "ok"
+
+
+def test_drift_cli_rejects_baseline_directory_and_missing_agent(tmp_path: Path) -> None:
+    runs_dir = tmp_path / "window" / "runs"
+    runs_dir.mkdir(parents=True)
+
+    directory_result = runner.invoke(
+        app,
+        ["drift", "--window", str(runs_dir), "--baseline", str(tmp_path)],
+    )
+    assert directory_result.exit_code == 2
+    assert "Baseline must be a JSON file" in directory_result.stderr
+
+    baseline = _baseline(tmp_path)
+    baseline["source_run_name"] = None
+    baseline_path = tmp_path / "legacy-baseline.json"
+    save_baseline(baseline, baseline_path)
+    _copy_trace("normal", runs_dir, trace_id="e" * 32, run_name="orders-agent")
+    agent_result = runner.invoke(
+        app,
+        [
+            "drift",
+            "--window",
+            str(runs_dir),
+            "--baseline",
+            str(baseline_path),
+        ],
+    )
+    assert agent_result.exit_code == 2
+    assert "pass --agent" in agent_result.stderr
+
+
+def test_drift_cli_returns_zero_for_pass_and_inconclusive(tmp_path: Path) -> None:
+    baseline = _baseline(tmp_path)
+    baseline_path = tmp_path / "baseline.json"
+    save_baseline(baseline, baseline_path)
+    runs_dir = tmp_path / "window" / "runs"
+    runs_dir.mkdir(parents=True)
+    for index in range(3):
+        _copy_trace(
+            "normal",
+            runs_dir,
+            trace_id=f"{index + 10:032x}",
+            run_name="orders-agent",
+            started_at=f"2026-08-01T00:00:0{index}.000Z",
+        )
+
+    passed = runner.invoke(
+        app,
+        [
+            "drift",
+            "--window",
+            str(runs_dir),
+            "--baseline",
+            str(baseline_path),
+        ],
+    )
+    assert passed.exit_code == 0, passed.output
+    assert "RESULT: PASS" in passed.stdout
+
+    policy_path = tmp_path / "policy.yaml"
+    policy_path.write_text(
+        """
+version: 2
+trials: 25
+fail_fast: false
+metrics:
+  task_pass_rate:
+    kind: statistical
+    direction: lower
+    threshold: 0.90
+    confidence: 0.95
+    success_predicate: all_invariants_passed
+    mode: gating
+""".lstrip(),
+        encoding="utf-8",
+    )
+    inconclusive = runner.invoke(
+        app,
+        [
+            "drift",
+            "--window",
+            str(runs_dir),
+            "--baseline",
+            str(baseline_path),
+            "--policy",
+            str(policy_path),
+            "--format",
+            "json",
+        ],
+    )
+    assert inconclusive.exit_code == 0, inconclusive.output
+    assert json.loads(inconclusive.stdout)["verdict"] == "inconclusive"
+
+
+def test_drift_cli_maps_unexpected_failures_to_internal_error(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    baseline = _baseline(tmp_path)
+    baseline_path = tmp_path / "baseline.json"
+    save_baseline(baseline, baseline_path)
+    runs_dir = tmp_path / "window" / "runs"
+    runs_dir.mkdir(parents=True)
+
+    def fail(*args, **kwargs):
+        del args, kwargs
+        raise RuntimeError("unexpected evaluator failure")
+
+    monkeypatch.setattr("maida.cli.run_drift", fail)
+    result = runner.invoke(
+        app,
+        [
+            "drift",
+            "--window",
+            str(runs_dir),
+            "--baseline",
+            str(baseline_path),
+        ],
+    )
+
+    assert result.exit_code == 10
+    assert "unexpected evaluator failure" in result.stderr
+
+
+def test_drift_report_schema_allows_stored_trace_status() -> None:
+    schema = json.loads(
+        (ROOT / "schemas" / "statistical-gate-report.schema.json").read_text(
+            encoding="utf-8"
+        )
+    )
+    trial_properties = schema["properties"]["trials"]["items"]["properties"]
+
+    assert trial_properties["process_exit_code"]["type"] == ["integer", "null"]
+    assert "run_status" in trial_properties


### PR DESCRIPTION
Treat conforming external-emitter runs as supported native drift inputs while preserving future exported-window and baseline-fanout seams.

**Changes**

- exercise the published external-emitter fixture through validation and the drift CLI without mutating source bytes
- document native emitter support and remove the obsolete future-contract wording

**Tests**

- `uv run pytest -q -n 0 tests/test_drift.py tests/test_trace_validation.py tests/test_validate_trace_cli.py tests/test_docs.py`
- `uv run ruff check maida/drift.py tests/test_drift.py tests/test_docs.py`
- `uv run ruff format --check maida/drift.py tests/test_drift.py tests/test_docs.py`
- `git diff --check`

Fixes #173



---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>