### PR TITLE
Redesign statistical gate comments

### DIFF
--- a/maida/cli.py
+++ b/maida/cli.py
@@ -690,7 +690,9 @@ def run_cmd(
         if output_format == "json":
             rendered = report.to_json()
         elif output_format == "markdown":
-            rendered = report.to_markdown()
+            rendered = report.to_markdown(
+                baseline_path=str(baseline_path) if baseline_path is not None else None
+            )
         else:
             rendered = report.to_text()
         typer.echo(rendered)
@@ -772,7 +774,7 @@ def drift_cmd(
         if output_format == "json":
             rendered = report.to_json()
         elif output_format == "markdown":
-            rendered = report.to_markdown()
+            rendered = report.to_markdown(baseline_path=str(baseline_path))
         else:
             rendered = report.to_text()
         typer.echo(rendered)

--- a/maida/drift.py
+++ b/maida/drift.py
@@ -227,4 +227,9 @@ def run_drift(
         window_input_format="maida_runs",
         baseline_source_run_id=baseline.get("source_run_id"),
         baseline_source_run_name=baseline.get("source_run_name"),
+        baseline_acceptance=(
+            baseline.get("acceptance")
+            if isinstance(baseline.get("acceptance"), dict)
+            else None
+        ),
     )

--- a/maida/runner_v2.py
+++ b/maida/runner_v2.py
@@ -19,6 +19,8 @@ from maida.assertions import (
     AssertionPolicy,
     AssertionReport,
     AssertionResult,
+    _markdown_baseline_provenance,
+    _markdown_table_cell,
     run_assertions,
 )
 from maida.baseline import extract_run_metrics
@@ -122,6 +124,7 @@ class TrialRunReport:
     window_input_format: str | None = None
     baseline_source_run_id: str | None = None
     baseline_source_run_name: str | None = None
+    baseline_acceptance: dict[str, Any] | None = None
 
     @property
     def verdict(self) -> GateVerdict:
@@ -164,6 +167,8 @@ class TrialRunReport:
                     "baseline_source_run_name": self.baseline_source_run_name,
                 }
             )
+        if self.baseline_acceptance is not None:
+            payload["baseline_acceptance"] = self.baseline_acceptance
         return payload
 
     def to_json(self) -> str:
@@ -187,110 +192,490 @@ class TrialRunReport:
         lines.extend(["", f"RESULT: {self.verdict.value.upper()}"])
         return "\n".join(lines)
 
-    def to_markdown(self) -> str:
-        icons = {
+    def to_markdown(self, baseline_path: str | None = None) -> str:
+        """Render the compact, GitHub-facing statistical gate report."""
+        return _render_trial_report_markdown(self, baseline_path=baseline_path)
+
+
+_CHECK_LABELS = {
+    "agent_process": "Agent execution",
+    "step_count": "Steps",
+    "tool_call_count": "Tool calls",
+    "cost_tokens": "Tokens",
+    "latency_ms": "Latency",
+    "llm_call_count": "Model calls",
+    "error_count": "Errors",
+    "loop_warning_count": "Loops",
+    "no_loops": "Loops",
+    "no_guardrails": "Guardrails",
+    "stop_condition_reached": "Terminal state",
+    "forbidden_tools": "Allowed tools",
+    "required_tools": "Required tools",
+    "task_pass_rate": "Successful behavior",
+}
+
+_SUMMARY_CHANGES = {
+    "total_events": ("Steps", ""),
+    "tool_calls": ("Tool calls", ""),
+    "total_tokens": ("Tokens", ""),
+    "duration_ms": ("Latency", " ms"),
+    "llm_calls": ("Model calls", ""),
+    "errors": ("Errors", ""),
+    "loop_warnings": ("Loops", ""),
+}
+
+
+def _plural(count: int, singular: str, plural: str | None = None) -> str:
+    return singular if count == 1 else (plural or f"{singular}s")
+
+
+def _number(value: object) -> str:
+    if isinstance(value, bool):
+        return str(value).lower()
+    if isinstance(value, (int, float)):
+        numeric = float(value)
+        return str(int(numeric)) if numeric.is_integer() else f"{numeric:g}"
+    return _markdown_table_cell(value)
+
+
+def _signed_number(value: object) -> str:
+    if isinstance(value, (int, float)) and not isinstance(value, bool):
+        numeric = float(value)
+        sign = "+" if numeric > 0 else ""
+        return f"{sign}{_number(numeric)}"
+    return _number(value)
+
+
+def _inline(value: object) -> str:
+    escaped = _markdown_table_cell(value).replace("`", "&#96;")
+    return f"`{escaped}`"
+
+
+def _sequence(values: object) -> str:
+    if not isinstance(values, list) or not values:
+        return "(none)"
+    return " → ".join(str(value).replace("\n", " ") for value in values)
+
+
+def _pair(value: object) -> tuple[object, object] | None:
+    if isinstance(value, (list, tuple)) and len(value) == 2:
+        return value[0], value[1]
+    return None
+
+
+def _change_sentence(label: str, suffix: str, current: object, baseline: object) -> str:
+    current_text = f"{_number(current)}{suffix}"
+    baseline_text = f"{_number(baseline)}{suffix}"
+    trend = "changed"
+    delta: object | None = None
+    if isinstance(current, (int, float)) and isinstance(baseline, (int, float)):
+        delta = current - baseline
+        if delta > 0:
+            trend = "increased"
+        elif delta < 0:
+            trend = "decreased"
+    sentence = f"{label} {trend} from {baseline_text} to {current_text}"
+    if delta:
+        sentence += f" ({_signed_number(delta)}{suffix})"
+    return f"{sentence}."
+
+
+def _behavior_lines(diff: dict[str, Any] | None) -> list[str]:
+    if not isinstance(diff, dict):
+        return []
+    lines: list[str] = []
+    current_sequence = diff.get("current_tool_sequence")
+    baseline_sequence = diff.get("baseline_tool_sequence")
+    if diff.get("reordered_tools"):
+        lines.append(
+            "Tool order changed from "
+            f"{_inline(_sequence(baseline_sequence))} to "
+            f"{_inline(_sequence(current_sequence))}."
+        )
+    for tool in diff.get("new_tools") or []:
+        lines.append(f"New tool used: {_inline(tool)}.")
+    for tool in diff.get("removed_tools") or []:
+        lines.append(f"Tool removed: {_inline(tool)}.")
+    repeated = diff.get("repeated_tools") or {}
+    if isinstance(repeated, dict):
+        for tool, counts in repeated.items():
+            pair = _pair(counts)
+            if pair is None:
+                continue
+            baseline_count, current_count = pair
+            lines.append(
+                f"Tool {_inline(tool)} repeated {_number(current_count)} times "
+                f"(baseline: {_number(baseline_count)})."
+            )
+
+    summary = diff.get("summary_diff") or {}
+    if isinstance(summary, dict):
+        for key, (label, suffix) in _SUMMARY_CHANGES.items():
+            pair = _pair(summary.get(key))
+            if pair is None:
+                continue
+            current, baseline = pair
+            lines.append(_change_sentence(label, suffix, current, baseline))
+
+    guardrails = _pair(diff.get("guardrail_event_diff"))
+    if guardrails is not None:
+        current, baseline = guardrails
+        count = int(current) if isinstance(current, (int, float)) else 0
+        lines.append(
+            f"Guardrails triggered {_number(current)} {_plural(count, 'time')} "
+            f"(baseline: {_number(baseline)})."
+        )
+    terminal = _pair(diff.get("terminal_status_diff"))
+    if terminal is not None:
+        current, baseline = terminal
+        lines.append(
+            f"Terminal state changed from {_inline(baseline)} to {_inline(current)}."
+        )
+    return lines
+
+
+def _all_behavior_lines(trials: list[TrialRecord]) -> list[str]:
+    return list(
+        dict.fromkeys(
+            sentence
+            for trial in trials
+            for sentence in _behavior_lines(trial.baseline_diff)
+        )
+    )
+
+
+def _check_label(check_name: str) -> str:
+    return _CHECK_LABELS.get(check_name, check_name.replace("_", " ").capitalize())
+
+
+def _result_title(result: StatisticalResult) -> str:
+    label = _check_label(result.check_name)
+    violations = int(result.evidence.get("violations", 0) or 0)
+    trials = result.trials_used
+    trial_word = _plural(trials, "trial")
+    if result.verdict is GateVerdict.PASS:
+        if result.check_name == "agent_process":
+            return "Agent execution stayed healthy."
+        return f"{label} stayed within the allowed range."
+    if result.verdict is GateVerdict.INCONCLUSIVE:
+        if result.check_name == "task_pass_rate":
+            return "Successful behavior is still inconclusive."
+        return f"{label} is still inconclusive."
+    if result.check_name == "agent_process":
+        return f"Agent execution failed in {violations} of {trials} {trial_word}."
+    if result.check_name in {"no_loops", "loop_warning_count"}:
+        return f"Loops appeared in {violations} of {trials} {trial_word}."
+    if result.check_name == "no_guardrails":
+        return f"Guardrails triggered in {violations} of {trials} {trial_word}."
+    if result.check_name == "stop_condition_reached":
+        return "The agent did not reach a successful terminal state."
+    if result.check_name == "latency_ms":
+        return "Latency increased beyond the allowed range."
+    if result.check_name == "step_count":
+        return "Steps increased beyond the allowed range."
+    if result.check_name == "cost_tokens":
+        return "Tokens increased beyond the allowed range."
+    if result.check_name == "task_pass_rate":
+        return "Successful behavior fell below the required rate."
+    return f"{label} violated the policy."
+
+
+def _measurement(value: object, check_name: str) -> str:
+    suffix = " ms" if check_name == "latency_ms" else ""
+    return f"{_number(value)}{suffix}"
+
+
+def _result_evidence(result: StatisticalResult) -> str | None:
+    evidence = result.evidence
+    if result.kind == "measured":
+        parts: list[str] = []
+        baseline = evidence.get("baseline")
+        if baseline is not None:
+            parts.append(f"baseline {_measurement(baseline, result.check_name)}")
+        delta = evidence.get("delta")
+        if (
+            result.check_name == "step_count"
+            and isinstance(delta, (int, float))
+            and delta
+        ):
+            parts.append(f"delta {_signed_number(delta)}")
+        allowed = evidence.get("allowed") or {}
+        lower = allowed.get("lower") if isinstance(allowed, dict) else None
+        upper = allowed.get("upper") if isinstance(allowed, dict) else None
+        if lower is not None and upper is not None:
+            parts.append(
+                "allowed between "
+                f"{_measurement(lower, result.check_name)} and "
+                f"{_measurement(upper, result.check_name)}"
+            )
+        elif upper is not None:
+            parts.append(f"allowed at most {_measurement(upper, result.check_name)}")
+        elif lower is not None:
+            parts.append(f"allowed at least {_measurement(lower, result.check_name)}")
+        observed = _measurement(evidence.get("observed", 0), result.check_name)
+        return f"Observed {observed}" + (f" ({'; '.join(parts)})." if parts else ".")
+    if result.kind == "invariant":
+        if result.check_name == "agent_process" and result.verdict is GateVerdict.PASS:
+            return (
+                f"All {result.trials_used} {_plural(result.trials_used, 'trial')} "
+                "completed successfully."
+            )
+        return None
+
+    bounds = evidence.get("confidence_bounds") or {}
+    lower = float(bounds.get("lower", 0.0))
+    upper = float(bounds.get("upper", 1.0))
+    confidence = float(evidence.get("confidence", 0.0)) * 100
+    observed_rate = float(evidence.get("observed_rate", 0.0))
+    if result.mode == "report_only":
+        return (
+            f"Observed pass rate {observed_rate:.3f}; {confidence:g}% confidence "
+            f"range {lower:.3f}–{upper:.3f}."
+        )
+    successes = int(evidence.get("successes", result.successes))
+    threshold = evidence.get("threshold", 0.0)
+    if isinstance(threshold, dict):
+        target = (
+            f"target {_number(threshold.get('lower'))}–"
+            f"{_number(threshold.get('upper'))}"
+        )
+    elif result.direction == "upper":
+        target = f"target at most {float(threshold):.3f}"
+    else:
+        target = f"target at least {float(threshold):.3f}"
+    return (
+        f"{successes}/{result.trials_used} trials passed; {confidence:g}% "
+        f"confidence range {lower:.3f}–{upper:.3f} ({target})."
+    )
+
+
+def _result_line(result: StatisticalResult, *, report_only: bool = False) -> str:
+    if report_only:
+        icon = "ℹ️"
+        title = f"{_check_label(result.check_name)} were observed without blocking the gate."
+    else:
+        icon = {
             GateVerdict.PASS: "✅",
             GateVerdict.FAIL: "❌",
             GateVerdict.INCONCLUSIVE: "⚪",
-        }
-        heading = "Maida drift check" if self.report_kind == "drift" else "Maida gate"
-        sample_description = (
-            f"{len(self.trials)} traces in window"
-            if self.report_kind == "drift"
-            else f"{len(self.trials)}/{self.trials_requested} trials used"
+        }[result.verdict]
+        title = _result_title(result)
+    line = f"- {icon} **{title}** {_inline(result.check_name)}"
+    if evidence := _result_evidence(result):
+        line += f" — {evidence}"
+    return line
+
+
+def _count_summary(report: TrialRunReport) -> str:
+    failures = sum(
+        result.verdict is GateVerdict.FAIL for result in report.aggregate_results
+    )
+    inconclusive = sum(
+        result.verdict is GateVerdict.INCONCLUSIVE
+        for result in report.aggregate_results
+    )
+    blocking = sum(result.verdict is not None for result in report.aggregate_results)
+    if failures:
+        check_summary = f"{failures} blocking {_plural(failures, 'check')} failed"
+        if inconclusive:
+            check_summary += (
+                f", {inconclusive} {_plural(inconclusive, 'check')} inconclusive"
+            )
+    elif inconclusive:
+        check_summary = (
+            f"{inconclusive} blocking {_plural(inconclusive, 'check')} inconclusive"
         )
-        lines = [
-            f"## {icons[self.verdict]} {heading}: {self.verdict.value}",
-            "",
-            f"**{sample_description}** · stopping rule `{self.stopping_rule}`",
-        ]
-        if self.abort_reason:
-            lines.append(f" · aborted: `{self.abort_reason}`")
-        trace_value_heading = (
-            "Run status" if self.report_kind == "drift" else "Process exit"
+    else:
+        check_summary = f"{blocking} blocking {_plural(blocking, 'check')} passed"
+
+    completed = len(report.trials)
+    if completed < report.trials_requested:
+        trial_summary = f"{completed}/{report.trials_requested} trials completed"
+    else:
+        passed = sum(trial.passed for trial in report.trials)
+        trial_summary = f"{passed}/{report.trials_requested} trials passed"
+    return f"**{check_summary}** · **{trial_summary}**"
+
+
+def _next_steps(report: TrialRunReport, baseline_path: str | None) -> list[str]:
+    short_trace = report.trials[0].trace_id[:8] if report.trials else "TRACE_ID"
+    safe_baseline = _markdown_table_cell(baseline_path) if baseline_path else None
+    if report.verdict is GateVerdict.PASS:
+        if report.trials:
+            return [
+                f"- No gate action needed. Inspect the trace: `maida view {short_trace}`"
+            ]
+        return ["- No gate action needed."]
+    if report.verdict is GateVerdict.INCONCLUSIVE:
+        rerun = (
+            f"maida drift --window RUNS_DIR --baseline {safe_baseline}"
+            if report.report_kind == "drift" and safe_baseline
+            else f"maida run AGENT.py --trials {report.trials_requested}"
         )
-        sample_item_heading = "Trace" if self.report_kind == "drift" else "Trial"
+        steps = [f"- Collect the remaining evidence and rerun: `{rerun}`"]
+        if report.trials:
+            steps.append(f"- Open the trace locally: `maida view {short_trace}`")
+        return steps
+
+    steps = ["- Review the behavioral changes and blocking checks above."]
+    if safe_baseline:
+        steps.append(
+            f"- Inspect the full diff: `maida diff {short_trace} --baseline {safe_baseline}`"
+        )
+    if report.trials:
+        steps.append(f"- Open the trace locally: `maida view {short_trace}`")
+    if safe_baseline:
+        steps.extend(
+            [
+                "- If this change is intentional, comment `/maida accept` on the PR "
+                "or accept locally: "
+                f"`maida accept {short_trace} --baseline {safe_baseline} "
+                '--reason "..."`',
+                "- Otherwise fix the agent behavior and rerun: "
+                f"`maida run AGENT.py --baseline {safe_baseline}`",
+            ]
+        )
+    else:
+        steps.append(
+            "- Otherwise fix the agent behavior or policy, then rerun the gate."
+        )
+    return steps
+
+
+def _render_trial_report_markdown(
+    report: TrialRunReport, *, baseline_path: str | None
+) -> str:
+    icons = {
+        GateVerdict.PASS: "✅",
+        GateVerdict.FAIL: "❌",
+        GateVerdict.INCONCLUSIVE: "⚪",
+    }
+    heading = "Maida drift check" if report.report_kind == "drift" else "Maida verdict"
+    lines = [
+        f"## {icons[report.verdict]} {heading}: {report.verdict.value}",
+        "",
+        _count_summary(report),
+    ]
+    if report.abort_reason:
         lines.extend(
             [
                 "",
-                "| Metric | Kind | Mode | Direction | Verdict | Evidence |",
-                "| --- | --- | --- | --- | --- | --- |",
+                f"> Sample stopped early: {_inline(report.abort_reason)}.",
             ]
         )
-        for result in self.aggregate_results:
-            verdict = (
-                result.verdict.value.upper()
-                if result.verdict is not None
-                else "REPORT ONLY"
-            )
-            evidence = result.evidence
-            if result.kind == "measured":
-                delta = evidence.get("delta")
-                delta_text = "n/a" if delta is None else f"{delta:+.3g}"
-                sample = evidence.get("sample") or {}
-                detail = (
-                    f"delta {delta_text}; min/median/max "
-                    f"{sample.get('min')}/{sample.get('median')}/{sample.get('max')}"
-                )
-            elif result.kind == "invariant":
-                detail = (
-                    f"violated in {evidence.get('violations', 0)}/"
-                    f"{result.trials_used} trials"
-                )
-            elif result.mode == "report_only":
-                detail = (
-                    f"observed rate {evidence.get('observed_rate', 0):.3f}; "
-                    "no confidence verdict"
-                )
-            else:
-                bounds = evidence.get("confidence_bounds") or {}
-                detail = (
-                    f"one-sided bounds "
-                    f"{bounds.get('lower', 0):.3f}–{bounds.get('upper', 1):.3f}"
-                )
-            lines.append(
-                f"| `{result.check_name}` | {result.kind} | {result.mode} | "
-                f"{result.direction or 'n/a'} | **{verdict}** | {detail} |"
-            )
-        lines.extend(
-            [
-                "",
-                (
-                    "### Window traces"
-                    if self.report_kind == "drift"
-                    else "### Trial traces"
-                ),
-                "",
-                f"| {sample_item_heading} | Outcome | Trace | {trace_value_heading} | Baseline changes |",
-                "| ---: | --- | --- | ---: | --- |",
-            ]
+    lines.extend(["", "### Behavior vs baseline", ""])
+    behavior_lines = _all_behavior_lines(report.trials)
+    baseline_configured = any(
+        trial.baseline_diff is not None for trial in report.trials
+    )
+    if behavior_lines:
+        lines.extend(f"- {sentence}" for sentence in behavior_lines)
+    elif baseline_configured:
+        lines.append(
+            "No behavior changed from the accepted baseline across the sampled trials."
         )
-        for trial in self.trials:
-            diff = trial.baseline_diff
-            changes = "not configured"
-            if diff is not None:
-                changed = list((diff.get("summary_diff") or {}).keys())
-                changed.extend(
-                    f"new tool: {tool}" for tool in diff.get("new_tools", [])
-                )
-                changes = ", ".join(changed) if changed else "none"
-            if self.report_kind == "drift":
-                execution_value = trial.run_status or "unknown"
-            else:
-                execution_value = str(trial.process_exit_code)
-            lines.append(
-                f"| {trial.trial} | {'PASS' if trial.passed else 'FAIL'} | "
-                f"`{trial.trace_id[:8]}` | {execution_value} | {changes} |"
-            )
-        if self.verdict is GateVerdict.INCONCLUSIVE:
+    else:
+        lines.append("No baseline comparison was configured for this run.")
+
+    blocking_results = [
+        result
+        for result in report.aggregate_results
+        if result.verdict in {GateVerdict.FAIL, GateVerdict.INCONCLUSIVE}
+    ]
+    if blocking_results:
+        lines.extend(["", "### Blocking checks", ""])
+        lines.extend(_result_line(result) for result in blocking_results)
+    if report.verdict is GateVerdict.INCONCLUSIVE:
+        if report.report_kind == "drift":
             lines.extend(
                 [
                     "",
                     "> Neutral result: no blocking failure was established. "
-                    "The CLI exits 0.",
+                    "The CLI exits 0; collect more evidence before promotion.",
                 ]
             )
-        return "\n".join(lines)
+        else:
+            lines.extend(
+                [
+                    "",
+                    "> Maida did not establish a blocking regression, but this sample "
+                    "is too small to approve confidently. Collect more trials and "
+                    "rerun before promotion.",
+                ]
+            )
+
+    lines.extend(_markdown_baseline_provenance(report.baseline_acceptance))
+    if lines[-1]:
+        lines.append("")
+    lines.extend(["### Next steps", "", *_next_steps(report, baseline_path)])
+
+    passing = [
+        result
+        for result in report.aggregate_results
+        if result.verdict is GateVerdict.PASS
+    ]
+    report_only = [
+        result for result in report.aggregate_results if result.verdict is None
+    ]
+    lines.extend(
+        [
+            "",
+            "<details>",
+            "<summary>Passing checks, report-only metrics, and trial evidence</summary>",
+        ]
+    )
+    if passing:
+        lines.extend(["", "#### Passing checks", ""])
+        lines.extend(_result_line(result) for result in passing)
+    if report_only:
+        lines.extend(["", "#### Report-only metrics", ""])
+        lines.extend(_result_line(result, report_only=True) for result in report_only)
+
+    evidence_heading = (
+        "### Window traces" if report.report_kind == "drift" else "#### Trial evidence"
+    )
+    lines.extend(["", evidence_heading, ""])
+    if report.trials:
+        execution_heading = (
+            "Run status" if report.report_kind == "drift" else "Process exit"
+        )
+        item_heading = "Trace" if report.report_kind == "drift" else "Trial"
+        lines.extend(
+            [
+                f"| {item_heading} | Outcome | Trace | {execution_heading} | Behavior changes |",
+                "| ---: | --- | --- | ---: | --- |",
+            ]
+        )
+        for trial in report.trials:
+            if trial.baseline_diff is None:
+                changes = "not configured"
+            else:
+                count = len(_behavior_lines(trial.baseline_diff))
+                changes = (
+                    "none" if count == 0 else f"{count} {_plural(count, 'change')}"
+                )
+            execution = (
+                trial.run_status or "unknown"
+                if report.report_kind == "drift"
+                else str(trial.process_exit_code)
+            )
+            lines.append(
+                f"| {trial.trial} | {'PASS' if trial.passed else 'FAIL'} | "
+                f"`{trial.trace_id[:8]}` | {execution} | {changes} |"
+            )
+    else:
+        lines.append("No trial evidence was recorded.")
+    lines.extend(
+        [
+            "",
+            "</details>",
+            "",
+            "---",
+            "*Gated by [Maida](https://maida.ai) — the local-first behavioral"
+            " regression gate for AI agents.*",
+        ]
+    )
+    return "\n".join(lines)
 
 
 def _workspace_files(project_root: Path) -> list[Path]:
@@ -483,4 +868,9 @@ def run_trials(
         stopping_rule=stopping_rule,
         abort_reason=abort_reason,
         environment_fingerprint=_environment_fingerprint(root),
+        baseline_acceptance=(
+            baseline.get("acceptance")
+            if isinstance((baseline or {}).get("acceptance"), dict)
+            else None
+        ),
     )

--- a/schemas/statistical-gate-report.schema.json
+++ b/schemas/statistical-gate-report.schema.json
@@ -10,6 +10,7 @@
     "trials_requested": { "type": "integer", "minimum": 1 },
     "verdict": { "enum": ["pass", "fail", "inconclusive"] },
     "passed": { "type": ["boolean", "null"] },
+    "baseline_acceptance": { "type": ["object", "null"] },
     "metadata": {
       "type": "object",
       "required": ["trials_used", "trials_budgeted", "stopping_rule", "abort_reason", "environment_fingerprint"],

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -875,7 +875,7 @@ if os.environ["MAIDA_TRIAL_INDEX"] == "3":
     )
 
     assert result.exit_code == 1, result.output
-    assert result.stdout.startswith("## ❌ Maida gate: fail")
+    assert result.stdout.startswith("## ❌ Maida verdict: fail")
     payload = json.loads(sidecar.read_text(encoding="utf-8"))
     assert payload["report_version"] == "2.0.0"
     assert payload["verdict"] == "fail"

--- a/tests/test_cli_issue_187.py
+++ b/tests/test_cli_issue_187.py
@@ -102,3 +102,35 @@ def test_gate_exit_code_contract_keeps_inconclusive_neutral(
     monkeypatch.setattr("maida.cli.run_trials", explode)
     internal = runner.invoke(app, ["run", str(script)])
     assert internal.exit_code == 10
+
+
+def test_run_markdown_forwards_baseline_path(tmp_path, monkeypatch) -> None:
+    script = tmp_path / "agent.py"
+    script.write_text("pass\n", encoding="utf-8")
+    baseline_path = tmp_path / "accepted-baseline.json"
+    seen: dict[str, str | None] = {}
+
+    class FakeReport:
+        verdict = GateVerdict.PASS
+
+        def to_markdown(self, baseline_path: str | None = None) -> str:
+            seen["baseline_path"] = baseline_path
+            return "markdown"
+
+    monkeypatch.setattr("maida.cli.load_baseline", lambda path: {"path": str(path)})
+    monkeypatch.setattr("maida.cli.run_trials", lambda *args, **kwargs: FakeReport())
+
+    result = runner.invoke(
+        app,
+        [
+            "run",
+            str(script),
+            "--baseline",
+            str(baseline_path),
+            "--format",
+            "markdown",
+        ],
+    )
+
+    assert result.exit_code == 0, result.output
+    assert seen == {"baseline_path": str(baseline_path)}

--- a/tests/test_drift.py
+++ b/tests/test_drift.py
@@ -206,6 +206,11 @@ def test_drift_cli_evaluates_external_emitter_native_window_read_only(
 
 def test_run_drift_reports_confirmed_structural_variance(tmp_path: Path) -> None:
     baseline = _baseline(tmp_path)
+    acceptance = {
+        "accepted_by": "reviewer-login",
+        "reason": "Expected baseline",
+    }
+    baseline["acceptance"] = acceptance
     runs_dir = tmp_path / "window" / "runs"
     runs_dir.mkdir(parents=True)
     _copy_trace(
@@ -223,6 +228,8 @@ def test_run_drift_reports_confirmed_structural_variance(tmp_path: Path) -> None
     )
 
     assert report.verdict is GateVerdict.FAIL
+    assert report.baseline_acceptance == acceptance
+    assert report.to_dict()["baseline_acceptance"] == acceptance
     assert report.trials[0].baseline_diff is not None
     assert report.trials[0].baseline_diff["new_tools"]
     markdown = report.to_markdown()

--- a/tests/test_runner.py
+++ b/tests/test_runner.py
@@ -168,7 +168,7 @@ with traced_run(name="json-agent"):
     assert payload["trials"][0]["checks"][0]["check_name"] == "step_count"
 
 
-def test_trial_report_markdown_is_verdict_first_with_intervals_and_traces(
+def test_trial_report_markdown_is_verdict_first_with_behavior_and_details(
     agent_repo: Path, temp_data_dir: Path
 ) -> None:
     _write_agent(
@@ -184,8 +184,13 @@ def test_trial_report_markdown_is_verdict_first_with_intervals_and_traces(
     )
 
     markdown = report.to_markdown()
-    assert markdown.startswith("## ✅ Maida gate: pass")
-    assert "| measured |" in markdown
+    assert markdown.startswith("## ✅ Maida verdict: pass")
+    assert "### Behavior vs baseline" in markdown
+    assert (
+        "<summary>Passing checks, report-only metrics, and trial evidence</summary>"
+        in markdown
+    )
+    assert "**Steps stayed within the allowed range.**" in markdown
     assert "`step_count`" in markdown
     assert f"`{report.trials[0].trace_id[:8]}`" in markdown
 
@@ -197,6 +202,11 @@ def test_trial_report_records_each_baseline_diff(
     with traced_run(name="baseline"):
         record_tool_call("old-tool", args={}, result="ok")
     baseline = create_baseline(get_latest_run_id(config), config)
+    acceptance = {
+        "accepted_by": "reviewer-login",
+        "reason": "Expected tool split",
+    }
+    baseline["acceptance"] = acceptance
     _write_agent(
         agent_repo,
         """
@@ -217,6 +227,8 @@ with traced_run(name="candidate"):
 
     assert report.trials[0].baseline_diff is not None
     assert report.trials[0].baseline_diff["new_tools"] == ["new-tool"]
+    assert report.baseline_acceptance == acceptance
+    assert report.to_dict()["baseline_acceptance"] == acceptance
 
 
 def test_statistical_report_schema_pins_three_verdict_contract() -> None:

--- a/tests/test_trial_report_markdown.py
+++ b/tests/test_trial_report_markdown.py
@@ -1,0 +1,406 @@
+"""Snapshots for the statistical gate's GitHub-facing Markdown report."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from textwrap import dedent
+
+import pytest
+
+from maida.assertions import AssertionReport
+from maida.runner_v2 import TrialRecord, TrialRunReport
+from maida.statistics import GateVerdict, StatisticalResult
+
+
+def _result(
+    check_name: str,
+    *,
+    kind: str,
+    verdict: GateVerdict | None,
+    mode: str = "gating",
+    direction: str | None = None,
+    evidence: dict | None = None,
+) -> StatisticalResult:
+    return StatisticalResult(
+        check_name=check_name,
+        kind=kind,
+        verdict=verdict,
+        decision_rule="report_only" if mode == "report_only" else "invariant",
+        trials_used=1,
+        trials_budgeted=1,
+        direction=direction,
+        mode=mode,
+        trial_outcomes=(verdict is not GateVerdict.FAIL,),
+        evidence=evidence or {},
+    )
+
+
+def _trial(*, baseline_diff: dict | None, passed: bool = True) -> TrialRecord:
+    assertion_report = AssertionReport(
+        run_id="a" * 32,
+        baseline_run_id="b" * 32 if baseline_diff is not None else None,
+        passed=passed,
+    )
+    return TrialRecord(
+        trial=1,
+        trace_id="a" * 32,
+        run_name="orders-agent",
+        process_exit_code=0,
+        stdout="",
+        stderr="",
+        assertion_report=assertion_report,
+        baseline_diff=baseline_diff,
+    )
+
+
+def test_trial_report_pass_markdown_snapshot() -> None:
+    report = TrialRunReport(
+        trials_requested=1,
+        trials=[_trial(baseline_diff={})],
+        aggregate_results=[
+            _result(
+                "agent_process",
+                kind="invariant",
+                verdict=GateVerdict.PASS,
+                evidence={"violations": 0},
+            ),
+            _result(
+                "step_count",
+                kind="measured",
+                verdict=GateVerdict.PASS,
+                direction="upper",
+                evidence={
+                    "observed": 8.0,
+                    "baseline": 8.0,
+                    "allowed": {"lower": None, "upper": 10.0},
+                    "delta": 0.0,
+                },
+            ),
+        ],
+    )
+
+    assert report.to_markdown(baseline_path=".maida/baselines/orders.json") == dedent(
+        """\
+        ## ✅ Maida verdict: pass
+
+        **2 blocking checks passed** · **1/1 trials passed**
+
+        ### Behavior vs baseline
+
+        No behavior changed from the accepted baseline across the sampled trials.
+
+        ### Next steps
+
+        - No gate action needed. Inspect the trace: `maida view aaaaaaaa`
+
+        <details>
+        <summary>Passing checks, report-only metrics, and trial evidence</summary>
+
+        #### Passing checks
+
+        - ✅ **Agent execution stayed healthy.** `agent_process` — All 1 trial completed successfully.
+        - ✅ **Steps stayed within the allowed range.** `step_count` — Observed 8 (baseline 8; allowed at most 10).
+
+        #### Trial evidence
+
+        | Trial | Outcome | Trace | Process exit | Behavior changes |
+        | ---: | --- | --- | ---: | --- |
+        | 1 | PASS | `aaaaaaaa` | 0 | none |
+
+        </details>
+
+        ---
+        *Gated by [Maida](https://maida.ai) — the local-first behavioral regression gate for AI agents.*"""
+    )
+
+
+def test_trial_report_fail_markdown_snapshot() -> None:
+    baseline_diff = {
+        "summary_diff": {
+            "total_events": (12, 8),
+            "total_tokens": (240, 100),
+            "duration_ms": (900, 300),
+            "loop_warnings": (2, 0),
+        },
+        "new_tools": ["delete|records"],
+        "removed_tools": ["lookup"],
+        "repeated_tools": {"retry": (1, 3)},
+        "reordered_tools": True,
+        "current_tool_sequence": ["retry", "delete|records"],
+        "baseline_tool_sequence": ["lookup", "retry"],
+        "guardrail_event_diff": (1, 0),
+        "terminal_status_diff": ("error", "ok"),
+    }
+    report = TrialRunReport(
+        trials_requested=1,
+        trials=[_trial(baseline_diff=baseline_diff, passed=False)],
+        aggregate_results=[
+            _result(
+                "agent_process",
+                kind="invariant",
+                verdict=GateVerdict.PASS,
+                evidence={"violations": 0},
+            ),
+            _result(
+                "no_loops",
+                kind="invariant",
+                verdict=GateVerdict.FAIL,
+                evidence={"violations": 1},
+            ),
+            _result(
+                "latency_ms",
+                kind="measured",
+                verdict=GateVerdict.FAIL,
+                direction="upper",
+                evidence={
+                    "observed": 900.0,
+                    "baseline": 300.0,
+                    "allowed": {"lower": None, "upper": 600.0},
+                    "delta": 600.0,
+                },
+            ),
+            _result(
+                "cost_tokens",
+                kind="statistical",
+                verdict=None,
+                mode="report_only",
+                direction="upper",
+                evidence={
+                    "successes": 1,
+                    "observed_rate": 1.0,
+                    "confidence": 0.95,
+                    "confidence_bounds": {"lower": 0.27, "upper": 1.0},
+                    "threshold": 0.9,
+                },
+            ),
+        ],
+        baseline_acceptance={
+            "accepted_at": "2026-07-22T20:15:00.000Z",
+            "accepted_by": "reviewer-login",
+            "reason": "Expected retrieval | tool split",
+            "source": {
+                "pull_request": {
+                    "number": 42,
+                    "url": "https://github.com/maida-ai/example-agent/pull/42",
+                },
+                "commit_sha": "abcdef1234567890",
+            },
+            "verdict": {
+                "outcome": "accepted",
+                "summary": "Accepted run status ok: 8 events, 2 tool calls.",
+            },
+        },
+    )
+
+    markdown = report.to_markdown(baseline_path=".maida/baselines/orders.json")
+
+    assert markdown == dedent(
+        """\
+        ## ❌ Maida verdict: fail
+
+        **2 blocking checks failed** · **0/1 trials passed**
+
+        ### Behavior vs baseline
+
+        - Tool order changed from `lookup → retry` to `retry → delete\\|records`.
+        - New tool used: `delete\\|records`.
+        - Tool removed: `lookup`.
+        - Tool `retry` repeated 3 times (baseline: 1).
+        - Steps increased from 8 to 12 (+4).
+        - Tokens increased from 100 to 240 (+140).
+        - Latency increased from 300 ms to 900 ms (+600 ms).
+        - Loops increased from 0 to 2 (+2).
+        - Guardrails triggered 1 time (baseline: 0).
+        - Terminal state changed from `ok` to `error`.
+
+        ### Blocking checks
+
+        - ❌ **Loops appeared in 1 of 1 trial.** `no_loops`
+        - ❌ **Latency increased beyond the allowed range.** `latency_ms` — Observed 900 ms (baseline 300 ms; allowed at most 600 ms).
+
+        ### Baseline provenance
+
+        | Accepted by | Accepted at | Source |
+        |---|---|---|
+        | `reviewer-login` | `2026-07-22T20:15:00.000Z` | [PR #42](https://github.com/maida-ai/example-agent/pull/42) at `abcdef12` |
+
+        **Acceptance verdict:** accepted — Accepted run status ok: 8 events, 2 tool calls.
+
+        **Reason:** Expected retrieval \\| tool split
+
+        ### Next steps
+
+        - Review the behavioral changes and blocking checks above.
+        - Inspect the full diff: `maida diff aaaaaaaa --baseline .maida/baselines/orders.json`
+        - Open the trace locally: `maida view aaaaaaaa`
+        - If this change is intentional, comment `/maida accept` on the PR or accept locally: `maida accept aaaaaaaa --baseline .maida/baselines/orders.json --reason "..."`
+        - Otherwise fix the agent behavior and rerun: `maida run AGENT.py --baseline .maida/baselines/orders.json`
+
+        <details>
+        <summary>Passing checks, report-only metrics, and trial evidence</summary>
+
+        #### Passing checks
+
+        - ✅ **Agent execution stayed healthy.** `agent_process` — All 1 trial completed successfully.
+
+        #### Report-only metrics
+
+        - ℹ️ **Tokens were observed without blocking the gate.** `cost_tokens` — Observed pass rate 1.000; 95% confidence range 0.270–1.000.
+
+        #### Trial evidence
+
+        | Trial | Outcome | Trace | Process exit | Behavior changes |
+        | ---: | --- | --- | ---: | --- |
+        | 1 | FAIL | `aaaaaaaa` | 0 | 10 changes |
+
+        </details>
+
+        ---
+        *Gated by [Maida](https://maida.ai) — the local-first behavioral regression gate for AI agents.*"""
+    )
+    assert markdown.count("<details>") == 1
+    assert markdown.count("</details>") == 1
+
+
+def test_trial_report_inconclusive_markdown_snapshot() -> None:
+    report = TrialRunReport(
+        trials_requested=3,
+        trials=[_trial(baseline_diff=None)],
+        aggregate_results=[
+            _result(
+                "agent_process",
+                kind="invariant",
+                verdict=GateVerdict.PASS,
+                evidence={"violations": 0},
+            ),
+            _result(
+                "task_pass_rate",
+                kind="statistical",
+                verdict=GateVerdict.INCONCLUSIVE,
+                direction="lower",
+                evidence={
+                    "successes": 1,
+                    "observed_rate": 1.0,
+                    "confidence": 0.95,
+                    "confidence_bounds": {"lower": 0.27, "upper": 1.0},
+                    "threshold": 0.9,
+                },
+            ),
+        ],
+    )
+
+    assert report.to_markdown() == dedent(
+        """\
+        ## ⚪ Maida verdict: inconclusive
+
+        **1 blocking check inconclusive** · **1/3 trials completed**
+
+        ### Behavior vs baseline
+
+        No baseline comparison was configured for this run.
+
+        ### Blocking checks
+
+        - ⚪ **Successful behavior is still inconclusive.** `task_pass_rate` — 1/1 trials passed; 95% confidence range 0.270–1.000 (target at least 0.900).
+
+        > Maida did not establish a blocking regression, but this sample is too small to approve confidently. Collect more trials and rerun before promotion.
+
+        ### Next steps
+
+        - Collect the remaining evidence and rerun: `maida run AGENT.py --trials 3`
+        - Open the trace locally: `maida view aaaaaaaa`
+
+        <details>
+        <summary>Passing checks, report-only metrics, and trial evidence</summary>
+
+        #### Passing checks
+
+        - ✅ **Agent execution stayed healthy.** `agent_process` — All 1 trial completed successfully.
+
+        #### Trial evidence
+
+        | Trial | Outcome | Trace | Process exit | Behavior changes |
+        | ---: | --- | --- | ---: | --- |
+        | 1 | PASS | `aaaaaaaa` | 0 | not configured |
+
+        </details>
+
+        ---
+        *Gated by [Maida](https://maida.ai) — the local-first behavioral regression gate for AI agents.*"""
+    )
+
+
+def test_trial_report_renders_legacy_acceptance_safely() -> None:
+    report = TrialRunReport(
+        trials_requested=1,
+        baseline_acceptance={
+            "accepted_at": "2026-07-09T12:00:00.000Z",
+            "reason": "Legacy local | acceptance",
+        },
+    )
+
+    markdown = report.to_markdown()
+
+    assert "### Baseline provenance" in markdown
+    assert "`unknown`" in markdown
+    assert "local acceptance" in markdown
+    assert "**Acceptance verdict:** accepted — not recorded" in markdown
+    assert "**Reason:** Legacy local \\| acceptance" in markdown
+
+
+def test_trial_report_baseline_acceptance_is_additive_json() -> None:
+    acceptance = {
+        "accepted_by": "reviewer-login",
+        "reason": "Expected tool split",
+    }
+
+    legacy_payload = TrialRunReport(trials_requested=1).to_dict()
+    current_payload = TrialRunReport(
+        trials_requested=1,
+        baseline_acceptance=acceptance,
+    ).to_dict()
+
+    assert "baseline_acceptance" not in legacy_payload
+    assert current_payload["baseline_acceptance"] == acceptance
+    assert (
+        current_payload["report_version"] == legacy_payload["report_version"] == "2.0.0"
+    )
+    assert current_payload["verdict"] == legacy_payload["verdict"] == "pass"
+
+
+def test_statistical_report_schema_accepts_optional_baseline_acceptance() -> None:
+    schema = json.loads(
+        (
+            Path(__file__).parents[1]
+            / "schemas"
+            / "statistical-gate-report.schema.json"
+        ).read_text(encoding="utf-8")
+    )
+
+    assert "baseline_acceptance" not in schema["required"]
+    assert schema["properties"]["baseline_acceptance"]["type"] == [
+        "object",
+        "null",
+    ]
+
+
+@pytest.mark.parametrize("verdict", list(GateVerdict))
+def test_trial_report_is_compact_for_five_or_fewer_checks(
+    verdict: GateVerdict,
+) -> None:
+    results = [
+        _result(
+            f"check_{index}",
+            kind="invariant",
+            verdict=verdict,
+            evidence={"violations": 0 if verdict is GateVerdict.PASS else 1},
+        )
+        for index in range(5)
+    ]
+    report = TrialRunReport(trials_requested=1, aggregate_results=results)
+
+    markdown = report.to_markdown()
+
+    assert markdown.count("<details>") == 1
+    assert len(markdown.splitlines()) <= 45


### PR DESCRIPTION
Lead statistical gate comments with verdict and behavioral evidence so reviewers can understand blocking changes and accept intentional behavior from a compact PR surface.

**Changes**

- summarize behavior changes and blocking checks in human terms
- collapse passing metrics and trial evidence into one detail section
- carry accepted-baseline provenance through reports and CLI rendering

**Tests**

- uv run pytest -q tests/test_assertions.py tests/test_cli.py tests/test_baseline_sample_issue_187.py tests/test_trial_report_markdown.py tests/test_runner.py tests/test_drift.py tests/test_issue_187.py tests/test_cli_issue_187.py
- uv run ruff check .
- uv run ruff format --check .

Fixes #147
Fixes #143

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>