### PR TITLE
Add the gate draft extraction CLI


### DIFF
--- a/docs/cli.md
+++ b/docs/cli.md
@@ -429,6 +429,32 @@ maida run my_agent.py --baseline .maida/baselines/my_agent.json \
 
 Each trial must create exactly one completed trace. Exit `1` is reserved for FAIL; PASS and the provider-neutral INCONCLUSIVE verdict exit `0`, so CI consumers must read the JSON `verdict` rather than infer uncertainty from the process status. Missing inputs exit `2` and internal execution failures exit `10`.
 
+## `maida extract`
+
+Derives inactive, review-required gate drafts from a completed native trace
+window without changing the source window or active `.maida` storage.
+
+```bash
+maida extract --window RUNS_DIR --out DRAFT_DIR [options]
+```
+
+| Argument/Option | Default | Description |
+|---|---|---|
+| `--window` | required | Native Maida `runs/` directory containing completed traces |
+| `--out` | required | New directory for the atomic draft output |
+| `--workflow` | every nonempty `run_name` | Exact workflow group; repeat for multiple groups |
+| `--json` | `false` | Print `draft.json` content to stdout; notices remain on stderr |
+
+The output contains `draft.json` plus one commented policy-v2 and immutable
+baseline pair per workflow. It remains inactive until human review and an
+intentional copy into the repository's gate paths. Exit `0` means extraction and
+self-consistency verification succeeded, `2` means invalid input or selection,
+and `10` means extraction or persistence failed without installing partial
+output.
+
+See [Extract reviewable gate drafts](extraction.md) for grouping, privacy,
+artifact layout, policy candidates, and review guidance.
+
 ## `maida drift`
 
 Evaluates a completed native Maida trace window against one agent baseline

--- a/docs/extraction.md
+++ b/docs/extraction.md
@@ -1,0 +1,90 @@
+# Extract reviewable gate drafts
+
+`maida extract` derives inactive baseline and policy drafts from a validated
+window of completed native traces. It groups runs by their exact `run_name` and
+uses structural evidence only. The result is a starting point for human review,
+not an active gate.
+
+```bash
+maida extract --window /srv/agent-export/runs --out ./maida-draft
+```
+
+The input must be a native directory ending in `runs/`. Every trace is validated
+before extraction, running or malformed traces are rejected, and the source
+files remain byte-for-byte unchanged.
+
+## Select workflows
+
+With no selector, every nonempty `run_name` group is extracted. Repeat
+`--workflow` to select exact groups:
+
+```bash
+maida extract --window /srv/agent-export/runs --out ./maida-draft \
+  --workflow orders-agent \
+  --workflow billing-agent
+```
+
+Selectors are exact and must be unique. Missing, empty, or duplicate selections
+exit without creating the output directory.
+
+## Draft layout
+
+Maida creates the output atomically and refuses to replace an existing path or
+write inside the input window:
+
+```text
+maida-draft/
+├── draft.json
+└── workflows/<safe-name>-<stable-hash>/
+    ├── baseline.json
+    └── policy.yaml
+```
+
+The manifest begins with:
+
+```yaml
+draft_version: 1.0.0
+review_required: true
+```
+
+`draft.json` records oldest-first trace IDs, structural-signature clusters and
+their representatives, tool union and intersection, exact observed step bands,
+tool/token ceilings, and terminal-state sets. A cluster includes only its
+sanitized structural signature: tool and event order, tool counts, model names,
+and terminal state.
+
+The generated `baseline.json` contains the complete selected fixed-size sample.
+The commented policy-v2 `policy.yaml` proposes only candidates supported by all
+selected evidence:
+
+- required tools when the intersection is nonempty;
+- successful terminal state when every selected run ended `ok`;
+- no-loop and no-guardrail invariants when every run satisfied them;
+- the exact measured step band; and
+- measured upper tool-call and token limits.
+
+Maida reloads both generated files and runs the draft against the full selected
+source window. The directory is installed only when every workflow returns
+PASS. A failed self-consistency check leaves no partial draft behind.
+
+## Privacy and activation
+
+Extraction never copies prompts, responses, tool arguments, or tool results.
+It also omits arbitrary source metadata, spans, and absolute paths. The command
+is local and never writes to `.maida`, including active policy, baseline, and
+run storage.
+
+Review and edit each candidate with the workflow owner. After human review,
+copy only the approved `policy.yaml` and `baseline.json` into the repository's
+normal gate paths. There is no extraction path that activates a draft.
+
+Use `--json` for a machine-readable manifest on stdout. Completion and review
+notices stay on stderr:
+
+```bash
+maida extract --window /srv/agent-export/runs --out ./maida-draft --json
+```
+
+Exit `0` means the draft was verified and installed. Exit `2` means the input,
+selection, or output path was invalid. Exit `10` means extraction, verification,
+or atomic persistence failed unexpectedly; no partial output is retained.

--- a/docs/index.md
+++ b/docs/index.md
@@ -60,7 +60,8 @@ After any run, inspect evidence with `maida view`, capture baselines with `maida
 | [Guardrails](guardrails.md) | Stop runaway runs with loop, count, and duration limits |
 | [Regression testing](regression-testing.md) | Baseline, assert, and diff workflow for catching agent regressions |
 | [Scheduled checks](scheduled-checks.md) | Batch verdicts over completed production trace windows |
-| [CLI](cli.md) | `demo`, `init`, `validate-trace`, `import`, `run`, `drift`, `list`, `view`, `export`, `baseline`, `accept`, `assert`, `diff` with options and exit codes |
+| [Gate draft extraction](extraction.md) | Derive inactive policy and baseline drafts from real trace windows for human review |
+| [CLI](cli.md) | `demo`, `init`, `validate-trace`, `import`, `run`, `extract`, `drift`, `list`, `view`, `export`, `baseline`, `accept`, `assert`, `diff` with options and exit codes |
 | [Viewer](viewer.md) | Timeline UI usage, URL params, live refresh, and development |
 | [SDK](sdk.md) | `@trace`, `traced_run`, `has_active_run`, `record_llm_call`, `record_tool_call`, `record_state` |
 | [Integrations](integrations.md) | LangChain handler, OpenAI Agents adapter, and planned adapters |

--- a/maida/cli.py
+++ b/maida/cli.py
@@ -1,7 +1,7 @@
 """
 Typer CLI for Maida.
 
-Commands: list, export, validate-trace, view, baseline, accept, assert, diff, import.
+Commands: list, export, validate-trace, extract, view, baseline, accept, assert, diff, import.
 Entrypoint: main() for console script maida.cli:main.
 """
 
@@ -57,6 +57,7 @@ from maida.demo import (
 from maida.diff import compute_diff, format_diff_text
 from maida.drift import DriftWindowError, run_drift
 from maida.evaluation import evaluate_stored_run_against_baseline
+from maida.extract import ExtractionInputError, extract_window
 from maida.integrations.langfuse import (
     LangfuseImportError,
     LangfuseInputError,
@@ -787,6 +788,53 @@ def drift_cmd(
         raise Exit(EXIT_NOT_FOUND)
     except Exception as error:
         typer.echo(f"error: {error}", err=True)
+        raise Exit(EXIT_INTERNAL)
+
+
+@app.command(name="extract")
+def extract_cmd(
+    window: Path = typer.Option(
+        ..., "--window", help="Native Maida runs directory to extract"
+    ),
+    out_dir: Path = typer.Option(
+        ..., "--out", help="New directory for the inactive gate draft"
+    ),
+    workflow: list[str] | None = typer.Option(
+        None,
+        "--workflow",
+        help="Exact run_name to include; repeat to select multiple workflows",
+    ),
+    json_out: bool = typer.Option(
+        False, "--json", help="Print the machine-readable draft manifest"
+    ),
+) -> None:
+    """Extract review-required gate drafts from completed native traces."""
+    try:
+        draft = extract_window(
+            window,
+            out_dir=out_dir,
+            config=load_config(),
+            workflows=workflow,
+        )
+        if json_out:
+            typer.echo(json.dumps(draft, ensure_ascii=False, indent=2))
+        else:
+            count = len(draft["workflows"])
+            suffix = "" if count == 1 else "s"
+            typer.echo(f"Extracted {count} workflow draft{suffix}:")
+            for item in draft["workflows"]:
+                typer.echo(f"- {item['run_name']} -> {item['artifact_dir']}")
+        typer.echo(
+            f"Draft written to {out_dir}. Human review is required before activation.",
+            err=True,
+        )
+    except Exit:
+        raise
+    except ExtractionInputError as error:
+        typer.echo(f"Invalid extraction input: {error}", err=True)
+        raise Exit(EXIT_NOT_FOUND)
+    except Exception as error:
+        typer.echo(f"Extraction failed: {error}", err=True)
         raise Exit(EXIT_INTERNAL)
 
 

--- a/maida/drift.py
+++ b/maida/drift.py
@@ -42,6 +42,8 @@ class TraceWindowSource(Protocol):
 
     analysis_config: MaidaConfig
 
+    def load_all(self) -> list[LoadedWindowTrace]: ...
+
     def load(self, agent_name: str) -> list[LoadedWindowTrace]: ...
 
 
@@ -78,7 +80,8 @@ class NativeTraceWindowSource:
             )
         self.analysis_config = replace(config, data_dir=self.runs_dir.parent)
 
-    def load(self, agent_name: str) -> list[LoadedWindowTrace]:
+    def load_all(self) -> list[LoadedWindowTrace]:
+        """Validate and load every completed trace in stable oldest-first order."""
         candidates = sorted(
             entry
             for entry in self.runs_dir.iterdir()
@@ -105,21 +108,25 @@ class NativeTraceWindowSource:
                     "can enter a drift window"
                 )
             started_at = _parse_started_at(trace_id, meta.get("started_at"))
-            if meta.get("run_name") == agent_name:
-                loaded.append(
-                    LoadedWindowTrace(
-                        trace_id=trace_id,
-                        meta=meta,
-                        events=events,
-                        started_at=started_at,
-                    )
+            loaded.append(
+                LoadedWindowTrace(
+                    trace_id=trace_id,
+                    meta=meta,
+                    events=events,
+                    started_at=started_at,
                 )
+            )
+        loaded.sort(key=lambda item: (item.started_at, item.trace_id))
+        return loaded
 
+    def load(self, agent_name: str) -> list[LoadedWindowTrace]:
+        loaded = [
+            item for item in self.load_all() if item.meta.get("run_name") == agent_name
+        ]
         if not loaded:
             raise DriftWindowError(
                 f"Trace window contains no completed traces for agent {agent_name!r}"
             )
-        loaded.sort(key=lambda item: (item.started_at, item.trace_id))
         return loaded
 
 

--- a/maida/extract.py
+++ b/maida/extract.py
@@ -123,6 +123,7 @@ def _workflow_summary(
             identifier,
             {
                 "signature_id": identifier,
+                "signature": item["signature"],
                 "representative_trace_id": trace_id,
                 "trace_ids": [],
                 "count": 0,
@@ -321,7 +322,10 @@ def extract_window(
     workflows: Iterable[str] | None = None,
 ) -> dict[str, Any]:
     """Create an atomic, inactive draft directory for selected workflow groups."""
-    final_dir = out_dir.expanduser().resolve()
+    requested_out = out_dir.expanduser()
+    if requested_out.exists() or requested_out.is_symlink():
+        raise ExtractionInputError(f"output directory already exists: {out_dir}")
+    final_dir = requested_out.resolve()
     source_dir = runs_dir.expanduser().resolve()
     if final_dir.exists() or final_dir.is_symlink():
         raise ExtractionInputError(f"output directory already exists: {out_dir}")

--- a/maida/extract.py
+++ b/maida/extract.py
@@ -1,0 +1,387 @@
+"""Extract reviewable gate drafts from completed native trace windows."""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import os
+import re
+import shutil
+import tempfile
+import unicodedata
+from collections import Counter
+from pathlib import Path
+from typing import Any, Iterable
+
+import yaml
+
+from maida.baseline import extract_run_metrics, load_baseline
+from maida.baseline_sample import create_baseline_from_report
+from maida.config import MaidaConfig
+from maida.drift import (
+    DriftWindowError,
+    LoadedWindowTrace,
+    NativeTraceWindowSource,
+    run_drift,
+)
+from maida.gate import invariant_outcomes, numeric_metrics, structural_signature
+from maida.policy import load_policy
+from maida.statistics import GateVerdict
+
+
+DRAFT_VERSION = "1.0.0"
+
+
+class ExtractionInputError(ValueError):
+    """The requested source, selection, or output location is unsafe."""
+
+
+def _signature_id(signature: dict[str, Any]) -> str:
+    encoded = json.dumps(
+        signature, ensure_ascii=False, sort_keys=True, separators=(",", ":")
+    ).encode("utf-8")
+    return hashlib.sha256(encoded).hexdigest()
+
+
+def _artifact_name(run_name: str) -> str:
+    normalized = unicodedata.normalize("NFKD", run_name)
+    ascii_name = normalized.encode("ascii", "ignore").decode("ascii").lower()
+    slug = re.sub(r"[^a-z0-9]+", "-", ascii_name).strip("-")
+    slug = (slug or "workflow")[:48].rstrip("-")
+    digest = hashlib.sha256(run_name.encode("utf-8")).hexdigest()[:12]
+    return f"{slug}-{digest}"
+
+
+def _as_number(value: float) -> int | float:
+    return int(value) if value.is_integer() else value
+
+
+def _select_workflows(
+    traces: list[LoadedWindowTrace], requested: Iterable[str] | None
+) -> list[tuple[str, list[LoadedWindowTrace]]]:
+    groups: dict[str, list[LoadedWindowTrace]] = {}
+    for trace in traces:
+        run_name = trace.meta.get("run_name")
+        if isinstance(run_name, str) and run_name.strip():
+            groups.setdefault(run_name, []).append(trace)
+
+    selectors = list(requested or ())
+    if selectors:
+        if any(not isinstance(item, str) or not item.strip() for item in selectors):
+            raise ExtractionInputError("--workflow must not be empty")
+        duplicates = sorted(
+            name for name, count in Counter(selectors).items() if count > 1
+        )
+        if duplicates:
+            raise ExtractionInputError(
+                f"duplicate --workflow selection: {', '.join(repr(x) for x in duplicates)}"
+            )
+        missing = sorted(name for name in selectors if name not in groups)
+        if missing:
+            raise ExtractionInputError(
+                "no traces for workflow selection: "
+                + ", ".join(repr(name) for name in missing)
+            )
+        selected_names = sorted(selectors)
+    else:
+        selected_names = sorted(groups)
+
+    if not selected_names:
+        raise ExtractionInputError(
+            "trace window contains no completed traces with a nonempty run_name"
+        )
+    return [(name, groups[name]) for name in selected_names]
+
+
+def _trace_evidence(trace: LoadedWindowTrace) -> dict[str, Any]:
+    extracted = extract_run_metrics(trace.meta, trace.events)
+    return {
+        "trace": trace,
+        "extracted": extracted,
+        "metrics": numeric_metrics(extracted),
+        "signature": structural_signature(extracted),
+    }
+
+
+def _workflow_summary(
+    run_name: str,
+    evidence: list[dict[str, Any]],
+    artifact_dir: str,
+) -> dict[str, Any]:
+    tools = [set(item["signature"].get("tool_path") or []) for item in evidence]
+    union = set().union(*tools)
+    intersection = set.intersection(*tools) if tools else set()
+    steps = [item["metrics"]["step_count"] for item in evidence]
+    tool_calls = [item["metrics"]["tool_call_count"] for item in evidence]
+    tokens = [item["metrics"]["cost_tokens"] for item in evidence]
+
+    clusters_by_id: dict[str, dict[str, Any]] = {}
+    for item in evidence:
+        identifier = _signature_id(item["signature"])
+        trace_id = item["trace"].trace_id
+        cluster = clusters_by_id.setdefault(
+            identifier,
+            {
+                "signature_id": identifier,
+                "representative_trace_id": trace_id,
+                "trace_ids": [],
+                "count": 0,
+            },
+        )
+        cluster["trace_ids"].append(trace_id)
+        cluster["count"] += 1
+
+    clusters = list(clusters_by_id.values())
+    return {
+        "run_name": run_name,
+        "artifact_dir": artifact_dir,
+        "trace_ids": [item["trace"].trace_id for item in evidence],
+        "representative_trace_ids": [
+            cluster["representative_trace_id"] for cluster in clusters
+        ],
+        "clusters": clusters,
+        "tools": {
+            "intersection": sorted(intersection),
+            "union": sorted(union),
+        },
+        "step_band": {
+            "lower": _as_number(min(steps)),
+            "upper": _as_number(max(steps)),
+        },
+        "ceilings": {
+            "tool_calls": _as_number(max(tool_calls)),
+            "tokens": _as_number(max(tokens)),
+        },
+        "terminal_states": sorted(
+            {str(item["signature"].get("final_status") or "") for item in evidence}
+        ),
+    }
+
+
+def _policy_candidates(
+    summary: dict[str, Any], evidence: list[dict[str, Any]]
+) -> list[tuple[str, str, dict[str, Any]]]:
+    candidates: list[tuple[str, str, dict[str, Any]]] = []
+    required_tools = summary["tools"]["intersection"]
+    if required_tools:
+        candidates.append(
+            (
+                "required_tools",
+                "Candidate: every selected trace used these tools; confirm they are required.",
+                {"kind": "invariant", "all_of": required_tools},
+            )
+        )
+    if summary["terminal_states"] == ["ok"]:
+        candidates.append(
+            (
+                "stop_condition_reached",
+                "Candidate: every selected trace ended successfully; confirm this invariant.",
+                {"kind": "invariant", "require": True},
+            )
+        )
+    if all(item["metrics"]["loop_warning_count"] == 0 for item in evidence):
+        candidates.append(
+            (
+                "no_loops",
+                "Candidate: no selected trace reported a loop; confirm this invariant.",
+                {"kind": "invariant", "require": True},
+            )
+        )
+    if all(not item["extracted"].get("guardrail_events") for item in evidence):
+        candidates.append(
+            (
+                "no_guardrails",
+                "Candidate: no selected trace triggered a guardrail; confirm this invariant.",
+                {"kind": "invariant", "require": True},
+            )
+        )
+    candidates.extend(
+        [
+            (
+                "step_count",
+                "Observed exact band; widen or narrow only after human review.",
+                {
+                    "kind": "measured",
+                    "direction": "both",
+                    "aggregate": "median",
+                    "limit": summary["step_band"],
+                },
+            ),
+            (
+                "tool_call_count",
+                "Observed upper ceiling; confirm the allowed tool-call budget.",
+                {
+                    "kind": "measured",
+                    "direction": "upper",
+                    "aggregate": "max",
+                    "limit": summary["ceilings"]["tool_calls"],
+                },
+            ),
+            (
+                "cost_tokens",
+                "Observed upper ceiling; confirm the allowed token budget.",
+                {
+                    "kind": "measured",
+                    "direction": "upper",
+                    "aggregate": "max",
+                    "limit": summary["ceilings"]["tokens"],
+                },
+            ),
+        ]
+    )
+    return candidates
+
+
+def _render_policy(summary: dict[str, Any], evidence: list[dict[str, Any]]) -> str:
+    lines = [
+        "# DRAFT: This policy is not active and requires human review.",
+        "# Review each candidate before copying it into .maida/policy.yaml.",
+        "version: 2",
+        f"trials: {len(evidence)}",
+        "fail_fast: false",
+        "metrics:",
+    ]
+    for name, comment, payload in _policy_candidates(summary, evidence):
+        lines.append(f"  # {comment}")
+        rendered = yaml.safe_dump(
+            {name: payload},
+            allow_unicode=True,
+            default_flow_style=False,
+            sort_keys=False,
+        ).rstrip()
+        lines.extend(f"  {line}" for line in rendered.splitlines())
+    return "\n".join(lines) + "\n"
+
+
+def _baseline_report(
+    run_name: str,
+    evidence: list[dict[str, Any]],
+    policy_path: Path,
+) -> dict[str, Any]:
+    policy = load_policy(policy_path)
+    trials = []
+    for index, item in enumerate(evidence, start=1):
+        trace = item["trace"]
+        trials.append(
+            {
+                "trial": index,
+                "trace_id": trace.trace_id,
+                "run_name": run_name,
+                "metric_values": item["metrics"],
+                "invariant_outcomes": invariant_outcomes(
+                    item["extracted"], policy, None
+                ),
+                "structural_signature": item["signature"],
+            }
+        )
+    return {
+        "report_version": "2.0.0",
+        "metadata": {
+            "trials_used": len(trials),
+            "trials_budgeted": len(trials),
+            "environment_fingerprint": {},
+        },
+        "trials": trials,
+    }
+
+
+def _write_json(path: Path, payload: dict[str, Any]) -> None:
+    path.write_text(
+        json.dumps(payload, ensure_ascii=False, indent=2) + "\n", encoding="utf-8"
+    )
+
+
+def _verify_workflow(
+    runs_dir: Path,
+    *,
+    artifact_dir: Path,
+    run_name: str,
+    config: MaidaConfig,
+) -> None:
+    baseline = load_baseline(artifact_dir / "baseline.json")
+    policy = load_policy(artifact_dir / "policy.yaml")
+    report = run_drift(
+        runs_dir,
+        baseline=baseline,
+        policy=policy,
+        config=config,
+        agent_name=run_name,
+    )
+    if report.verdict is not GateVerdict.PASS:
+        raise RuntimeError(
+            f"generated draft for workflow {run_name!r} did not pass its source window"
+        )
+
+
+def extract_window(
+    runs_dir: Path,
+    *,
+    out_dir: Path,
+    config: MaidaConfig,
+    workflows: Iterable[str] | None = None,
+) -> dict[str, Any]:
+    """Create an atomic, inactive draft directory for selected workflow groups."""
+    final_dir = out_dir.expanduser().resolve()
+    source_dir = runs_dir.expanduser().resolve()
+    if final_dir.exists() or final_dir.is_symlink():
+        raise ExtractionInputError(f"output directory already exists: {out_dir}")
+    if final_dir.is_relative_to(source_dir):
+        raise ExtractionInputError(
+            "output directory must not be inside the trace window"
+        )
+
+    try:
+        source = NativeTraceWindowSource(runs_dir, config)
+        traces = source.load_all()
+    except DriftWindowError as error:
+        raise ExtractionInputError(str(error)) from error
+    selected = _select_workflows(traces, workflows)
+
+    artifact_names = [_artifact_name(run_name) for run_name, _items in selected]
+    if len(set(artifact_names)) != len(artifact_names):
+        raise ExtractionInputError(
+            "ambiguous workflow names produce the same artifact directory"
+        )
+
+    final_dir.parent.mkdir(parents=True, exist_ok=True)
+    staging_dir = Path(
+        tempfile.mkdtemp(
+            prefix=f".{final_dir.name}.", suffix=".tmp", dir=final_dir.parent
+        )
+    )
+    try:
+        draft: dict[str, Any] = {
+            "draft_version": DRAFT_VERSION,
+            "review_required": True,
+            "workflows": [],
+        }
+        for (run_name, workflow_traces), artifact_name in zip(selected, artifact_names):
+            evidence = [_trace_evidence(trace) for trace in workflow_traces]
+            artifact_rel = (Path("workflows") / artifact_name).as_posix()
+            summary = _workflow_summary(run_name, evidence, artifact_rel)
+            artifact_dir = staging_dir / artifact_rel
+            artifact_dir.mkdir(parents=True)
+
+            policy_path = artifact_dir / "policy.yaml"
+            policy_path.write_text(_render_policy(summary, evidence), encoding="utf-8")
+            baseline = create_baseline_from_report(
+                _baseline_report(run_name, evidence, policy_path)
+            )
+            baseline["created_at"] = str(workflow_traces[-1].meta["ended_at"])
+            _write_json(artifact_dir / "baseline.json", baseline)
+            _verify_workflow(
+                runs_dir,
+                artifact_dir=artifact_dir,
+                run_name=run_name,
+                config=config,
+            )
+            draft["workflows"].append(summary)
+
+        _write_json(staging_dir / "draft.json", draft)
+        if final_dir.exists() or final_dir.is_symlink():
+            raise ExtractionInputError(f"output directory already exists: {out_dir}")
+        os.replace(staging_dir, final_dir)
+        return draft
+    except Exception:
+        shutil.rmtree(staging_dir, ignore_errors=True)
+        raise

--- a/tests/test_docs.py
+++ b/tests/test_docs.py
@@ -265,3 +265,30 @@ def test_scheduled_checks_document_drift_contract_and_future_inputs():
         assert snippet in combined
 
     assert "monitoring" not in combined.lower()
+
+
+def test_extraction_docs_require_review_and_preserve_local_storage() -> None:
+    guide = (ROOT / "docs/extraction.md").read_text(encoding="utf-8")
+    cli = (ROOT / "docs/cli.md").read_text(encoding="utf-8")
+    index = (ROOT / "docs/index.md").read_text(encoding="utf-8")
+    combined = "\n".join([guide, cli, index])
+
+    for snippet in (
+        "maida extract --window",
+        "--workflow",
+        "draft_version: 1.0.0",
+        "review_required: true",
+        "draft.json",
+        "baseline.json",
+        "policy.yaml",
+        "human review",
+        "never writes to `.maida`",
+        "prompts, responses, tool arguments, or tool results",
+        "Exit `0`",
+        "Exit `2`",
+        "Exit `10`",
+    ):
+        assert snippet in combined
+
+    assert "auto-adopt" not in combined.lower()
+    assert "automatically activates" not in combined.lower()

--- a/tests/test_extract.py
+++ b/tests/test_extract.py
@@ -158,6 +158,14 @@ def test_extract_window_writes_reviewable_multi_workflow_draft_atomically(
     ]
     assert orders["clusters"][0]["trace_ids"] == ["1" * 32, "4" * 32]
     assert orders["clusters"][0]["count"] == 2
+    assert orders["clusters"][0]["signature"] == {
+        "tool_path": ["search"],
+        "tool_call_sequence": ["search"],
+        "tool_call_counts": {"search": 1},
+        "llm_models_used": ["gpt-4o-mini"],
+        "event_type_sequence": ["RUN_START", "LLM_CALL", "TOOL_CALL", "RUN_END"],
+        "final_status": "ok",
+    }
     assert orders["tools"] == {
         "intersection": ["search"],
         "union": ["calculator", "fetch_profile", "search", "summarize"],
@@ -376,6 +384,13 @@ def test_extract_window_rejects_unsafe_output_and_cleans_failed_staging(
         extract_window(runs_dir, out_dir=existing, config=load_config())
     assert (existing / "keep.txt").read_text(encoding="utf-8") == "keep"
 
+    dangling = tmp_path / "dangling"
+    dangling.symlink_to(tmp_path / "missing-target", target_is_directory=True)
+    with pytest.raises(ExtractionInputError, match="already exists"):
+        extract_window(runs_dir, out_dir=dangling, config=load_config())
+    assert dangling.is_symlink()
+    assert not (tmp_path / "missing-target").exists()
+
     with pytest.raises(ExtractionInputError, match="inside the trace window"):
         extract_window(
             runs_dir,
@@ -394,6 +409,27 @@ def test_extract_window_rejects_unsafe_output_and_cleans_failed_staging(
     assert not failed_out.exists()
     assert not list(tmp_path.glob(".failed-draft.*.tmp"))
     assert _read_tree(runs_dir)
+
+
+def test_completed_error_window_fails_self_consistency_without_installing_output(
+    tmp_path: Path,
+) -> None:
+    runs_dir = tmp_path / "error-window" / "runs"
+    runs_dir.mkdir(parents=True)
+    _copy_trace(
+        "guardrail",
+        runs_dir,
+        trace_id="7" * 32,
+        run_name="Known error workflow",
+        started_at="2026-08-07T00:00:00.000Z",
+    )
+    out_dir = tmp_path / "error-draft"
+
+    with pytest.raises(RuntimeError, match="did not pass its source window"):
+        extract_window(runs_dir, out_dir=out_dir, config=load_config())
+
+    assert not out_dir.exists()
+    assert not list(tmp_path.glob(".error-draft.*.tmp"))
 
 
 def test_workflow_artifact_names_use_safe_slug_and_stable_hash(tmp_path: Path) -> None:

--- a/tests/test_extract.py
+++ b/tests/test_extract.py
@@ -1,0 +1,415 @@
+"""Reviewable gate-draft extraction from native trace windows."""
+
+from __future__ import annotations
+
+import json
+import shutil
+from hashlib import sha256
+from pathlib import Path
+
+import jsonschema
+import pytest
+import yaml
+
+from maida.baseline import load_baseline
+from maida.config import load_config
+from maida.drift import NativeTraceWindowSource, run_drift
+from maida.extract import ExtractionInputError, extract_window
+from maida.policy import load_policy
+from maida.statistics import GateVerdict
+
+
+ROOT = Path(__file__).parents[1]
+FIXTURES = ROOT / "tests" / "fixtures" / "traces" / "current"
+
+
+def _copy_trace(
+    fixture: str,
+    runs_dir: Path,
+    *,
+    trace_id: str,
+    run_name: str | None,
+    started_at: str,
+) -> Path:
+    destination = runs_dir / trace_id
+    shutil.copytree(FIXTURES / fixture, destination)
+
+    meta_path = destination / "meta.json"
+    meta = json.loads(meta_path.read_text(encoding="utf-8"))
+    old_trace_id = meta["trace_id"]
+    meta.update(
+        trace_id=trace_id,
+        run_name=run_name,
+        started_at=started_at,
+    )
+    meta_path.write_text(json.dumps(meta), encoding="utf-8")
+
+    spans_path = destination / "spans.jsonl"
+    spans = []
+    for line in spans_path.read_text(encoding="utf-8").splitlines():
+        span = json.loads(line)
+        assert span["trace_id"] == old_trace_id
+        span["trace_id"] = trace_id
+        spans.append(span)
+    spans_path.write_text(
+        "".join(json.dumps(span) + "\n" for span in spans), encoding="utf-8"
+    )
+    return destination
+
+
+def _window(tmp_path: Path) -> Path:
+    runs_dir = tmp_path / "partner-export" / "runs"
+    runs_dir.mkdir(parents=True)
+    _copy_trace(
+        "tool-call-spike",
+        runs_dir,
+        trace_id="2" * 32,
+        run_name="Orders / Primary",
+        started_at="2026-08-02T00:00:00.000Z",
+    )
+    _copy_trace(
+        "normal",
+        runs_dir,
+        trace_id="1" * 32,
+        run_name="Orders / Primary",
+        started_at="2026-08-01T00:00:00.000Z",
+    )
+    _copy_trace(
+        "normal",
+        runs_dir,
+        trace_id="4" * 32,
+        run_name="Orders / Primary",
+        started_at="2026-08-01T12:00:00.000Z",
+    )
+    _copy_trace(
+        "normal",
+        runs_dir,
+        trace_id="3" * 32,
+        run_name="Billing",
+        started_at="2026-08-03T00:00:00.000Z",
+    )
+    return runs_dir
+
+
+def _read_tree(path: Path) -> dict[str, bytes]:
+    return {
+        item.relative_to(path).as_posix(): item.read_bytes()
+        for item in sorted(path.rglob("*"))
+        if item.is_file()
+    }
+
+
+def _artifact_text(path: Path) -> str:
+    return "\n".join(
+        item.read_text(encoding="utf-8")
+        for item in sorted(path.rglob("*"))
+        if item.is_file()
+    )
+
+
+def test_native_window_load_all_validates_every_trace_and_sorts_oldest_first(
+    tmp_path: Path,
+) -> None:
+    runs_dir = _window(tmp_path)
+    before = _read_tree(runs_dir)
+
+    source = NativeTraceWindowSource(runs_dir, load_config())
+    traces = source.load_all()
+
+    assert [item.trace_id for item in traces] == [
+        "1" * 32,
+        "4" * 32,
+        "2" * 32,
+        "3" * 32,
+    ]
+    assert source.load("Billing")[0].trace_id == "3" * 32
+    assert _read_tree(runs_dir) == before
+
+    running = runs_dir / ("3" * 32) / "meta.json"
+    meta = json.loads(running.read_text(encoding="utf-8"))
+    meta.update(status="running", ended_at=None, duration_ms=None)
+    running.write_text(json.dumps(meta), encoding="utf-8")
+    with pytest.raises(ValueError, match="only completed traces"):
+        source.load_all()
+
+
+def test_extract_window_writes_reviewable_multi_workflow_draft_atomically(
+    tmp_path: Path,
+) -> None:
+    runs_dir = _window(tmp_path)
+    source_before = _read_tree(runs_dir)
+    out_dir = tmp_path / "gate-draft"
+
+    draft = extract_window(runs_dir, out_dir=out_dir, config=load_config())
+
+    assert draft == json.loads((out_dir / "draft.json").read_text(encoding="utf-8"))
+    assert draft["draft_version"] == "1.0.0"
+    assert draft["review_required"] is True
+    assert [item["run_name"] for item in draft["workflows"]] == [
+        "Billing",
+        "Orders / Primary",
+    ]
+    orders = draft["workflows"][1]
+    assert orders["trace_ids"] == ["1" * 32, "4" * 32, "2" * 32]
+    assert orders["representative_trace_ids"] == ["1" * 32, "2" * 32]
+    assert [cluster["representative_trace_id"] for cluster in orders["clusters"]] == [
+        "1" * 32,
+        "2" * 32,
+    ]
+    assert orders["clusters"][0]["trace_ids"] == ["1" * 32, "4" * 32]
+    assert orders["clusters"][0]["count"] == 2
+    assert orders["tools"] == {
+        "intersection": ["search"],
+        "union": ["calculator", "fetch_profile", "search", "summarize"],
+    }
+    assert orders["step_band"] == {"lower": 2, "upper": 5}
+    assert orders["ceilings"] == {"tool_calls": 4, "tokens": 25}
+    assert orders["terminal_states"] == ["ok"]
+
+    artifact_paths = {
+        item.relative_to(out_dir).as_posix()
+        for item in out_dir.rglob("*")
+        if item.is_file()
+    }
+    assert artifact_paths == {
+        "draft.json",
+        *{
+            f"{workflow['artifact_dir']}/baseline.json"
+            for workflow in draft["workflows"]
+        },
+        *{f"{workflow['artifact_dir']}/policy.yaml" for workflow in draft["workflows"]},
+    }
+    assert all(
+        workflow["artifact_dir"].startswith("workflows/")
+        and ".." not in workflow["artifact_dir"]
+        and not Path(workflow["artifact_dir"]).is_absolute()
+        for workflow in draft["workflows"]
+    )
+    assert _read_tree(runs_dir) == source_before
+
+
+def test_extracted_baselines_and_policies_are_valid_and_pass_the_source_window(
+    tmp_path: Path,
+) -> None:
+    runs_dir = _window(tmp_path)
+    out_dir = tmp_path / "gate-draft"
+    draft = extract_window(runs_dir, out_dir=out_dir, config=load_config())
+    baseline_schema = json.loads(
+        (ROOT / "schemas" / "baseline.schema.json").read_text(encoding="utf-8")
+    )
+    policy_schema = json.loads(
+        (ROOT / "schemas" / "policy.schema.json").read_text(encoding="utf-8")
+    )
+
+    for workflow in draft["workflows"]:
+        artifact_dir = out_dir / workflow["artifact_dir"]
+        baseline = load_baseline(artifact_dir / "baseline.json")
+        policy = load_policy(artifact_dir / "policy.yaml")
+        policy_payload = yaml.safe_load(
+            (artifact_dir / "policy.yaml").read_text(encoding="utf-8")
+        )
+        jsonschema.validate(baseline, baseline_schema)
+        jsonschema.validate(policy_payload, policy_schema)
+        assert baseline["source_run_ids"] == workflow["trace_ids"]
+        assert baseline["trial_sample"]["trials"] == len(workflow["trace_ids"])
+        assert policy.trials == len(workflow["trace_ids"])
+        report = run_drift(
+            runs_dir,
+            baseline=baseline,
+            policy=policy,
+            config=load_config(),
+            agent_name=workflow["run_name"],
+        )
+        assert report.verdict is GateVerdict.PASS
+
+    policy_text = (
+        out_dir / draft["workflows"][1]["artifact_dir"] / "policy.yaml"
+    ).read_text(encoding="utf-8")
+    assert "DRAFT" in policy_text
+    assert "human review" in policy_text
+    assert "required_tools:" in policy_text
+    assert "stop_condition_reached:" in policy_text
+    assert "no_loops:" in policy_text
+    assert "no_guardrails:" in policy_text
+    assert "direction: both" in policy_text
+    assert "lower: 2" in policy_text
+    assert "upper: 5" in policy_text
+    assert "aggregate: max" in policy_text
+
+
+def test_extraction_is_deterministic_and_omits_trace_payloads_and_paths(
+    tmp_path: Path,
+) -> None:
+    runs_dir = _window(tmp_path)
+    first = tmp_path / "draft-one"
+    second = tmp_path / "draft-two"
+
+    extract_window(runs_dir, out_dir=first, config=load_config())
+    extract_window(runs_dir, out_dir=second, config=load_config())
+
+    assert _read_tree(first) == _read_tree(second)
+    output = _artifact_text(first)
+    for private_value in (
+        "find context",
+        "use search",
+        '"query":"maida"',
+        '"results":1',
+        "same plan",
+        "call many tools",
+        '"user":"ada"',
+        '"tier":"pro"',
+        "maida.cwd",
+        "/workspace/maida",
+        str(runs_dir.resolve()),
+    ):
+        assert private_value not in output
+    assert "spans" not in json.loads((first / "draft.json").read_text())["workflows"][0]
+    assert "meta" not in json.loads((first / "draft.json").read_text())["workflows"][0]
+
+
+@pytest.mark.parametrize(
+    ("selectors", "message"),
+    [
+        (["Missing"], "no traces for workflow"),
+        (["Billing", "Billing"], "duplicate --workflow"),
+        ([""], "must not be empty"),
+    ],
+)
+def test_extract_window_rejects_invalid_workflow_selections(
+    tmp_path: Path, selectors: list[str], message: str
+) -> None:
+    runs_dir = _window(tmp_path)
+    out_dir = tmp_path / "draft"
+
+    with pytest.raises(ExtractionInputError, match=message):
+        extract_window(
+            runs_dir,
+            out_dir=out_dir,
+            config=load_config(),
+            workflows=selectors,
+        )
+
+    assert not out_dir.exists()
+
+
+def test_extract_window_exact_selector_ignores_other_workflows_and_empty_names(
+    tmp_path: Path,
+) -> None:
+    runs_dir = _window(tmp_path)
+    _copy_trace(
+        "normal",
+        runs_dir,
+        trace_id="5" * 32,
+        run_name=None,
+        started_at="2026-08-04T00:00:00.000Z",
+    )
+
+    selected_dir = tmp_path / "selected"
+    draft = extract_window(
+        runs_dir,
+        out_dir=selected_dir,
+        config=load_config(),
+        workflows=["Orders / Primary"],
+    )
+    assert [item["run_name"] for item in draft["workflows"]] == ["Orders / Primary"]
+
+    all_dir = tmp_path / "all"
+    all_draft = extract_window(runs_dir, out_dir=all_dir, config=load_config())
+    assert [item["run_name"] for item in all_draft["workflows"]] == [
+        "Billing",
+        "Orders / Primary",
+    ]
+
+
+def test_extract_window_rejects_wrong_layout_empty_and_invalid_windows(
+    tmp_path: Path,
+) -> None:
+    wrong_layout = tmp_path / "wrong-layout"
+    wrong_layout.mkdir()
+    with pytest.raises(ExtractionInputError, match="ending in /runs"):
+        extract_window(
+            wrong_layout,
+            out_dir=tmp_path / "wrong-draft",
+            config=load_config(),
+        )
+
+    empty_runs = tmp_path / "empty" / "runs"
+    empty_runs.mkdir(parents=True)
+    with pytest.raises(ExtractionInputError, match="contains no traces"):
+        extract_window(
+            empty_runs,
+            out_dir=tmp_path / "empty-draft",
+            config=load_config(),
+        )
+
+    invalid_runs = tmp_path / "invalid" / "runs"
+    invalid_runs.mkdir(parents=True)
+    invalid_trace = _copy_trace(
+        "normal",
+        invalid_runs,
+        trace_id="6" * 32,
+        run_name="Orders",
+        started_at="2026-08-06T00:00:00.000Z",
+    )
+    (invalid_trace / "spans.jsonl").write_text("not-json\n", encoding="utf-8")
+    with pytest.raises(ExtractionInputError, match="malformed JSON"):
+        extract_window(
+            invalid_runs,
+            out_dir=tmp_path / "invalid-draft",
+            config=load_config(),
+        )
+
+    assert not (tmp_path / "wrong-draft").exists()
+    assert not (tmp_path / "empty-draft").exists()
+    assert not (tmp_path / "invalid-draft").exists()
+
+
+def test_extract_window_rejects_unsafe_output_and_cleans_failed_staging(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    runs_dir = _window(tmp_path)
+    existing = tmp_path / "existing"
+    existing.mkdir()
+    (existing / "keep.txt").write_text("keep", encoding="utf-8")
+
+    with pytest.raises(ExtractionInputError, match="already exists"):
+        extract_window(runs_dir, out_dir=existing, config=load_config())
+    assert (existing / "keep.txt").read_text(encoding="utf-8") == "keep"
+
+    with pytest.raises(ExtractionInputError, match="inside the trace window"):
+        extract_window(
+            runs_dir,
+            out_dir=runs_dir / "draft",
+            config=load_config(),
+        )
+
+    def fail_verification(*args: object, **kwargs: object) -> None:
+        raise RuntimeError("verification failed")
+
+    monkeypatch.setattr("maida.extract._verify_workflow", fail_verification)
+    failed_out = tmp_path / "failed-draft"
+    with pytest.raises(RuntimeError, match="verification failed"):
+        extract_window(runs_dir, out_dir=failed_out, config=load_config())
+
+    assert not failed_out.exists()
+    assert not list(tmp_path.glob(".failed-draft.*.tmp"))
+    assert _read_tree(runs_dir)
+
+
+def test_workflow_artifact_names_use_safe_slug_and_stable_hash(tmp_path: Path) -> None:
+    runs_dir = tmp_path / "input" / "runs"
+    runs_dir.mkdir(parents=True)
+    _copy_trace(
+        "normal",
+        runs_dir,
+        trace_id="5" * 32,
+        run_name="../../ACME Orders!?",
+        started_at="2026-08-05T00:00:00.000Z",
+    )
+
+    draft = extract_window(runs_dir, out_dir=tmp_path / "draft", config=load_config())
+    artifact_dir = draft["workflows"][0]["artifact_dir"]
+    expected_hash = sha256("../../ACME Orders!?".encode("utf-8")).hexdigest()[:12]
+
+    assert artifact_dir == f"workflows/acme-orders-{expected_hash}"
+    assert (tmp_path / "draft" / artifact_dir / "baseline.json").is_file()

--- a/tests/test_extract_cli.py
+++ b/tests/test_extract_cli.py
@@ -1,0 +1,189 @@
+"""CLI contract for extracting inactive gate drafts."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+from typer.testing import CliRunner
+
+from maida.cli import app
+from tests.test_extract import _copy_trace
+
+
+runner = CliRunner()
+
+
+def _cli_window(tmp_path: Path) -> Path:
+    runs_dir = tmp_path / "native" / "runs"
+    runs_dir.mkdir(parents=True)
+    _copy_trace(
+        "normal",
+        runs_dir,
+        trace_id="8" * 32,
+        run_name="Orders",
+        started_at="2026-08-01T00:00:00.000Z",
+    )
+    _copy_trace(
+        "normal",
+        runs_dir,
+        trace_id="9" * 32,
+        run_name="Billing",
+        started_at="2026-08-02T00:00:00.000Z",
+    )
+    return runs_dir
+
+
+def test_extract_cli_help_documents_required_and_repeatable_options() -> None:
+    result = runner.invoke(app, ["extract", "--help"])
+
+    assert result.exit_code == 0, result.output
+    assert "--window" in result.stdout
+    assert "--out" in result.stdout
+    assert "--workflow" in result.stdout
+    assert "repeat" in result.stdout.lower()
+    assert "--json" in result.stdout
+
+
+def test_extract_cli_json_stdout_is_machine_readable_and_notices_use_stderr(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    runs_dir = _cli_window(tmp_path)
+    project = tmp_path / "project"
+    active = project / ".maida"
+    active.mkdir(parents=True)
+    policy_before = b"active policy must not change\n"
+    (active / "policy.yaml").write_bytes(policy_before)
+    monkeypatch.chdir(project)
+    out_dir = tmp_path / "draft"
+
+    result = runner.invoke(
+        app,
+        [
+            "extract",
+            "--window",
+            str(runs_dir),
+            "--out",
+            str(out_dir),
+            "--json",
+        ],
+    )
+
+    assert result.exit_code == 0, result.output
+    payload = json.loads(result.stdout)
+    assert payload["draft_version"] == "1.0.0"
+    assert [item["run_name"] for item in payload["workflows"]] == [
+        "Billing",
+        "Orders",
+    ]
+    assert "Draft written to" in result.stderr
+    assert "review" in result.stderr.lower()
+    assert "Draft written to" not in result.stdout
+    assert (active / "policy.yaml").read_bytes() == policy_before
+    assert not (active / "baselines").exists()
+    assert not (active / "runs").exists()
+
+
+def test_extract_cli_repeated_workflows_select_exact_groups(tmp_path: Path) -> None:
+    runs_dir = _cli_window(tmp_path)
+    out_dir = tmp_path / "draft"
+
+    result = runner.invoke(
+        app,
+        [
+            "extract",
+            "--window",
+            str(runs_dir),
+            "--out",
+            str(out_dir),
+            "--workflow",
+            "Orders",
+            "--workflow",
+            "Billing",
+            "--json",
+        ],
+    )
+
+    assert result.exit_code == 0, result.output
+    payload = json.loads(result.stdout)
+    assert [item["run_name"] for item in payload["workflows"]] == [
+        "Billing",
+        "Orders",
+    ]
+
+
+def test_extract_cli_human_summary_is_compact(tmp_path: Path) -> None:
+    runs_dir = _cli_window(tmp_path)
+
+    result = runner.invoke(
+        app,
+        [
+            "extract",
+            "--window",
+            str(runs_dir),
+            "--out",
+            str(tmp_path / "draft"),
+            "--workflow",
+            "Billing",
+        ],
+    )
+
+    assert result.exit_code == 0, result.output
+    assert result.stdout.startswith("Extracted 1 workflow draft")
+    assert "Billing -> workflows/" in result.stdout
+    assert "review" in result.stderr.lower()
+
+
+@pytest.mark.parametrize(
+    ("extra", "message"),
+    [
+        (["--workflow", "Missing"], "no traces for workflow"),
+        (
+            ["--workflow", "Orders", "--workflow", "Orders"],
+            "duplicate --workflow",
+        ),
+    ],
+)
+def test_extract_cli_invalid_selection_exits_two_without_output(
+    tmp_path: Path, extra: list[str], message: str
+) -> None:
+    runs_dir = _cli_window(tmp_path)
+    out_dir = tmp_path / "draft"
+
+    result = runner.invoke(
+        app,
+        ["extract", "--window", str(runs_dir), "--out", str(out_dir), *extra],
+    )
+
+    assert result.exit_code == 2
+    assert message in result.stderr
+    assert result.stdout == ""
+    assert not out_dir.exists()
+
+
+def test_extract_cli_unexpected_failure_exits_ten_and_keeps_json_stdout_clean(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    runs_dir = _cli_window(tmp_path)
+
+    def fail(*args: object, **kwargs: object) -> None:
+        raise OSError("persistence failed")
+
+    monkeypatch.setattr("maida.cli.extract_window", fail)
+    result = runner.invoke(
+        app,
+        [
+            "extract",
+            "--window",
+            str(runs_dir),
+            "--out",
+            str(tmp_path / "draft"),
+            "--json",
+        ],
+    )
+
+    assert result.exit_code == 10
+    assert result.stdout == ""
+    assert "extraction failed" in result.stderr.lower()
+    assert "persistence failed" in result.stderr

--- a/tests/test_extract_cli.py
+++ b/tests/test_extract_cli.py
@@ -6,6 +6,7 @@ import json
 from pathlib import Path
 
 import pytest
+from click import unstyle
 from typer.testing import CliRunner
 
 from maida.cli import app
@@ -39,11 +40,12 @@ def test_extract_cli_help_documents_required_and_repeatable_options() -> None:
     result = runner.invoke(app, ["extract", "--help"])
 
     assert result.exit_code == 0, result.output
-    assert "--window" in result.stdout
-    assert "--out" in result.stdout
-    assert "--workflow" in result.stdout
-    assert "repeat" in result.stdout.lower()
-    assert "--json" in result.stdout
+    help_text = unstyle(result.stdout)
+    assert "--window" in help_text
+    assert "--out" in help_text
+    assert "--workflow" in help_text
+    assert "repeat" in help_text.lower()
+    assert "--json" in help_text
 
 
 def test_extract_cli_json_stdout_is_machine_readable_and_notices_use_stderr(

--- a/tests/test_packaging.py
+++ b/tests/test_packaging.py
@@ -26,6 +26,8 @@ def test_built_wheel_contains_importable_package_and_cli(tmp_path):
 
     assert "maida/__init__.py" in names
     assert "maida/cli.py" in names
+    assert "maida/drift.py" in names
+    assert "maida/extract.py" in names
     assert "maida/server.py" in names
     assert "maida/ui_static/index.html" in names
     assert "maida = maida.cli:main" in entry_points


### PR DESCRIPTION
Expose deterministic extraction as an explicit local command while keeping generated artifacts inactive until a human reviews them.

**Changes**

- add exact repeatable workflow selection, JSON stdout, stderr notices, and stable exit handling
- document draft layout, privacy boundaries, self-consistency checks, and intentional activation
- reject dangling output symlinks and make sanitized structural cluster evidence explicit
- verify completed-error windows fail without partial output and package the extraction module

**Tests**

- `uv run pytest tests/test_extract.py tests/test_extract_cli.py tests/test_drift.py tests/test_runner.py tests/test_trial_report_markdown.py tests/test_cli.py tests/test_storage.py tests/test_baseline.py tests/test_baseline_sample_issue_187.py tests/test_policy.py tests/test_trace_validation.py tests/test_published_trace_schemas.py tests/test_docs.py tests/test_packaging.py -q`
- `uv run ruff check .`
- `uv run ruff format --check .`
- `git diff --cached --check`

Fixes #175


---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>