### PR TITLE
release: cut v0.5.0 and move docs to the released channel

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 ## Unreleased
 
+## v0.5.0
+
+First PyPI release of the synchronized cross-repository contract. Install with
+`uv tool install "maida-ai>=0.5"`; the GitHub Action moves to
+`maida-ai/maida-assert@v5`.
+
 ### Highlights
 
 - **Statistical gate (`maida run`)** - the primary gate command. Runs an agent over multiple isolated trials, aggregates them with a Wilson-bound three-verdict rule (pass / fail / inconclusive), and publishes tri-state statistical gate reports (`report_version` `2.0.0`).
@@ -14,13 +20,29 @@
 - **`maida extract`** - derives inactive policy and baseline drafts from real trace windows for human review.
 - **Adapter conformance** - LangChain, OpenAI Agents, and CrewAI adapters verified against a shared conformance contract, including payload-privacy protections.
 
+### Upgrading
+
+- **Install from PyPI.** Replace the `git+https://github.com/maida-ai/maida.git@main` requirement with `maida-ai>=0.5`.
+- **Repin the Action.** Workflows tracking `maida-ai/maida-assert@main` should move to `maida-ai/maida-assert@v5`, and the `accept-command` and `write-back` sub-actions with it. The Action now defaults `maida-version` to `v0.5.0` instead of the development channel.
+- **`maida run` is the primary gate.** `maida assert` remains supported for single-run evaluation; new workflows should call `maida run`.
+- **Policy files must declare `version: 2`.** Unreachable metric configurations are now rejected when the policy loads rather than silently passing.
+
+### Contract
+
+| Surface | Version |
+|---------|---------|
+| Trace schema | `0.2.0` |
+| Baseline schema | `0.3.0` |
+| Policy schema | `2` |
+| Report schema | `2.0.0` |
+
 ## v0.4
 
 ### Highlights
 
 - **`maida demo`** - bundled simulated agent: `pip install maida-ai && maida demo` produces a traced run with no repo clone, no network, and no API keys.
 - **`maida demo --regression`** - the full gate story in one command: baseline a known-good run, run a "refactored" agent that loops, calls a new tool, and burns more tokens, then show the failing report with a PR-comment preview.
-- **`maida init`** - scaffolds a commented starter `.maida/policy.yaml`, and with `--github` a ready-to-edit workflow currently tracking `maida-ai/maida-assert@main`.
+- **`maida init`** - scaffolds a commented starter `.maida/policy.yaml`, and with `--github` a ready-to-edit gate workflow.
 - **Latest-run defaults** - `maida assert`, `maida baseline`, `maida export`, and `maida diff` no longer require a run ID; they default to the most recent run (announced on stderr so stdout stays machine-readable).
 - **Richer gate reports** - the markdown report (the PR comment) now leads with a verdict, lists failed checks first with expected vs actual values, collapses passing checks, embeds a "What changed vs baseline" structural diff, and ends with a local-repro snippet. The text report appends the same diff on failure.
 - **OTel storage contract** - run lifecycle, storage APIs, CLI, server, and viewer moved onto trace-ID/`meta.json`/`spans.jsonl` storage, with JSON schemas updated to match.

--- a/README.md
+++ b/README.md
@@ -32,11 +32,10 @@ The viewer shows the execution timeline behind a pass/fail decision, but the cor
 
 ## Try it in 60 seconds
 
-Until the `0.5.x` release, install the current engine from GitHub `main`. The
-demo still needs no repo clone, config file, API key, or sign-up:
+No repo clone, config file, API key, or sign-up:
 
 ```bash
-uv tool install "maida-ai @ git+https://github.com/maida-ai/maida.git@main"
+uv tool install "maida-ai>=0.5"
 maida demo
 maida view
 ```
@@ -435,7 +434,7 @@ Maida is framework-agnostic at its core. The SDK works with any Python code.
 Optional callback handler that auto-records LLM and tool events. Requires `langchain-core`:
 
 ```bash
-uv add "maida-ai[langchain] @ git+https://github.com/maida-ai/maida.git@main"
+uv add "maida-ai[langchain]>=0.5"
 ```
 
 ```python
@@ -457,7 +456,7 @@ See `examples/langchain/minimal.py` for a runnable example.
 Optional tracing adapter that auto-records generation, function, and handoff spans. Requires `openai-agents`:
 
 ```bash
-uv add "maida-ai[openai] @ git+https://github.com/maida-ai/maida.git@main"
+uv add "maida-ai[openai]>=0.5"
 ```
 
 ```python
@@ -478,7 +477,7 @@ See `examples/openai_agents/minimal.py` for a runnable fake-data example with no
 Optional execution-hook adapter that auto-records LLM and tool events from CrewAI crews and flows. Requires `crewai[tools]`:
 
 ```bash
-uv add "maida-ai[crewai] @ git+https://github.com/maida-ai/maida.git@main"
+uv add "maida-ai[crewai]>=0.5"
 ```
 
 ```python

--- a/contracts/current-main.json
+++ b/contracts/current-main.json
@@ -1,8 +1,8 @@
 {
   "contract_version": 1,
-  "engine_ref": "main",
-  "install_requirement": "maida-ai @ git+https://github.com/maida-ai/maida.git@main",
-  "action_ref": "maida-ai/maida-assert@main",
+  "engine_ref": "v0.5.0",
+  "install_requirement": "maida-ai>=0.5",
+  "action_ref": "maida-ai/maida-assert@v5",
   "schemas": {
     "trace": "0.2.0",
     "baseline": "0.3.0",

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -164,13 +164,13 @@ maida init [--github] [--force]
 
 | Option | Description |
 |--------|-------------|
-| `--github` | Also write `.github/workflows/maida.yml` using the current `maida-ai/maida-assert@main` gate and the `maida-ai/maida-assert/accept-command@main` handler |
+| `--github` | Also write `.github/workflows/maida.yml` using the `maida-ai/maida-assert@v5` gate and the `maida-ai/maida-assert/accept-command@v5` handler |
 | `--force` | Overwrite existing files |
 
 **Files written:**
 
 - `.maida/policy.yaml` — strict v2 starter with invariant contracts, directional measured tolerances, and a three-trial report-only pass-rate metric
-- `.github/workflows/maida.yml` (with `--github`) — PR check running your traced agent and posting the regression report as a sticky comment; also handles authorized `/maida accept [optional reason]` comments and rechecks an accepted PR-head commit; pins `actions/checkout@v7` and currently tracks `maida-ai/maida-assert@main`, with the command handler at `maida-ai/maida-assert/accept-command@main`
+- `.github/workflows/maida.yml` (with `--github`) — PR check running your traced agent and posting the regression report as a sticky comment; also handles authorized `/maida accept [optional reason]` comments and rechecks an accepted PR-head commit; pins `actions/checkout@v7` and `maida-ai/maida-assert@v5`, with the command handler at `maida-ai/maida-assert/accept-command@v5`
 
 Edit the generated `MAIDA_AGENT_SCRIPT` value for your entrypoint. After
 committing a baseline, set `MAIDA_BASELINE` to its tracked path; leaving it blank

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -4,10 +4,10 @@
 
 Requires Python 3.10+.
 
-**Current synchronized contract (until the next `0.5.x` release):**
+**With uv:**
 
 ```bash
-uv tool install "maida-ai @ git+https://github.com/maida-ai/maida.git@main"
+uv tool install "maida-ai>=0.5"
 ```
 
 **From source with uv:**
@@ -34,7 +34,7 @@ pip install -e .
 No repo clone, no config, no API keys:
 
 ```bash
-uv tool install "maida-ai @ git+https://github.com/maida-ai/maida.git@main"
+uv tool install "maida-ai>=0.5"
 maida demo        # trace a bundled simulated agent
 maida view        # inspect the timeline in your browser
 ```

--- a/docs/index.md
+++ b/docs/index.md
@@ -10,14 +10,11 @@
 
 ## In 60 seconds
 
-**1. Install the current `main` contract:**
+**1. Install Maida:**
 
 ```bash
-uv tool install "maida-ai @ git+https://github.com/maida-ai/maida.git@main"
+uv tool install "maida-ai>=0.5"
 ```
-
-This temporary development-channel install will be replaced with the next
-`0.5.x` package after the synchronized contract is tagged.
 
 **2. Run the bundled demo agent** (simulated; no repo clone, no API keys):
 

--- a/docs/integrations.md
+++ b/docs/integrations.md
@@ -17,7 +17,7 @@ Maida is **framework-agnostic** at the core. The SDK is a thin layer: you call `
 **Requirements:** `langchain-core` must be installed. Install the optional dependency group:
 
 ```bash
-uv add "maida-ai[langchain] @ git+https://github.com/maida-ai/maida.git@main"
+uv add "maida-ai[langchain]>=0.5"
 ```
 
 If `langchain-core` is not installed, importing the integration raises a clear `ImportError` with install instructions. The integration is optional; the core package does not depend on it.
@@ -86,7 +86,7 @@ All guardrails work with the callback handler. When a guardrail fires, the handl
 **Requirements:** `openai-agents` must be installed. Install Maida with the optional OpenAI dependency group:
 
 ```bash
-uv add "maida-ai[openai] @ git+https://github.com/maida-ai/maida.git@main"
+uv add "maida-ai[openai]>=0.5"
 ```
 
 If `openai-agents` is not installed, importing the integration raises a clear `ImportError` with install instructions. The integration is optional; the core package does not depend on it.
@@ -165,7 +165,7 @@ As a defensive fallback, the exception is also stored on `PROCESSOR.abort_except
 **Requirements:** `crewai[tools]` must be installed. Install the optional dependency group:
 
 ```bash
-uv add "maida-ai[crewai] @ git+https://github.com/maida-ai/maida.git@main"
+uv add "maida-ai[crewai]>=0.5"
 ```
 
 If `crewai` is not installed, importing the integration raises a clear `ImportError` with install instructions.

--- a/docs/langfuse.md
+++ b/docs/langfuse.md
@@ -15,7 +15,7 @@ Until the importer is included in the next PyPI release, install the current
 `main` revision:
 
 ```bash
-uv tool install "maida-ai @ git+https://github.com/maida-ai/maida.git@main"
+uv tool install "maida-ai>=0.5"
 ```
 
 Source checkouts using `uv sync` already have the importer.
@@ -147,7 +147,7 @@ importer rather than a traced Python entrypoint. Keep credentials in GitHub
 secrets and select exactly one completed trace:
 
 ```yaml
-- uses: maida-ai/maida-assert@main
+- uses: maida-ai/maida-assert@v5
   env:
     LANGFUSE_PUBLIC_KEY: ${{ secrets.LANGFUSE_PUBLIC_KEY }}
     LANGFUSE_SECRET_KEY: ${{ secrets.LANGFUSE_SECRET_KEY }}

--- a/docs/regression-testing.md
+++ b/docs/regression-testing.md
@@ -132,8 +132,7 @@ history.
 
 ## GitHub Actions
 
-`maida init --github` currently tracks `maida-ai/maida-assert@main`. The Action
+`maida init --github` pins `maida-ai/maida-assert@v5`. The Action
 consumes report schema 2, keeps INCONCLUSIVE neutral, and posts the tier-aware
 Markdown as a sticky PR comment and check summary. The action contract is
-maintained in the separate `maida-assert` repository. Pin a released major
-after this contract is tagged.
+maintained in the separate `maida-assert` repository.

--- a/maida/scaffold.py
+++ b/maida/scaffold.py
@@ -5,8 +5,8 @@ from pathlib import Path
 POLICY_RELPATH = Path(".maida") / "policy.yaml"
 WORKFLOW_RELPATH = Path(".github") / "workflows" / "maida.yml"
 CHECKOUT_ACTION_REF = "actions/checkout@v7"
-MAIDA_ASSERT_ACTION_REF = "maida-ai/maida-assert@main"
-MAIDA_ACCEPT_ACTION_REF = "maida-ai/maida-assert/accept-command@main"
+MAIDA_ASSERT_ACTION_REF = "maida-ai/maida-assert@v5"
+MAIDA_ACCEPT_ACTION_REF = "maida-ai/maida-assert/accept-command@v5"
 
 POLICY_TEMPLATE = """\
 # Maida policy v2 - enforced locally and by maida-assert main.

--- a/tests/test_cross_repo_contracts.py
+++ b/tests/test_cross_repo_contracts.py
@@ -36,8 +36,8 @@ def test_current_main_contract_matches_python_source_of_truth() -> None:
         "policy": POLICY_SCHEMA_VERSION,
         "report": REPORT_SCHEMA_VERSION,
     }
-    assert contract["engine_ref"] == "main"
-    assert contract["action_ref"] == "maida-ai/maida-assert@main"
+    assert contract["engine_ref"] == "v0.5.0"
+    assert contract["action_ref"] == "maida-ai/maida-assert@v5"
     assert contract["cli"]["primary_gate"] == "run"
     assert contract["cli"]["legacy_gate"] == "assert"
     assert (
@@ -50,12 +50,12 @@ def test_current_main_contract_matches_python_source_of_truth() -> None:
     )
 
 
-def test_primary_public_docs_use_the_current_main_channel() -> None:
+def test_primary_public_docs_use_the_released_channel() -> None:
     contract = _read_json(CONTRACTS / "current-main.json")
     for relative in ("README.md", "docs/index.md", "docs/getting-started.md"):
         text = (ROOT / relative).read_text(encoding="utf-8")
         assert contract["install_requirement"] in text
-        assert "pip install maida-ai" not in text
+        assert "git+https://github.com/maida-ai/maida.git@main" not in text
 
     readme = (ROOT / "README.md").read_text(encoding="utf-8")
     assert "maida run my_agent.py" in readme

--- a/tests/test_docs.py
+++ b/tests/test_docs.py
@@ -81,7 +81,7 @@ def test_action_version_references_match_scaffold():
         (ROOT / rel_path).read_text(encoding="utf-8") for rel_path in docs
     )
 
-    assert MAIDA_ASSERT_ACTION_REF == "maida-ai/maida-assert@main"
+    assert MAIDA_ASSERT_ACTION_REF == "maida-ai/maida-assert@v5"
     assert MAIDA_ASSERT_ACTION_REF in combined
     assert MAIDA_ACCEPT_ACTION_REF in combined
     assert "maida-ai/maida-assert@v2" not in combined
@@ -168,7 +168,7 @@ def test_openai_agents_docs_include_offline_success_and_regression_workflow():
     example = (ROOT / "examples/openai_agents/minimal.py").read_text(encoding="utf-8")
 
     required_docs = [
-        'uv add "maida-ai[openai] @ git+https://github.com/maida-ai/maida.git@main"',
+        'uv add "maida-ai[openai]>=0.5"',
         "openai-agents-baseline.json",
         "examples/openai_agents/minimal.py --regression",
         "RUN_START -> LLM_CALL -> TOOL_CALL(lookup_docs) -> TOOL_CALL(handoff) -> RUN_END",
@@ -188,7 +188,7 @@ def test_crewai_docs_cover_offline_success_and_strict_regression_workflow():
     example = (ROOT / "examples/crewai/minimal.py").read_text(encoding="utf-8")
 
     for snippet in (
-        'uv add "maida-ai[crewai] @ git+https://github.com/maida-ai/maida.git@main"',
+        'uv add "maida-ai[crewai]>=0.5"',
         "examples/crewai/minimal.py",
         "--regression",
     ):
@@ -236,7 +236,7 @@ def test_langfuse_docs_cover_read_only_import_and_mapping_contract():
         "fully synthetic",
         "read-only",
         "trace-command:",
-        "maida-ai/maida-assert@main",
+        "maida-ai/maida-assert@v5",
         "fixed one-trial gate",
         "maida-tutorials/tree/main/demos/langfuse_import",
     ):


### PR DESCRIPTION
Point the contract at the released engine and Action: engine_ref v0.5.0, install_requirement maida-ai>=0.5, action_ref maida-ai/maida-assert@v5.

Update the scaffold, README, and docs to install from PyPI instead of git+main, retire the wording that framed main as a temporary development channel, and add the v0.5.0 changelog section with upgrading notes and the schema version table.